### PR TITLE
fix: handle missing stderr in git init failure path

### DIFF
--- a/src/azure_functions_scaffold/scaffolder.py
+++ b/src/azure_functions_scaffold/scaffolder.py
@@ -283,5 +283,5 @@ def _initialize_git_repository(project_root: Path) -> None:
     except FileNotFoundError as exc:
         raise ScaffoldError("Git is not installed or not available on PATH.") from exc
     except subprocess.CalledProcessError as exc:
-        stderr = exc.stderr.strip() or "git init failed"
+        stderr = (exc.stderr or "").strip() or "git init failed"
         raise ScaffoldError(f"Failed to initialize a git repository: {stderr}") from exc

--- a/tests/test_scaffolder.py
+++ b/tests/test_scaffolder.py
@@ -398,6 +398,33 @@ def test_initialize_git_repository_rejects_missing_git(
         _initialize_git_repository(tmp_path)
 
 
+def test_initialize_git_repository_handles_missing_stderr_on_failure(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fake_run(
+        command: list[str],
+        *,
+        cwd: Path,
+        check: bool,
+        capture_output: bool,
+        text: bool,
+    ) -> object:
+        raise subprocess.CalledProcessError(returncode=1, cmd=command, stderr=None)
+
+    monkeypatch.setattr(
+        "azure_functions_scaffold.scaffolder.shutil.which",
+        lambda _: "/usr/bin/git",
+    )
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    with pytest.raises(
+        ScaffoldError,
+        match="Failed to initialize a git repository: git init failed",
+    ):
+        _initialize_git_repository(tmp_path)
+
+
 def _run_generated_project_checks(project_path: Path) -> None:
     subprocess.run(
         ["make", "install"],


### PR DESCRIPTION
## Summary
- prevent `_initialize_git_repository` from raising `AttributeError` when `CalledProcessError.stderr` is `None`
- preserve a meaningful fallback error message (`git init failed`) when stderr content is unavailable

## Changes
- updated `src/azure_functions_scaffold/scaffolder.py` to safely normalize `exc.stderr` with a `None` guard
- added regression test in `tests/test_scaffolder.py` that mocks `subprocess.run` raising `CalledProcessError(stderr=None)`

## Validation
- `python -m pytest --no-cov -x -q`
- `python -m ruff check src/ tests/`
- `python -m mypy src/`

Closes #18