### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,14 +4,27 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-03-21
+
 ### Added
 
 - Real Azure end-to-end test workflow (`e2e-azure.yml`) deploying to Consumption plan (`koreacentral`)
-- `docs/testing.md` — Real Azure E2E Tests section (new file)
+- `docs/testing.md` — Real Azure E2E Tests section
+- EventHub, CosmosDB, Durable, and AI scaffold templates
+- Mermaid diagrams to architecture and README
+- Generator coverage tests
 
 ### Changed
 
-- GitHub Actions versions upgraded to Node.js 24 compatible: `checkout@v6`, `setup-python@v6`, `upload-artifact@v7`, `azure/login@v2.3.0`
+- GitHub Actions versions upgraded to Node.js 24 compatible versions
+- Repository consistency fixes (LICENSE, .gitignore standardization)
+
+### Fixed
+
+- Generate `requirements.txt` from `pyproject.toml` before `func publish`, add startup probe
+- Fix scaffold e2e warmup route, pyproject.toml check, cleanup resilience
+- Fix e2e workflow to use correct scaffold CLI `new` command
+
 ## [0.3.1] - 2026-03-14
 
 ### Added

--- a/src/azure_functions_scaffold/__init__.py
+++ b/src/azure_functions_scaffold/__init__.py
@@ -2,4 +2,4 @@
 
 __all__ = ["__version__"]
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,6 +1,15 @@
 """Tests for the public API surface of azure-functions-scaffold."""
 
-import azure_functions_scaffold
+from importlib import import_module
+from typing import Protocol, cast
+
+
+class _PublicAPI(Protocol):
+    __all__: list[str]
+    __version__: str
+
+
+azure_functions_scaffold = cast(_PublicAPI, cast(object, import_module("azure_functions_scaffold")))
 
 
 class TestAPISurface:
@@ -9,8 +18,8 @@ class TestAPISurface:
     def test_all_exports(self) -> None:
         assert set(azure_functions_scaffold.__all__) == {"__version__"}
 
-    def test_version_is_0_3_1(self) -> None:
-        assert azure_functions_scaffold.__version__ == "0.3.1"
+    def test_version_is_0_3_2(self) -> None:
+        assert azure_functions_scaffold.__version__ == "0.3.2"
 
     def test_version_is_string(self) -> None:
         assert isinstance(azure_functions_scaffold.__version__, str)


### PR DESCRIPTION
Release v0.3.2: bump package version to 0.3.2, align public API version test, and publish release notes in CHANGELOG.