### PR TITLE
docs: fix stale diagrams in architecture.md

### DIFF
--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -128,6 +128,8 @@ sequenceDiagram
     participant FS as File System
 
     Dev->>CLI: afs new my-api --template http
+    CLI->>TR: build_project_options(preset, python_version, ...)
+    TR-->>CLI: ProjectOptions
     CLI->>SC: scaffold_project(name, template, options)
     SC->>TR: get_template(template_name)
     TR-->>SC: TemplateSpec (template directory)
@@ -150,7 +152,7 @@ sequenceDiagram
     CLI->>GEN: verify project root
     GEN->>FS: read function_app.py
     GEN->>FS: render new function module
-    GEN->>FS: append import + app.register_functions(blueprint)
+    GEN->>FS: append import + app.register_functions(<name>_blueprint)
     GEN-->>Dev: function added
 ```
 


### PR DESCRIPTION
## Summary

Fixes pre-existing factual drift in architecture diagrams identified during Oracle PR review of #26.

### Changes
- **Dependency graph**: Remove non-existent `scaffolder→generator` and `models→errors` edges; add correct `cli→generator/template_registry/models/errors`, `generator→errors`, `template_registry→errors` edges
- **`afs new` sequence**: Remove generator participant — scaffolder does its own Jinja2 rendering directly, not via generator
- **`afs add` sequence**: Fix `register_blueprint` → `app.register_functions(blueprint)` to match actual code
- **Module boundaries table**: Clarify scaffolder owns Jinja2 rendering for project scaffolding; generator owns function module generation for `afs add` only
- **Class diagram**: Verified accurate against `models.py` — no changes needed

### Verification
- All diagrams verified against actual import statements and call flows in source code
- `make check-all` passes

Closes #27