### PR TITLE
docs: pin Mermaid JS version and add site_url

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,6 +2,7 @@ site_name: Azure Functions Scaffold
 site_description: Scaffolding CLI for Azure Functions Python v2 projects
 site_author: Yeongseon Choe
 repo_url: https://github.com/yeongseon/azure-functions-scaffold
+site_url: https://yeongseon.github.io/azure-functions-scaffold/
 edit_uri: edit/main/docs/
 
 theme:
@@ -81,4 +82,4 @@ extra:
     © 2026 Yeongseon Choe – MIT Licensed
 
 extra_javascript:
-  - https://unpkg.com/mermaid@11/dist/mermaid.min.js
+  - https://unpkg.com/mermaid@11.14.0/dist/mermaid.min.js


### PR DESCRIPTION
## Summary

- Pin Mermaid CDN from floating `@11` to exact `@11.14.0` for reproducible builds
- Add `site_url` for canonical URLs and sitemap generation

## Changes

**`mkdocs.yml`**: 
- `https://unpkg.com/mermaid@11/dist/mermaid.min.js` → `https://unpkg.com/mermaid@11.14.0/dist/mermaid.min.js`
- Added `site_url: https://yeongseon.github.io/azure-functions-scaffold/`

## Context

Part of cross-repo mkdocs.yml standardization. All 6 azure-functions repos now use identical Mermaid configuration.

## Validation

- `make check-all` passes

Fixes #28