### PR TITLE
chore: polish templates — fix sdist paths, update deps, enrich DX (#50)

### DIFF
--- a/src/azure_functions_scaffold/cli_common.py
+++ b/src/azure_functions_scaffold/cli_common.py
@@ -192,9 +192,10 @@ def _print_success_message(
     # Next steps
     typer.echo("")
     typer.secho("  Next steps:", bold=True)
-    typer.echo(f"    cd {project_path.name}")
+    typer.echo(f"    cd {project_path}")
     typer.echo("    python -m venv .venv")
-    typer.echo("    source .venv/bin/activate")
+    typer.echo("    source .venv/bin/activate   # Linux/macOS")
+    typer.echo("    .venv\\Scripts\\activate      # Windows")
     dev_extra = "[dev]" if options.tooling else ""
     typer.echo(f"    pip install -e .{dev_extra}")
     typer.echo("    func start")

--- a/src/azure_functions_scaffold/cli_common.py
+++ b/src/azure_functions_scaffold/cli_common.py
@@ -156,4 +156,50 @@ def run_scaffold(
         typer.secho(str(exc), fg=typer.colors.RED)
         raise typer.Exit(code=1) from exc
 
-    typer.echo(f"Created project at {project_path}")
+    _print_success_message(project_path, template_name, options)
+
+
+def _print_success_message(
+    project_path: Path,
+    template_name: str,
+    options: ProjectOptions,
+) -> None:
+    """Print a rich post-scaffold landing message with next steps."""
+    typer.secho("\n  Project created successfully!\n", fg=typer.colors.GREEN, bold=True)
+
+    typer.echo(f"  Location:  {project_path}")
+    typer.echo(f"  Template:  {template_name}")
+    typer.echo(f"  Preset:    {options.preset_name}")
+    typer.echo(f"  Python:    {options.python_version}")
+
+    # Feature badges
+    features: list[str] = []
+    if options.include_openapi:
+        features.append("openapi")
+    if options.include_validation:
+        features.append("validation")
+    if options.include_doctor:
+        features.append("doctor")
+    if options.include_db:
+        features.append("db")
+    if options.include_azd:
+        features.append("azd")
+    if options.include_github_actions:
+        features.append("github-actions")
+    if features:
+        typer.echo(f"  Features:  {', '.join(features)}")
+
+    # Next steps
+    typer.echo("")
+    typer.secho("  Next steps:", bold=True)
+    typer.echo(f"    cd {project_path.name}")
+    typer.echo("    python -m venv .venv")
+    typer.echo("    source .venv/bin/activate")
+    dev_extra = "[dev]" if options.tooling else ""
+    typer.echo(f"    pip install -e .{dev_extra}")
+    typer.echo("    func start")
+    if options.include_openapi:
+        typer.echo("")
+        typer.secho("  API docs:", bold=True)
+        typer.echo("    http://localhost:7071/api/docs")
+    typer.echo("")

--- a/src/azure_functions_scaffold/templates/ai/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/ai/pyproject.toml.j2
@@ -7,14 +7,14 @@ packages = ["app"]
 
 [tool.hatch.build.targets.sdist]
 include = [
-  "/app",
-  "/tests",
-  "/function_app.py",
-  "/host.json",
-  "/local.settings.json.example",
-  "/README.md",
-  "/Makefile",
-  "/pyproject.toml",
+  "app",
+  "tests",
+  "function_app.py",
+  "host.json",
+  "local.settings.json.example",
+  "README.md",
+  "Makefile",
+  "pyproject.toml",
 ]
 
 [project]
@@ -25,10 +25,10 @@ readme = "README.md"
 requires-python = ">={{ python_version }},<{{ python_upper_bound }}"
 dependencies = [
   "azure-functions>=1.23.0",
-  "azure-functions-logging>=0.2.0",
+  "azure-functions-logging>=0.5.0",
   "openai>=1.0.0",
 {% if include_doctor -%}
-  "azure-functions-doctor>=0.15.0",
+  "azure-functions-doctor>=0.16.0",
 {% endif -%}
 ]
 

--- a/src/azure_functions_scaffold/templates/blob/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/blob/pyproject.toml.j2
@@ -7,14 +7,14 @@ packages = ["app"]
 
 [tool.hatch.build.targets.sdist]
 include = [
-  "/app",
-  "/tests",
-  "/function_app.py",
-  "/host.json",
-  "/local.settings.json.example",
-  "/README.md",
-  "/Makefile",
-  "/pyproject.toml",
+  "app",
+  "tests",
+  "function_app.py",
+  "host.json",
+  "local.settings.json.example",
+  "README.md",
+  "Makefile",
+  "pyproject.toml",
 ]
 
 [project]
@@ -25,9 +25,9 @@ readme = "README.md"
 requires-python = ">={{ python_version }},<{{ python_upper_bound }}"
 dependencies = [
   "azure-functions>=1.23.0",
-  "azure-functions-logging>=0.2.0",
+  "azure-functions-logging>=0.5.0",
 {% if include_doctor -%}
-  "azure-functions-doctor>=0.15.0",
+  "azure-functions-doctor>=0.16.0",
 {% endif -%}
 ]
 

--- a/src/azure_functions_scaffold/templates/cosmosdb/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/cosmosdb/pyproject.toml.j2
@@ -7,14 +7,14 @@ packages = ["app"]
 
 [tool.hatch.build.targets.sdist]
 include = [
-  "/app",
-  "/tests",
-  "/function_app.py",
-  "/host.json",
-  "/local.settings.json.example",
-  "/README.md",
-  "/Makefile",
-  "/pyproject.toml",
+  "app",
+  "tests",
+  "function_app.py",
+  "host.json",
+  "local.settings.json.example",
+  "README.md",
+  "Makefile",
+  "pyproject.toml",
 ]
 
 [project]
@@ -25,9 +25,9 @@ readme = "README.md"
 requires-python = ">={{ python_version }},<{{ python_upper_bound }}"
 dependencies = [
   "azure-functions>=1.23.0",
-  "azure-functions-logging>=0.2.0",
+  "azure-functions-logging>=0.5.0",
 {% if include_doctor -%}
-  "azure-functions-doctor>=0.15.0",
+  "azure-functions-doctor>=0.16.0",
 {% endif -%}
 ]
 

--- a/src/azure_functions_scaffold/templates/durable/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/durable/pyproject.toml.j2
@@ -7,14 +7,14 @@ packages = ["app"]
 
 [tool.hatch.build.targets.sdist]
 include = [
-  "/app",
-  "/tests",
-  "/function_app.py",
-  "/host.json",
-  "/local.settings.json.example",
-  "/README.md",
-  "/Makefile",
-  "/pyproject.toml",
+  "app",
+  "tests",
+  "function_app.py",
+  "host.json",
+  "local.settings.json.example",
+  "README.md",
+  "Makefile",
+  "pyproject.toml",
 ]
 
 [project]
@@ -25,10 +25,10 @@ readme = "README.md"
 requires-python = ">={{ python_version }},<{{ python_upper_bound }}"
 dependencies = [
   "azure-functions>=1.23.0",
-  "azure-functions-logging>=0.2.0",
+  "azure-functions-logging>=0.5.0",
   "azure-functions-durable>=1.2.9",
 {% if include_doctor -%}
-  "azure-functions-doctor>=0.15.0",
+  "azure-functions-doctor>=0.16.0",
 {% endif -%}
 ]
 

--- a/src/azure_functions_scaffold/templates/eventhub/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/eventhub/pyproject.toml.j2
@@ -7,14 +7,14 @@ packages = ["app"]
 
 [tool.hatch.build.targets.sdist]
 include = [
-  "/app",
-  "/tests",
-  "/function_app.py",
-  "/host.json",
-  "/local.settings.json.example",
-  "/README.md",
-  "/Makefile",
-  "/pyproject.toml",
+  "app",
+  "tests",
+  "function_app.py",
+  "host.json",
+  "local.settings.json.example",
+  "README.md",
+  "Makefile",
+  "pyproject.toml",
 ]
 
 [project]
@@ -25,9 +25,9 @@ readme = "README.md"
 requires-python = ">={{ python_version }},<{{ python_upper_bound }}"
 dependencies = [
   "azure-functions>=1.23.0",
-  "azure-functions-logging>=0.2.0",
+  "azure-functions-logging>=0.5.0",
 {% if include_doctor -%}
-  "azure-functions-doctor>=0.15.0",
+  "azure-functions-doctor>=0.16.0",
 {% endif -%}
 ]
 

--- a/src/azure_functions_scaffold/templates/http/README.md.j2
+++ b/src/azure_functions_scaffold/templates/http/README.md.j2
@@ -14,6 +14,58 @@ OpenAPI: enabled — visit `/api/docs` for Swagger UI
 Validation: enabled — request/response models validated via `azure-functions-validation`
 {% endif %}
 
+## Prerequisites
+
+- Python `{{ python_version }}` or newer
+- Azure Functions Core Tools v4 (`func`)
+- A local virtual environment (`python -m venv .venv`)
+- Optional: Docker for containerized local runs
+
+## Project Structure
+
+```text
+.
+├── function_app.py
+├── app/
+│   ├── functions/http.py
+{% if include_db %}│   ├── functions/db_items.py
+{% endif %}
+│   ├── schemas/request_models.py
+│   ├── services/hello_service.py
+│   └── core/logging.py
+└── {host.json, local.settings.json.example, .funcignore}
+```
+
+## Configuration
+
+- `.funcignore` controls files excluded from local packaging/deployment.
+- `host.json` defines Azure Functions host-level runtime configuration.
+- `local.settings.json.example` documents required local app settings.
+
+{% if include_validation %}
+## Validation
+
+Request and response payloads are validated with `azure-functions-validation`.
+Schemas are defined with `pydantic` models in `app/schemas/request_models.py`.
+Invalid requests return structured 4xx errors before service logic executes.
+{% endif %}
+
+{% if include_db %}
+## Database
+
+The `db_items` endpoint provides a basic CRUD surface for item records.
+Persistence and connection handling are managed through `azure-functions-db`.
+Use this route as a reference for data-access patterns in other functions.
+{% endif %}
+
+{% if include_doctor %}
+## Health Check
+
+The doctor endpoint exposes a lightweight runtime health signal.
+Use it to verify app startup, dependency wiring, and basic readiness.
+It is intended for local checks and platform health probes.
+{% endif %}
+
 ## Development
 
 ```bash

--- a/src/azure_functions_scaffold/templates/http/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/http/pyproject.toml.j2
@@ -7,14 +7,14 @@ packages = ["app"]
 
 [tool.hatch.build.targets.sdist]
 include = [
-  "/app",
-  "/tests",
-  "/function_app.py",
-  "/host.json",
-  "/local.settings.json.example",
-  "/README.md",
-  "/Makefile",
-  "/pyproject.toml",
+  "app",
+  "tests",
+  "function_app.py",
+  "host.json",
+  "local.settings.json.example",
+  "README.md",
+  "Makefile",
+  "pyproject.toml",
 ]
 
 [project]
@@ -25,22 +25,22 @@ readme = "README.md"
 requires-python = ">={{ python_version }},<{{ python_upper_bound }}"
 dependencies = [
   "azure-functions>=1.23.0",
-  "azure-functions-logging>=0.2.0",
+  "azure-functions-logging>=0.5.0",
 {% if include_openapi -%}
-  "azure-functions-openapi>=0.13.0",
+  "azure-functions-openapi>=0.17.0",
 {% endif -%}
 {% if include_validation -%}
-  "azure-functions-validation>=0.5.0",
+  "azure-functions-validation>=0.7.0",
 {% endif -%}
 {% if include_validation -%}
   "pydantic>=2.0.0",
 {% endif -%}
 {% if include_doctor -%}
-  "azure-functions-doctor>=0.15.0",
+  "azure-functions-doctor>=0.16.0",
 {% endif -%}
 {% if include_db -%}
   # Database: default postgres driver. Alternatives: [mysql], [mssql], or omit for SQLite.
-  "azure-functions-db[postgres]>=0.1.0",
+  "azure-functions-db[postgres]>=0.2.0",
 {% endif -%}
 ]
 

--- a/src/azure_functions_scaffold/templates/langgraph/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/langgraph/pyproject.toml.j2
@@ -7,14 +7,14 @@ packages = ["app"]
 
 [tool.hatch.build.targets.sdist]
 include = [
-  "/app",
-  "/tests",
-  "/function_app.py",
-  "/host.json",
-  "/local.settings.json.example",
-  "/README.md",
-  "/Makefile",
-  "/pyproject.toml",
+  "app",
+  "tests",
+  "function_app.py",
+  "host.json",
+  "local.settings.json.example",
+  "README.md",
+  "Makefile",
+  "pyproject.toml",
 ]
 
 [project]
@@ -25,7 +25,7 @@ readme = "README.md"
 requires-python = ">={{ python_version }},<{{ python_upper_bound }}"
 dependencies = [
   "azure-functions>=1.23.0",
-  "azure-functions-langgraph>=0.5.0",
+  "azure-functions-langgraph>=0.5.1",
   "langgraph>=0.2.0",
 ]
 

--- a/src/azure_functions_scaffold/templates/queue/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/queue/pyproject.toml.j2
@@ -7,14 +7,14 @@ packages = ["app"]
 
 [tool.hatch.build.targets.sdist]
 include = [
-  "/app",
-  "/tests",
-  "/function_app.py",
-  "/host.json",
-  "/local.settings.json.example",
-  "/README.md",
-  "/Makefile",
-  "/pyproject.toml",
+  "app",
+  "tests",
+  "function_app.py",
+  "host.json",
+  "local.settings.json.example",
+  "README.md",
+  "Makefile",
+  "pyproject.toml",
 ]
 
 [project]
@@ -25,9 +25,9 @@ readme = "README.md"
 requires-python = ">={{ python_version }},<{{ python_upper_bound }}"
 dependencies = [
   "azure-functions>=1.23.0",
-  "azure-functions-logging>=0.2.0",
+  "azure-functions-logging>=0.5.0",
 {% if include_doctor -%}
-  "azure-functions-doctor>=0.15.0",
+  "azure-functions-doctor>=0.16.0",
 {% endif -%}
 ]
 

--- a/src/azure_functions_scaffold/templates/servicebus/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/servicebus/pyproject.toml.j2
@@ -7,14 +7,14 @@ packages = ["app"]
 
 [tool.hatch.build.targets.sdist]
 include = [
-  "/app",
-  "/tests",
-  "/function_app.py",
-  "/host.json",
-  "/local.settings.json.example",
-  "/README.md",
-  "/Makefile",
-  "/pyproject.toml",
+  "app",
+  "tests",
+  "function_app.py",
+  "host.json",
+  "local.settings.json.example",
+  "README.md",
+  "Makefile",
+  "pyproject.toml",
 ]
 
 [project]
@@ -25,9 +25,9 @@ readme = "README.md"
 requires-python = ">={{ python_version }},<{{ python_upper_bound }}"
 dependencies = [
   "azure-functions>=1.23.0",
-  "azure-functions-logging>=0.2.0",
+  "azure-functions-logging>=0.5.0",
 {% if include_doctor -%}
-  "azure-functions-doctor>=0.15.0",
+  "azure-functions-doctor>=0.16.0",
 {% endif -%}
 ]
 

--- a/src/azure_functions_scaffold/templates/timer/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/timer/pyproject.toml.j2
@@ -7,14 +7,14 @@ packages = ["app"]
 
 [tool.hatch.build.targets.sdist]
 include = [
-  "/app",
-  "/tests",
-  "/function_app.py",
-  "/host.json",
-  "/local.settings.json.example",
-  "/README.md",
-  "/Makefile",
-  "/pyproject.toml",
+  "app",
+  "tests",
+  "function_app.py",
+  "host.json",
+  "local.settings.json.example",
+  "README.md",
+  "Makefile",
+  "pyproject.toml",
 ]
 
 [project]
@@ -25,9 +25,9 @@ readme = "README.md"
 requires-python = ">={{ python_version }},<{{ python_upper_bound }}"
 dependencies = [
   "azure-functions>=1.23.0",
-  "azure-functions-logging>=0.2.0",
+  "azure-functions-logging>=0.5.0",
 {% if include_doctor -%}
-  "azure-functions-doctor>=0.15.0",
+  "azure-functions-doctor>=0.16.0",
 {% endif -%}
 ]
 

--- a/tests/test_cli_intents.py
+++ b/tests/test_cli_intents.py
@@ -427,3 +427,42 @@ class TestErrorPaths:
         )
         assert result.exit_code == 1
         assert "Unknown template" in result.stdout
+
+
+class TestSuccessMessage:
+    """Verify the post-scaffold landing message content."""
+
+    def test_success_message_shows_project_info(self, tmp_path: Path) -> None:
+        result = runner.invoke(app, ["api", "new", "msg-test", "--destination", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "Project created successfully" in result.stdout
+        assert "Template:  http" in result.stdout
+        assert "Preset:    strict" in result.stdout
+        assert "Features:" in result.stdout
+        assert "openapi" in result.stdout
+
+    def test_success_message_shows_full_path_in_cd(self, tmp_path: Path) -> None:
+        result = runner.invoke(app, ["api", "new", "cd-test", "--destination", str(tmp_path)])
+        assert result.exit_code == 0
+        # Must show the full project path, not just the project name
+        expected_path = str(tmp_path / "cd-test")
+        assert f"cd {expected_path}" in result.stdout
+
+    def test_success_message_shows_platform_aware_activate(self, tmp_path: Path) -> None:
+        result = runner.invoke(app, ["api", "new", "act-test", "--destination", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "source .venv/bin/activate" in result.stdout
+        assert ".venv\\Scripts\\activate" in result.stdout
+
+    def test_success_message_shows_openapi_docs_url(self, tmp_path: Path) -> None:
+        result = runner.invoke(app, ["api", "new", "docs-test", "--destination", str(tmp_path)])
+        assert result.exit_code == 0
+        assert "http://localhost:7071/api/docs" in result.stdout
+
+    def test_success_message_omits_openapi_url_for_worker(self, tmp_path: Path) -> None:
+        result = runner.invoke(
+            app, ["worker", "timer", "timer-test", "--destination", str(tmp_path)]
+        )
+        assert result.exit_code == 0
+        assert "Project created successfully" in result.stdout
+        assert "http://localhost:7071/api/docs" not in result.stdout

--- a/tests/test_cli_intents.py
+++ b/tests/test_cli_intents.py
@@ -31,9 +31,9 @@ class TestApiNew:
         http_text = (project_dir / "app/functions/http.py").read_text(encoding="utf-8")
         makefile_text = (project_dir / "Makefile").read_text(encoding="utf-8")
         # api intent: strict preset + openapi + validation + doctor
-        assert "azure-functions-openapi>=0.13.0" in pyproject_text
-        assert "azure-functions-validation>=0.5.0" in pyproject_text
-        assert "azure-functions-doctor>=0.15.0" in pyproject_text
+        assert "azure-functions-openapi>=0.17.0" in pyproject_text
+        assert "azure-functions-validation>=0.7.0" in pyproject_text
+        assert "azure-functions-doctor>=0.16.0" in pyproject_text
         assert "mypy>=1.17.1" in pyproject_text  # strict preset
         assert "@openapi(" in http_text
         assert "@validate_http(" in http_text
@@ -100,10 +100,10 @@ class TestApiCrud:
         pyproject_text = (project_dir / "pyproject.toml").read_text(encoding="utf-8")
         function_app_text = (project_dir / "function_app.py").read_text(encoding="utf-8")
         # crud = api + db
-        assert "azure-functions-openapi>=0.13.0" in pyproject_text
-        assert "azure-functions-validation>=0.5.0" in pyproject_text
-        assert "azure-functions-doctor>=0.15.0" in pyproject_text
-        assert "azure-functions-db[postgres]>=0.1.0" in pyproject_text
+        assert "azure-functions-openapi>=0.17.0" in pyproject_text
+        assert "azure-functions-validation>=0.7.0" in pyproject_text
+        assert "azure-functions-doctor>=0.16.0" in pyproject_text
+        assert "azure-functions-db[postgres]>=0.2.0" in pyproject_text
         assert "mypy>=1.17.1" in pyproject_text
         assert (project_dir / "app/functions/db_items.py").exists()
         assert "db_items_blueprint" in function_app_text
@@ -226,7 +226,7 @@ class TestAiAgent:
         pyproject_text = (project_dir / "pyproject.toml").read_text(encoding="utf-8")
         assert (project_dir / "app/graphs/echo_agent.py").exists()
         assert "LangGraphApp" in function_app_text
-        assert "azure-functions-langgraph>=0.5.0" in pyproject_text
+        assert "azure-functions-langgraph>=0.5.1" in pyproject_text
 
     def test_dry_run(self, tmp_path: Path) -> None:
         result = runner.invoke(
@@ -278,10 +278,10 @@ class TestAdvanced:
         assert result.exit_code == 0
         project_dir = tmp_path / "full-api"
         pyproject_text = (project_dir / "pyproject.toml").read_text(encoding="utf-8")
-        assert "azure-functions-openapi>=0.13.0" in pyproject_text
-        assert "azure-functions-validation>=0.5.0" in pyproject_text
-        assert "azure-functions-doctor>=0.15.0" in pyproject_text
-        assert "azure-functions-db[postgres]>=0.1.0" in pyproject_text
+        assert "azure-functions-openapi>=0.17.0" in pyproject_text
+        assert "azure-functions-validation>=0.7.0" in pyproject_text
+        assert "azure-functions-doctor>=0.16.0" in pyproject_text
+        assert "azure-functions-db[postgres]>=0.2.0" in pyproject_text
         assert (project_dir / "azure.yaml").exists()
 
     def test_new_dry_run(self, tmp_path: Path) -> None:

--- a/tests/test_scaffolder.py
+++ b/tests/test_scaffolder.py
@@ -268,7 +268,7 @@ def test_scaffold_project_generates_expected_project_contract(
     assert "mypy>=1.17.1" in pyproject_text
     assert "pytest>=8.3.5" in pyproject_text
     assert "Preset: `strict`" in readme_text
-    assert "azure-functions-logging>=0.2.0" in pyproject_text
+    assert "azure-functions-logging>=0.5.0" in pyproject_text
 
 
 @pytest.mark.parametrize("template_name", ["queue", "blob", "servicebus", "eventhub", "cosmosdb"])
@@ -581,7 +581,7 @@ def test_scaffold_project_with_db_generates_db_items(tmp_path: Path) -> None:
     assert "from app.functions.db_items import db_items_blueprint" in function_app_text
     assert "app.register_functions(db_items_blueprint)" in function_app_text
     pyproject_text = (project_path / "pyproject.toml").read_text(encoding="utf-8")
-    assert "azure-functions-db[postgres]>=0.1.0" in pyproject_text
+    assert "azure-functions-db[postgres]>=0.2.0" in pyproject_text
     local_settings = (project_path / "local.settings.json.example").read_text(encoding="utf-8")
     assert "DB_URL" in local_settings
 
@@ -648,7 +648,7 @@ def test_scaffold_project_renders_langgraph_template(tmp_path: Path) -> None:
     assert "LangGraphApp" in function_app_text
     assert "lg_app.register" in function_app_text
     pyproject_text = (project_path / "pyproject.toml").read_text(encoding="utf-8")
-    assert "azure-functions-langgraph>=0.5.0" in pyproject_text
+    assert "azure-functions-langgraph>=0.5.1" in pyproject_text
     assert "langgraph>=0.2.0" in pyproject_text
 
 

--- a/tests/test_template_smoke.py
+++ b/tests/test_template_smoke.py
@@ -1,0 +1,165 @@
+from __future__ import annotations
+
+import ast
+import importlib
+from pathlib import Path
+import sys
+from typing import Callable, cast
+
+import pytest
+
+from azure_functions_scaffold.scaffolder import scaffold_project
+from azure_functions_scaffold.template_registry import build_project_options
+
+
+def _load_pyproject(project_root: Path) -> dict[str, object]:
+    parsed = _toml_loads((project_root / "pyproject.toml").read_text(encoding="utf-8"))
+    return _as_string_key_dict(parsed)
+
+
+def _toml_loads(content: str) -> object:
+    version_info = sys.version_info
+    module_name = "tomllib" if version_info >= (3, 11) else "tomli"
+    module = importlib.import_module(module_name)
+    loads = cast(Callable[[str], object], getattr(module, "loads"))
+    return loads(content)
+
+
+def _as_string_key_dict(value: object) -> dict[str, object]:
+    assert isinstance(value, dict)
+    typed_value = cast(dict[object, object], value)
+    result: dict[str, object] = {}
+    for key, item in typed_value.items():
+        assert isinstance(key, str)
+        result[key] = item
+    return result
+
+
+def _as_string_list(value: object) -> list[str]:
+    assert isinstance(value, list)
+    typed_value = cast(list[object], value)
+    result: list[str] = []
+    for item in typed_value:
+        assert isinstance(item, str)
+        result.append(item)
+    return result
+
+
+def _get_sdist_includes(pyproject_data: dict[str, object]) -> list[str]:
+    tool = _as_string_key_dict(pyproject_data["tool"])
+    hatch = _as_string_key_dict(tool["hatch"])
+    build = _as_string_key_dict(hatch["build"])
+    targets = _as_string_key_dict(build["targets"])
+    sdist = _as_string_key_dict(targets["sdist"])
+    return _as_string_list(sdist["include"])
+
+
+@pytest.mark.parametrize(
+    (
+        "template_name",
+        "preset_name",
+        "include_openapi",
+        "include_validation",
+        "include_doctor",
+        "include_db",
+    ),
+    [
+        ("http", "strict", True, True, True, False),
+        ("http", "standard", False, False, False, False),
+        ("http", "strict", False, False, False, True),
+        ("timer", "standard", False, False, False, False),
+    ],
+)
+def test_scaffolded_templates_produce_parseable_python_and_toml(
+    tmp_path: Path,
+    template_name: str,
+    preset_name: str,
+    include_openapi: bool,
+    include_validation: bool,
+    include_doctor: bool,
+    include_db: bool,
+) -> None:
+    project_name = (
+        f"{template_name}-{preset_name}-"
+        f"openapi-{int(include_openapi)}-"
+        f"validation-{int(include_validation)}-"
+        f"doctor-{int(include_doctor)}-"
+        f"db-{int(include_db)}"
+    )
+    options = build_project_options(
+        preset_name=preset_name,
+        python_version="3.10",
+        include_github_actions=False,
+        initialize_git=False,
+        include_openapi=include_openapi,
+        include_validation=include_validation,
+        include_doctor=include_doctor,
+        include_db=include_db,
+    )
+    project_root = scaffold_project(
+        project_name=project_name,
+        destination=tmp_path,
+        template_name=template_name,
+        options=options,
+    )
+
+    python_files = sorted(project_root.rglob("*.py"))
+    assert python_files
+    for python_file in python_files:
+        _ = ast.parse(python_file.read_text(encoding="utf-8"), filename=str(python_file))
+
+    pyproject_data = _load_pyproject(project_root)
+    assert isinstance(pyproject_data, dict)
+
+
+@pytest.mark.parametrize(
+    (
+        "template_name",
+        "preset_name",
+        "include_openapi",
+        "include_validation",
+        "include_doctor",
+        "include_db",
+    ),
+    [
+        ("http", "strict", True, True, True, False),
+        ("http", "strict", False, False, False, True),
+        ("timer", "standard", False, False, False, False),
+    ],
+)
+def test_scaffolded_pyproject_sdist_includes_do_not_use_leading_slashes(
+    tmp_path: Path,
+    template_name: str,
+    preset_name: str,
+    include_openapi: bool,
+    include_validation: bool,
+    include_doctor: bool,
+    include_db: bool,
+) -> None:
+    project_name = (
+        f"sdist-{template_name}-{preset_name}-"
+        f"openapi-{int(include_openapi)}-"
+        f"validation-{int(include_validation)}-"
+        f"doctor-{int(include_doctor)}-"
+        f"db-{int(include_db)}"
+    )
+    options = build_project_options(
+        preset_name=preset_name,
+        python_version="3.10",
+        include_github_actions=False,
+        initialize_git=False,
+        include_openapi=include_openapi,
+        include_validation=include_validation,
+        include_doctor=include_doctor,
+        include_db=include_db,
+    )
+    project_root = scaffold_project(
+        project_name=project_name,
+        destination=tmp_path,
+        template_name=template_name,
+        options=options,
+    )
+
+    pyproject_data = _load_pyproject(project_root)
+    sdist_includes = _get_sdist_includes(pyproject_data)
+    assert all(not path.startswith("/") for path in sdist_includes)


### PR DESCRIPTION
## Summary

- Fix leading slashes in `pyproject.toml.j2` sdist include paths across all 10 templates
- Update dependency version pins to match latest PyPI releases
- Add rich post-scaffold landing message with project info, features, next steps, and OpenAPI URL
- Enrich HTTP `README.md.j2` with prerequisites, project structure, configuration sections
- Add `test_template_smoke.py` — 7 parametrized tests verifying rendered templates produce valid Python/TOML
- Fix `cd` instruction to use full path (not just project name) per Oracle review
- Add platform-aware venv activation (Linux/macOS + Windows) per Oracle review
- Add 5 tests for success message output (path, platform, OpenAPI URL presence/absence)

## Changes

| Area | Files | Description |
|------|-------|-------------|
| CLI | `cli_common.py` | Rich `_print_success_message()` with full path, platform-aware activate |
| Templates | 10 × `pyproject.toml.j2` | Remove leading slashes, bump dep versions |
| Templates | `http/README.md.j2` | Prerequisites, structure, config, validation, DB, health sections |
| Tests | `test_template_smoke.py` (new) | 7 smoke tests for ast.parse, TOML parse, sdist paths |
| Tests | `test_cli_intents.py` | 12 version assertions updated + 5 new success message tests |
| Tests | `test_scaffolder.py` | 3 version assertions updated |

## Verification

- 184 passed, 3 skipped, 97.96% coverage
- Lint clean (20 files)
- Typecheck clean (20 files)
- Oracle reviewed: 2 blockers fixed (full path in cd, platform-aware activate)

Closes #50