### PR TITLE
feat: add route/resource engine — Jinja partials, generator, CLI commands, tests

### DIFF
--- a/src/azure_functions_scaffold/cli_advanced.py
+++ b/src/azure_functions_scaffold/cli_advanced.py
@@ -18,7 +18,11 @@ from azure_functions_scaffold.errors import ScaffoldError
 from azure_functions_scaffold.generator import (
     SUPPORTED_TRIGGERS,
     add_function,
+    add_resource,
+    add_route,
     describe_add_function,
+    describe_add_resource,
+    describe_add_route,
 )
 from azure_functions_scaffold.template_registry import (
     build_project_options,
@@ -185,3 +189,76 @@ def advanced_presets() -> None:
     for preset in list_presets():
         tooling = ", ".join(preset.tooling) or "none"
         typer.echo(f"{preset.name}: {preset.description} [tooling: {tooling}]")
+
+
+@advanced_app.command("add-route")
+def advanced_add_route(
+    route_name: Annotated[
+        str,
+        typer.Argument(..., help="Route name to add."),
+    ],
+    project_root: Annotated[
+        Path,
+        typer.Option(
+            ".",
+            "--project-root",
+            help="Existing scaffolded project directory.",
+        ),
+    ] = Path("."),
+    dry_run: DryRunOption = False,
+) -> None:
+    """Add a simple HTTP route to an existing project."""
+    try:
+        if dry_run:
+            for line in describe_add_route(
+                project_root=project_root,
+                route_name=route_name,
+            ):
+                typer.echo(line)
+            return
+        route_path = add_route(
+            project_root=project_root,
+            route_name=route_name,
+        )
+    except ScaffoldError as exc:
+        typer.secho(str(exc), fg=typer.colors.RED)
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(f"Created route at {route_path}")
+
+
+@advanced_app.command("add-resource")
+def advanced_add_resource(
+    resource_name: Annotated[
+        str,
+        typer.Argument(..., help="Resource name to add (e.g. products)."),
+    ],
+    project_root: Annotated[
+        Path,
+        typer.Option(
+            ".",
+            "--project-root",
+            help="Existing scaffolded project directory.",
+        ),
+    ] = Path("."),
+    dry_run: DryRunOption = False,
+) -> None:
+    """Add a full CRUD resource (blueprint, service, schema, test) to an existing project."""
+    try:
+        if dry_run:
+            for line in describe_add_resource(
+                project_root=project_root,
+                resource_name=resource_name,
+            ):
+                typer.echo(line)
+            return
+        created = add_resource(
+            project_root=project_root,
+            resource_name=resource_name,
+        )
+    except ScaffoldError as exc:
+        typer.secho(str(exc), fg=typer.colors.RED)
+        raise typer.Exit(code=1) from exc
+
+    for path in created:
+        typer.echo(f"Created {path}")

--- a/src/azure_functions_scaffold/cli_api.py
+++ b/src/azure_functions_scaffold/cli_api.py
@@ -17,7 +17,14 @@ from azure_functions_scaffold.cli_common import (
     run_intent,
 )
 from azure_functions_scaffold.errors import ScaffoldError
-from azure_functions_scaffold.generator import add_function, describe_add_function
+from azure_functions_scaffold.generator import (
+    add_function,
+    add_resource,
+    add_route,
+    describe_add_function,
+    describe_add_resource,
+    describe_add_route,
+)
 
 api_app = typer.Typer(
     add_completion=False,
@@ -80,3 +87,64 @@ def api_add(
         raise typer.Exit(code=1) from exc
 
     typer.echo(f"Created function at {function_path}")
+
+
+@api_app.command("add-route")
+def api_add_route(
+    route_name: str = typer.Argument(..., help="Route name to add."),
+    project_root: Path = typer.Option(
+        ".",
+        "--project-root",
+        help="Existing scaffolded project directory.",
+    ),
+    dry_run: DryRunOption = False,
+) -> None:
+    """Add a simple HTTP route to an existing API project."""
+    try:
+        if dry_run:
+            for line in describe_add_route(
+                project_root=project_root,
+                route_name=route_name,
+            ):
+                typer.echo(line)
+            return
+        route_path = add_route(
+            project_root=project_root,
+            route_name=route_name,
+        )
+    except ScaffoldError as exc:
+        typer.secho(str(exc), fg=typer.colors.RED)
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(f"Created route at {route_path}")
+
+
+@api_app.command("add-resource")
+def api_add_resource(
+    resource_name: str = typer.Argument(..., help="Resource name to add (e.g. products)."),
+    project_root: Path = typer.Option(
+        ".",
+        "--project-root",
+        help="Existing scaffolded project directory.",
+    ),
+    dry_run: DryRunOption = False,
+) -> None:
+    """Add a full CRUD resource (blueprint, service, schema, test) to an existing API project."""
+    try:
+        if dry_run:
+            for line in describe_add_resource(
+                project_root=project_root,
+                resource_name=resource_name,
+            ):
+                typer.echo(line)
+            return
+        created = add_resource(
+            project_root=project_root,
+            resource_name=resource_name,
+        )
+    except ScaffoldError as exc:
+        typer.secho(str(exc), fg=typer.colors.RED)
+        raise typer.Exit(code=1) from exc
+
+    for path in created:
+        typer.echo(f"Created {path}")

--- a/src/azure_functions_scaffold/generator.py
+++ b/src/azure_functions_scaffold/generator.py
@@ -641,10 +641,17 @@ def _derive_resource_names(resource_name: str) -> dict[str, str]:
         route_name      = "products"
         store_class     = "ProductsStore"
     """
-    # Simple English singular: strip trailing 's' when it exists and the word
-    # is longer than 3 characters (avoids breaking "bus" → "bu").
+    # Simple English singular: strip trailing 's' when safe.
+    # Guard against false positives where stripping 's' produces nonsense.
+    _NO_STRIP = frozenset({
+        "status", "bus", "news", "address", "class", "process",
+        "access", "success", "progress", "focus", "canvas",
+        "analysis", "basis", "crisis", "diagnosis", "thesis",
+    })
     singular = resource_name
-    if singular.endswith("s") and len(singular) > 3:
+    # Check the last segment (after final underscore) for the no-strip list.
+    last_segment = resource_name.rsplit("_", maxsplit=1)[-1]
+    if last_segment not in _NO_STRIP and singular.endswith("s") and len(singular) > 3:
         singular = singular[:-1]
 
     # PascalCase: split on underscore, capitalise each part.

--- a/src/azure_functions_scaffold/generator.py
+++ b/src/azure_functions_scaffold/generator.py
@@ -4,12 +4,15 @@ import json
 from pathlib import Path
 import re
 
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
 from azure_functions_scaffold.errors import ScaffoldError
 from azure_functions_scaffold.template_registry import list_templates
 
 FUNCTION_IMPORT_MARKER = "# azure-functions-scaffold: function imports"
 FUNCTION_REGISTRATION_MARKER = "# azure-functions-scaffold: function registrations"
 SUPPORTED_TRIGGERS = tuple(template.name for template in list_templates())
+PARTIALS_ROOT = Path(__file__).parent / "templates" / "partials"
 
 
 def add_function(
@@ -620,3 +623,235 @@ def _ensure_local_settings_values(project_root: Path, trigger: str) -> None:
         f"{json.dumps(local_settings, indent=2)}\n",
         encoding="utf-8",
     )
+
+
+# ---------------------------------------------------------------------------
+# Resource generation (Jinja partials)
+# ---------------------------------------------------------------------------
+
+
+def _derive_resource_names(resource_name: str) -> dict[str, str]:
+    """Derive all template variable names from a normalized resource name.
+
+    For example, ``products`` yields::
+
+        resource_name   = "products"
+        resource_singular = "product"
+        resource_class  = "Product"
+        route_name      = "products"
+        store_class     = "ProductsStore"
+    """
+    # Simple English singular: strip trailing 's' when it exists and the word
+    # is longer than 3 characters (avoids breaking "bus" → "bu").
+    singular = resource_name
+    if singular.endswith("s") and len(singular) > 3:
+        singular = singular[:-1]
+
+    # PascalCase: split on underscore, capitalise each part.
+    class_name = "".join(part.capitalize() for part in singular.split("_"))
+    store_class = "".join(part.capitalize() for part in resource_name.split("_")) + "Store"
+    route_name = resource_name.replace("_", "-")
+
+    return {
+        "resource_name": resource_name,
+        "resource_singular": singular,
+        "resource_class": class_name,
+        "route_name": route_name,
+        "store_class": store_class,
+    }
+
+
+def _render_partial(template_name: str, context: dict[str, str]) -> str:
+    """Render a Jinja partial template with the given context."""
+    env = Environment(
+        loader=FileSystemLoader(str(PARTIALS_ROOT)),
+        autoescape=select_autoescape(
+            enabled_extensions=("html", "xml"),
+            default_for_string=False,
+            default=False,
+        ),
+        keep_trailing_newline=True,
+    )
+    template = env.get_template(template_name)
+    return template.render(**context)
+
+
+def add_resource(
+    *,
+    project_root: Path,
+    resource_name: str,
+) -> list[Path]:
+    """Add a full CRUD resource to an existing scaffolded project.
+
+    Creates four files:
+        - ``app/functions/{name}.py`` — CRUD blueprint
+        - ``app/services/{name}_service.py`` — in-memory store
+        - ``app/schemas/{name}.py`` — request/response dataclasses
+        - ``tests/test_{name}.py`` — test suite (if ``tests/`` exists)
+
+    Also registers the new blueprint in ``function_app.py`` via markers.
+
+    Returns the list of created file paths.
+    """
+    normalized = _normalize_function_name(resource_name)
+    _validate_project_root(project_root)
+    names = _derive_resource_names(normalized)
+
+    # Check for existing files before writing anything.
+    blueprint_path = project_root / "app" / "functions" / f"{normalized}.py"
+    service_path = project_root / "app" / "services" / f"{normalized}_service.py"
+    schema_path = project_root / "app" / "schemas" / f"{normalized}.py"
+
+    for path in (blueprint_path, service_path, schema_path):
+        if path.exists():
+            raise ScaffoldError(f"File already exists: {path}")
+
+    # Render and write files.
+    created: list[Path] = []
+
+    blueprint_path.parent.mkdir(parents=True, exist_ok=True)
+    blueprint_path.write_text(_render_partial("resource_blueprint.py.j2", names), encoding="utf-8")
+    created.append(blueprint_path)
+
+    service_path.parent.mkdir(parents=True, exist_ok=True)
+    service_path.write_text(_render_partial("resource_service.py.j2", names), encoding="utf-8")
+    created.append(service_path)
+
+    schema_path.parent.mkdir(parents=True, exist_ok=True)
+    schema_path.write_text(_render_partial("resource_schema.py.j2", names), encoding="utf-8")
+    created.append(schema_path)
+
+    if (project_root / "tests").is_dir():
+        test_path = project_root / "tests" / f"test_{normalized}.py"
+        if not test_path.exists():
+            test_path.write_text(_render_partial("resource_test.py.j2", names), encoding="utf-8")
+            created.append(test_path)
+
+    _update_function_app(
+        project_root / "function_app.py",
+        import_stmt=f"from app.functions.{normalized} import {normalized}_blueprint",
+        registration_stmt=f"app.register_functions({normalized}_blueprint)",
+    )
+
+    return created
+
+
+def describe_add_resource(
+    *,
+    project_root: Path,
+    resource_name: str,
+) -> list[str]:
+    """Return a dry-run description of what ``add_resource`` would do."""
+    normalized = _normalize_function_name(resource_name)
+    _validate_project_root(project_root)
+
+    blueprint_path = project_root / "app" / "functions" / f"{normalized}.py"
+    service_path = project_root / "app" / "services" / f"{normalized}_service.py"
+    schema_path = project_root / "app" / "schemas" / f"{normalized}.py"
+
+    for path in (blueprint_path, service_path, schema_path):
+        if path.exists():
+            raise ScaffoldError(f"File already exists: {path}")
+
+    lines = [
+        f"Dry run: add resource '{normalized}'",
+        f"Project root: {project_root}",
+        "Files:",
+        f"  - app/functions/{normalized}.py",
+        f"  - app/services/{normalized}_service.py",
+        f"  - app/schemas/{normalized}.py",
+    ]
+
+    if (project_root / "tests").is_dir():
+        lines.append(f"  - tests/test_{normalized}.py")
+
+    lines.extend(
+        [
+            "Updates:",
+            "  - function_app.py import registration",
+        ]
+    )
+
+    return lines
+
+
+# ---------------------------------------------------------------------------
+# Route generation (Jinja partials)
+# ---------------------------------------------------------------------------
+
+
+def add_route(
+    *,
+    project_root: Path,
+    route_name: str,
+) -> Path:
+    """Add a simple HTTP route blueprint to an existing scaffolded project.
+
+    Creates:
+        - ``app/functions/{name}.py`` — route blueprint
+        - ``tests/test_{name}.py`` — test (if ``tests/`` exists)
+
+    Also registers the new blueprint in ``function_app.py`` via markers.
+
+    Returns the path to the created blueprint file.
+    """
+    normalized = _normalize_function_name(route_name)
+    _validate_project_root(project_root)
+
+    blueprint_path = project_root / "app" / "functions" / f"{normalized}.py"
+    if blueprint_path.exists():
+        raise ScaffoldError(f"Function module already exists: {blueprint_path}")
+
+    names = {
+        "resource_name": normalized,
+        "route_name": normalized.replace("_", "-"),
+    }
+
+    blueprint_path.parent.mkdir(parents=True, exist_ok=True)
+    blueprint_path.write_text(_render_partial("route_blueprint.py.j2", names), encoding="utf-8")
+
+    if (project_root / "tests").is_dir():
+        test_path = project_root / "tests" / f"test_{normalized}.py"
+        if not test_path.exists():
+            test_path.write_text(_render_partial("route_test.py.j2", names), encoding="utf-8")
+
+    _update_function_app(
+        project_root / "function_app.py",
+        import_stmt=f"from app.functions.{normalized} import {normalized}_blueprint",
+        registration_stmt=f"app.register_functions({normalized}_blueprint)",
+    )
+
+    return blueprint_path
+
+
+def describe_add_route(
+    *,
+    project_root: Path,
+    route_name: str,
+) -> list[str]:
+    """Return a dry-run description of what ``add_route`` would do."""
+    normalized = _normalize_function_name(route_name)
+    _validate_project_root(project_root)
+
+    blueprint_path = project_root / "app" / "functions" / f"{normalized}.py"
+    if blueprint_path.exists():
+        raise ScaffoldError(f"Function module already exists: {blueprint_path}")
+
+    lines = [
+        f"Dry run: add route '{normalized}'",
+        f"Project root: {project_root}",
+        "Files:",
+        f"  - app/functions/{normalized}.py",
+    ]
+
+    if (project_root / "tests").is_dir():
+        lines.append(f"  - tests/test_{normalized}.py")
+
+    lines.extend(
+        [
+            "Updates:",
+            "  - function_app.py import registration",
+        ]
+    )
+
+    return lines

--- a/src/azure_functions_scaffold/template_registry.py
+++ b/src/azure_functions_scaffold/template_registry.py
@@ -91,6 +91,7 @@ INTENT_SPECS: dict[str, IntentSpec] = {
     "ai/agent": IntentSpec(template="langgraph", preset="standard"),
 }
 
+
 def list_templates() -> list[TemplateSpec]:
     return list(TEMPLATE_SPECS)
 
@@ -168,5 +169,3 @@ def validate_tooling(tooling: tuple[str, ...]) -> tuple[str, ...]:
             f"Unsupported tooling selection '{invalid_list}'. Supported tooling: {available}"
         )
     return normalized
-
-

--- a/src/azure_functions_scaffold/templates/partials/resource_blueprint.py.j2
+++ b/src/azure_functions_scaffold/templates/partials/resource_blueprint.py.j2
@@ -69,6 +69,12 @@ def create_{{ resource_singular }}(req: func.HttpRequest) -> func.HttpResponse:
             mimetype="application/json",
             status_code=400,
         )
+    if not isinstance(body, dict):
+        return func.HttpResponse(
+            body=json.dumps({"error": "Request body must be a JSON object"}),
+            mimetype="application/json",
+            status_code=400,
+        )
     name = body.get("name", "")
     if not name:
         return func.HttpResponse(
@@ -100,6 +106,12 @@ def update_{{ resource_singular }}(req: func.HttpRequest) -> func.HttpResponse:
     except ValueError:
         return func.HttpResponse(
             body=json.dumps({"error": "Invalid JSON body"}),
+            mimetype="application/json",
+            status_code=400,
+        )
+    if not isinstance(body, dict):
+        return func.HttpResponse(
+            body=json.dumps({"error": "Request body must be a JSON object"}),
             mimetype="application/json",
             status_code=400,
         )

--- a/src/azure_functions_scaffold/templates/partials/resource_blueprint.py.j2
+++ b/src/azure_functions_scaffold/templates/partials/resource_blueprint.py.j2
@@ -1,0 +1,138 @@
+from __future__ import annotations
+
+import json
+
+import azure.functions as func
+
+from app.services.{{ resource_name }}_service import {{ resource_name }}_store
+
+{{ resource_name }}_blueprint = func.Blueprint()  # type: ignore[no-untyped-call]
+
+
+# ---------------------------------------------------------------------------
+# GET /api/{{ route_name }} — list all {{ route_name }}
+# ---------------------------------------------------------------------------
+
+@{{ resource_name }}_blueprint.route(
+    route="{{ route_name }}",
+    methods=["GET"],
+    auth_level=func.AuthLevel.ANONYMOUS,
+)
+def list_{{ resource_name }}(req: func.HttpRequest) -> func.HttpResponse:
+    return func.HttpResponse(
+        body=json.dumps({{ resource_name }}_store.list_all()),
+        mimetype="application/json",
+        status_code=200,
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /api/{{ route_name }}/{item_id} — get a single {{ resource_singular }}
+# ---------------------------------------------------------------------------
+
+@{{ resource_name }}_blueprint.route(
+    route="{{ route_name }}/{item_id}",
+    methods=["GET"],
+    auth_level=func.AuthLevel.ANONYMOUS,
+)
+def get_{{ resource_singular }}(req: func.HttpRequest) -> func.HttpResponse:
+    item_id = req.route_params.get("item_id", "")
+    item = {{ resource_name }}_store.get(item_id)
+    if item is None:
+        return func.HttpResponse(
+            body=json.dumps({"error": "{{ resource_class }} not found"}),
+            mimetype="application/json",
+            status_code=404,
+        )
+    return func.HttpResponse(
+        body=json.dumps(item),
+        mimetype="application/json",
+        status_code=200,
+    )
+
+
+# ---------------------------------------------------------------------------
+# POST /api/{{ route_name }} — create a new {{ resource_singular }}
+# ---------------------------------------------------------------------------
+
+@{{ resource_name }}_blueprint.route(
+    route="{{ route_name }}",
+    methods=["POST"],
+    auth_level=func.AuthLevel.ANONYMOUS,
+)
+def create_{{ resource_singular }}(req: func.HttpRequest) -> func.HttpResponse:
+    try:
+        body = req.get_json()
+    except ValueError:
+        return func.HttpResponse(
+            body=json.dumps({"error": "Invalid JSON body"}),
+            mimetype="application/json",
+            status_code=400,
+        )
+    name = body.get("name", "")
+    if not name:
+        return func.HttpResponse(
+            body=json.dumps({"error": "name is required"}),
+            mimetype="application/json",
+            status_code=400,
+        )
+    item = {{ resource_name }}_store.create(name)
+    return func.HttpResponse(
+        body=json.dumps(item),
+        mimetype="application/json",
+        status_code=201,
+    )
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/{{ route_name }}/{item_id} — update an existing {{ resource_singular }}
+# ---------------------------------------------------------------------------
+
+@{{ resource_name }}_blueprint.route(
+    route="{{ route_name }}/{item_id}",
+    methods=["PUT"],
+    auth_level=func.AuthLevel.ANONYMOUS,
+)
+def update_{{ resource_singular }}(req: func.HttpRequest) -> func.HttpResponse:
+    item_id = req.route_params.get("item_id", "")
+    try:
+        body = req.get_json()
+    except ValueError:
+        return func.HttpResponse(
+            body=json.dumps({"error": "Invalid JSON body"}),
+            mimetype="application/json",
+            status_code=400,
+        )
+    item = {{ resource_name }}_store.update(item_id, name=body.get("name"))
+    if item is None:
+        return func.HttpResponse(
+            body=json.dumps({"error": "{{ resource_class }} not found"}),
+            mimetype="application/json",
+            status_code=404,
+        )
+    return func.HttpResponse(
+        body=json.dumps(item),
+        mimetype="application/json",
+        status_code=200,
+    )
+
+
+# ---------------------------------------------------------------------------
+# DELETE /api/{{ route_name }}/{item_id} — delete a {{ resource_singular }}
+# ---------------------------------------------------------------------------
+
+@{{ resource_name }}_blueprint.route(
+    route="{{ route_name }}/{item_id}",
+    methods=["DELETE"],
+    auth_level=func.AuthLevel.ANONYMOUS,
+)
+def delete_{{ resource_singular }}(req: func.HttpRequest) -> func.HttpResponse:
+    item_id = req.route_params.get("item_id", "")
+    deleted = {{ resource_name }}_store.delete(item_id)
+    if not deleted:
+        return func.HttpResponse(
+            body=json.dumps({"error": "{{ resource_class }} not found"}),
+            mimetype="application/json",
+            status_code=404,
+        )
+    return func.HttpResponse(status_code=204)

--- a/src/azure_functions_scaffold/templates/partials/resource_schema.py.j2
+++ b/src/azure_functions_scaffold/templates/partials/resource_schema.py.j2
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(slots=True)
+class Create{{ resource_class }}Request:
+    name: str
+
+
+@dataclass(slots=True)
+class {{ resource_class }}Response:
+    id: str
+    name: str

--- a/src/azure_functions_scaffold/templates/partials/resource_schema.py.j2
+++ b/src/azure_functions_scaffold/templates/partials/resource_schema.py.j2
@@ -12,3 +12,8 @@ class Create{{ resource_class }}Request:
 class {{ resource_class }}Response:
     id: str
     name: str
+
+
+@dataclass(slots=True)
+class Update{{ resource_class }}Request:
+    name: str | None = None

--- a/src/azure_functions_scaffold/templates/partials/resource_service.py.j2
+++ b/src/azure_functions_scaffold/templates/partials/resource_service.py.j2
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import uuid
+
+
+class {{ store_class }}:
+    """In-memory {{ resource_singular }} store for demonstration purposes.
+
+    Replace with a real database in production.
+    """
+
+    def __init__(self) -> None:
+        self._items: dict[str, dict[str, str]] = {}
+
+    def list_all(self) -> list[dict[str, str]]:
+        return list(self._items.values())
+
+    def get(self, item_id: str) -> dict[str, str] | None:
+        return self._items.get(item_id)
+
+    def create(self, name: str) -> dict[str, str]:
+        item_id = uuid.uuid4().hex[:8]
+        item = {"id": item_id, "name": name}
+        self._items[item_id] = item
+        return item
+
+    def update(
+        self,
+        item_id: str,
+        *,
+        name: str | None = None,
+    ) -> dict[str, str] | None:
+        item = self._items.get(item_id)
+        if item is None:
+            return None
+        if name is not None:
+            item["name"] = name
+        return item
+
+    def delete(self, item_id: str) -> bool:
+        return self._items.pop(item_id, None) is not None
+
+
+{{ resource_name }}_store = {{ store_class }}()

--- a/src/azure_functions_scaffold/templates/partials/resource_test.py.j2
+++ b/src/azure_functions_scaffold/templates/partials/resource_test.py.j2
@@ -99,6 +99,19 @@ class TestCreate{{ resource_class }}:
         assert body["name"] == "New Item"
         assert "id" in body
 
+    def test_returns_400_for_non_object_json(self) -> None:
+        {{ resource_name }}_store._items.clear()
+
+        request = _make_request(
+            "POST",
+            "http://localhost/api/{{ route_name }}",
+            body=json.dumps(["not", "an", "object"]).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        response = create_{{ resource_singular }}(request)
+
+        assert response.status_code == 400
+        assert "JSON object" in json.loads(response.get_body())["error"]
 
 class TestUpdate{{ resource_class }}:
     def test_updates_existing_item(self) -> None:
@@ -147,6 +160,21 @@ class TestUpdate{{ resource_class }}:
 
         assert response.status_code == 400
 
+    def test_returns_400_for_non_object_json(self) -> None:
+        {{ resource_name }}_store._items.clear()
+        item = {{ resource_name }}_store.create("Valid")
+
+        request = _make_request(
+            "PUT",
+            f"http://localhost/api/{{ route_name }}/{item['id']}",
+            body=json.dumps([1, 2, 3]).encode(),
+            route_params={"item_id": item["id"]},
+            headers={"Content-Type": "application/json"},
+        )
+        response = update_{{ resource_singular }}(request)
+
+        assert response.status_code == 400
+        assert "JSON object" in json.loads(response.get_body())["error"]
 
 class TestDelete{{ resource_class }}:
     def test_deletes_existing_item(self) -> None:

--- a/src/azure_functions_scaffold/templates/partials/resource_test.py.j2
+++ b/src/azure_functions_scaffold/templates/partials/resource_test.py.j2
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+import json
+
+import azure.functions as func
+
+from app.functions.{{ resource_name }} import (
+    create_{{ resource_singular }},
+    delete_{{ resource_singular }},
+    get_{{ resource_singular }},
+    list_{{ resource_name }},
+    update_{{ resource_singular }},
+)
+from app.services.{{ resource_name }}_service import {{ resource_name }}_store
+
+
+def _make_request(
+    method: str,
+    url: str,
+    *,
+    body: bytes = b"",
+    route_params: dict[str, str] | None = None,
+    headers: dict[str, str] | None = None,
+) -> func.HttpRequest:
+    return func.HttpRequest(
+        method=method,
+        url=url,
+        params={},
+        body=body,
+        route_params=route_params or {},
+        headers=headers or {},
+    )
+
+
+class TestList{{ resource_class }}:
+    def test_returns_empty_list_initially(self) -> None:
+        {{ resource_name }}_store._items.clear()
+        request = _make_request("GET", "http://localhost/api/{{ route_name }}")
+        response = list_{{ resource_name }}(request)
+
+        assert response.status_code == 200
+        assert json.loads(response.get_body()) == []
+
+    def test_returns_created_items(self) -> None:
+        {{ resource_name }}_store._items.clear()
+        {{ resource_name }}_store.create("Item One")
+
+        request = _make_request("GET", "http://localhost/api/{{ route_name }}")
+        response = list_{{ resource_name }}(request)
+
+        body = json.loads(response.get_body())
+        assert len(body) == 1
+        assert body[0]["name"] == "Item One"
+
+
+class TestGet{{ resource_class }}:
+    def test_returns_item_by_id(self) -> None:
+        {{ resource_name }}_store._items.clear()
+        item = {{ resource_name }}_store.create("Item Two")
+
+        request = _make_request(
+            "GET",
+            f"http://localhost/api/{{ route_name }}/{item['id']}",
+            route_params={"item_id": item["id"]},
+        )
+        response = get_{{ resource_singular }}(request)
+
+        assert response.status_code == 200
+        body = json.loads(response.get_body())
+        assert body["name"] == "Item Two"
+
+    def test_returns_404_for_unknown_id(self) -> None:
+        {{ resource_name }}_store._items.clear()
+
+        request = _make_request(
+            "GET",
+            "http://localhost/api/{{ route_name }}/unknown",
+            route_params={"item_id": "unknown"},
+        )
+        response = get_{{ resource_singular }}(request)
+
+        assert response.status_code == 404
+
+
+class TestCreate{{ resource_class }}:
+    def test_creates_item_successfully(self) -> None:
+        {{ resource_name }}_store._items.clear()
+
+        request = _make_request(
+            "POST",
+            "http://localhost/api/{{ route_name }}",
+            body=json.dumps({"name": "New Item"}).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        response = create_{{ resource_singular }}(request)
+
+        assert response.status_code == 201
+        body = json.loads(response.get_body())
+        assert body["name"] == "New Item"
+        assert "id" in body
+
+
+class TestUpdate{{ resource_class }}:
+    def test_updates_existing_item(self) -> None:
+        {{ resource_name }}_store._items.clear()
+        item = {{ resource_name }}_store.create("Old Name")
+
+        request = _make_request(
+            "PUT",
+            f"http://localhost/api/{{ route_name }}/{item['id']}",
+            body=json.dumps({"name": "New Name"}).encode(),
+            route_params={"item_id": item["id"]},
+            headers={"Content-Type": "application/json"},
+        )
+        response = update_{{ resource_singular }}(request)
+
+        assert response.status_code == 200
+        body = json.loads(response.get_body())
+        assert body["name"] == "New Name"
+
+    def test_returns_404_for_unknown_id(self) -> None:
+        {{ resource_name }}_store._items.clear()
+
+        request = _make_request(
+            "PUT",
+            "http://localhost/api/{{ route_name }}/unknown",
+            body=json.dumps({"name": "Ghost"}).encode(),
+            route_params={"item_id": "unknown"},
+            headers={"Content-Type": "application/json"},
+        )
+        response = update_{{ resource_singular }}(request)
+
+        assert response.status_code == 404
+
+    def test_returns_400_for_invalid_json(self) -> None:
+        {{ resource_name }}_store._items.clear()
+        item = {{ resource_name }}_store.create("Valid")
+
+        request = _make_request(
+            "PUT",
+            f"http://localhost/api/{{ route_name }}/{item['id']}",
+            body=b"not-json",
+            route_params={"item_id": item["id"]},
+            headers={"Content-Type": "application/json"},
+        )
+        response = update_{{ resource_singular }}(request)
+
+        assert response.status_code == 400
+
+
+class TestDelete{{ resource_class }}:
+    def test_deletes_existing_item(self) -> None:
+        {{ resource_name }}_store._items.clear()
+        item = {{ resource_name }}_store.create("To Delete")
+
+        request = _make_request(
+            "DELETE",
+            f"http://localhost/api/{{ route_name }}/{item['id']}",
+            route_params={"item_id": item["id"]},
+        )
+        response = delete_{{ resource_singular }}(request)
+
+        assert response.status_code == 204
+
+    def test_returns_404_for_unknown_id(self) -> None:
+        {{ resource_name }}_store._items.clear()
+
+        request = _make_request(
+            "DELETE",
+            "http://localhost/api/{{ route_name }}/unknown",
+            route_params={"item_id": "unknown"},
+        )
+        response = delete_{{ resource_singular }}(request)
+
+        assert response.status_code == 404

--- a/src/azure_functions_scaffold/templates/partials/route_blueprint.py.j2
+++ b/src/azure_functions_scaffold/templates/partials/route_blueprint.py.j2
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import azure.functions as func
+
+{{ resource_name }}_blueprint = func.Blueprint()  # type: ignore[no-untyped-call]
+
+
+@{{ resource_name }}_blueprint.route(
+    route="{{ route_name }}",
+    methods=["GET"],
+    auth_level=func.AuthLevel.ANONYMOUS,
+)
+def {{ resource_name }}(req: func.HttpRequest) -> func.HttpResponse:
+    return func.HttpResponse(
+        body="TODO: implement {{ route_name }}",
+        status_code=200,
+    )

--- a/src/azure_functions_scaffold/templates/partials/route_test.py.j2
+++ b/src/azure_functions_scaffold/templates/partials/route_test.py.j2
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+import azure.functions as func
+
+from app.functions.{{ resource_name }} import {{ resource_name }}
+
+
+def test_{{ resource_name }}_returns_placeholder_response() -> None:
+    request = func.HttpRequest(
+        method="GET",
+        url="http://localhost/api/{{ route_name }}",
+        params={},
+        body=b"",
+    )
+
+    response = {{ resource_name }}(request)
+
+    assert response.status_code == 200
+    assert response.get_body() == b"TODO: implement {{ route_name }}"

--- a/tests/e2e/test_scaffold_e2e.py
+++ b/tests/e2e/test_scaffold_e2e.py
@@ -9,6 +9,7 @@ Usage:
     E2E_BASE_URL=https://<app>.azurewebsites.net pytest tests/e2e -v
     (BASE_URL is set by the workflow after deployment)
 """
+
 from __future__ import annotations
 
 import os
@@ -43,10 +44,12 @@ def warmup() -> None:
 
 # ── Scaffold generation tests (no Azure needed) ────────────────────────────
 
+
 @pytest.mark.skipif(not SCAFFOLDED_DIR, reason=SKIP_SCAFFOLD_REASON)
 def test_scaffolded_project_has_required_files() -> None:
     """Verify the scaffold CLI generated the expected file structure."""
     import pathlib
+
     root = pathlib.Path(SCAFFOLDED_DIR)
     assert (root / "function_app.py").exists(), "function_app.py missing"
     assert (root / "host.json").exists(), "host.json missing"
@@ -58,6 +61,7 @@ def test_scaffolded_project_has_required_files() -> None:
 def test_scaffolded_function_app_imports_cleanly() -> None:
     """Verify generated function_app.py is importable (syntax valid)."""
     import pathlib
+
     app_file = pathlib.Path(SCAFFOLDED_DIR) / "function_app.py"
     result = subprocess.run(
         [sys.executable, "-c", f"import ast; ast.parse(open('{app_file}').read())"],
@@ -68,6 +72,7 @@ def test_scaffolded_function_app_imports_cleanly() -> None:
 
 
 # ── Deployed app HTTP tests ────────────────────────────────────────────────
+
 
 @pytest.mark.skipif(not BASE_URL, reason=SKIP_REASON)
 def test_hello_endpoint_returns_200() -> None:

--- a/tests/test_cli_intents.py
+++ b/tests/test_cli_intents.py
@@ -79,9 +79,13 @@ class TestApiNew:
         result = runner.invoke(
             app,
             [
-                "api", "new", "py312-api",
-                "--destination", str(tmp_path),
-                "--python-version", "3.12",
+                "api",
+                "new",
+                "py312-api",
+                "--destination",
+                str(tmp_path),
+                "--python-version",
+                "3.12",
             ],
         )
         assert result.exit_code == 0
@@ -100,9 +104,7 @@ class TestApiAdd:
         runner.invoke(app, ["api", "new", "my-api", "--destination", str(tmp_path)])
         project_dir = tmp_path / "my-api"
 
-        result = runner.invoke(
-            app, ["api", "add", "get-user", "--project-root", str(project_dir)]
-        )
+        result = runner.invoke(app, ["api", "add", "get-user", "--project-root", str(project_dir)])
         assert result.exit_code == 0
         assert (project_dir / "app/functions/get_user.py").exists()
         assert (project_dir / "tests/test_get_user.py").exists()
@@ -119,6 +121,83 @@ class TestApiAdd:
         assert result.exit_code == 0
         assert "Dry run:" in result.stdout
         assert not (project_dir / "app/functions/list_items.py").exists()
+
+
+class TestApiAddRoute:
+    def test_adds_route(self, tmp_path: Path) -> None:
+        runner.invoke(app, ["api", "new", "my-api", "--destination", str(tmp_path)])
+        project_dir = tmp_path / "my-api"
+
+        result = runner.invoke(
+            app, ["api", "add-route", "status", "--project-root", str(project_dir)]
+        )
+        assert result.exit_code == 0
+        assert (project_dir / "app/functions/status.py").exists()
+        assert (project_dir / "tests/test_status.py").exists()
+        function_app_text = (project_dir / "function_app.py").read_text(encoding="utf-8")
+        assert "status_blueprint" in function_app_text
+
+    def test_dry_run(self, tmp_path: Path) -> None:
+        runner.invoke(app, ["api", "new", "my-api", "--destination", str(tmp_path)])
+        project_dir = tmp_path / "my-api"
+
+        result = runner.invoke(
+            app, ["api", "add-route", "status", "--project-root", str(project_dir), "--dry-run"]
+        )
+        assert result.exit_code == 0
+        assert "Dry run:" in result.stdout
+        assert not (project_dir / "app/functions/status.py").exists()
+
+    def test_rejects_existing_route(self, tmp_path: Path) -> None:
+        runner.invoke(app, ["api", "new", "my-api", "--destination", str(tmp_path)])
+        project_dir = tmp_path / "my-api"
+        runner.invoke(app, ["api", "add-route", "status", "--project-root", str(project_dir)])
+
+        result = runner.invoke(
+            app, ["api", "add-route", "status", "--project-root", str(project_dir)]
+        )
+        assert result.exit_code == 1
+        assert "already exists" in result.stdout
+
+
+class TestApiAddResource:
+    def test_adds_resource(self, tmp_path: Path) -> None:
+        runner.invoke(app, ["api", "new", "my-api", "--destination", str(tmp_path)])
+        project_dir = tmp_path / "my-api"
+
+        result = runner.invoke(
+            app, ["api", "add-resource", "products", "--project-root", str(project_dir)]
+        )
+        assert result.exit_code == 0
+        assert (project_dir / "app/functions/products.py").exists()
+        assert (project_dir / "app/services/products_service.py").exists()
+        assert (project_dir / "app/schemas/products.py").exists()
+        assert (project_dir / "tests/test_products.py").exists()
+        function_app_text = (project_dir / "function_app.py").read_text(encoding="utf-8")
+        assert "products_blueprint" in function_app_text
+
+    def test_dry_run(self, tmp_path: Path) -> None:
+        runner.invoke(app, ["api", "new", "my-api", "--destination", str(tmp_path)])
+        project_dir = tmp_path / "my-api"
+
+        result = runner.invoke(
+            app,
+            ["api", "add-resource", "products", "--project-root", str(project_dir), "--dry-run"],
+        )
+        assert result.exit_code == 0
+        assert "Dry run:" in result.stdout
+        assert not (project_dir / "app/functions/products.py").exists()
+
+    def test_rejects_existing_resource(self, tmp_path: Path) -> None:
+        runner.invoke(app, ["api", "new", "my-api", "--destination", str(tmp_path)])
+        project_dir = tmp_path / "my-api"
+        runner.invoke(app, ["api", "add-resource", "products", "--project-root", str(project_dir)])
+
+        result = runner.invoke(
+            app, ["api", "add-resource", "products", "--project-root", str(project_dir)]
+        )
+        assert result.exit_code == 1
+        assert "already exists" in result.stdout
 
 
 # ---------------------------------------------------------------------------
@@ -157,9 +236,7 @@ class TestWorker:
         assert f"{template_name}_blueprint" in function_app_text
 
     def test_timer_uses_standard_preset(self, tmp_path: Path) -> None:
-        result = runner.invoke(
-            app, ["worker", "timer", "my-job", "--destination", str(tmp_path)]
-        )
+        result = runner.invoke(app, ["worker", "timer", "my-job", "--destination", str(tmp_path)])
         assert result.exit_code == 0
 
         project_dir = tmp_path / "my-job"
@@ -196,9 +273,7 @@ class TestWorker:
 
 class TestAiAgent:
     def test_creates_langgraph_project(self, tmp_path: Path) -> None:
-        result = runner.invoke(
-            app, ["ai", "agent", "my-agent", "--destination", str(tmp_path)]
-        )
+        result = runner.invoke(app, ["ai", "agent", "my-agent", "--destination", str(tmp_path)])
         assert result.exit_code == 0
 
         project_dir = tmp_path / "my-agent"
@@ -235,9 +310,7 @@ class TestAiAgent:
 
 class TestAdvanced:
     def test_new_creates_project(self, tmp_path: Path) -> None:
-        result = runner.invoke(
-            app, ["advanced", "new", "my-api", "--destination", str(tmp_path)]
-        )
+        result = runner.invoke(app, ["advanced", "new", "my-api", "--destination", str(tmp_path)])
         assert result.exit_code == 0
         assert (tmp_path / "my-api" / "function_app.py").exists()
 
@@ -245,9 +318,13 @@ class TestAdvanced:
         result = runner.invoke(
             app,
             [
-                "advanced", "new", "full-api",
-                "--destination", str(tmp_path),
-                "--preset", "strict",
+                "advanced",
+                "new",
+                "full-api",
+                "--destination",
+                str(tmp_path),
+                "--preset",
+                "strict",
                 "--with-openapi",
                 "--with-validation",
                 "--with-doctor",
@@ -288,8 +365,12 @@ class TestAdvanced:
         result = runner.invoke(
             app,
             [
-                "advanced", "add", "servicebus", "process-events",
-                "--project-root", str(project_dir),
+                "advanced",
+                "add",
+                "servicebus",
+                "process-events",
+                "--project-root",
+                str(project_dir),
                 "--dry-run",
             ],
         )
@@ -318,6 +399,67 @@ class TestAdvanced:
         assert result.exit_code == 0
         assert "minimal:" in result.stdout
         assert "strict:" in result.stdout
+
+
+class TestAdvancedAddRoute:
+    def test_adds_route(self, tmp_path: Path) -> None:
+        runner.invoke(app, ["api", "new", "my-api", "--destination", str(tmp_path)])
+        project_dir = tmp_path / "my-api"
+
+        result = runner.invoke(
+            app, ["advanced", "add-route", "status", "--project-root", str(project_dir)]
+        )
+        assert result.exit_code == 0
+        assert (project_dir / "app/functions/status.py").exists()
+        function_app_text = (project_dir / "function_app.py").read_text(encoding="utf-8")
+        assert "status_blueprint" in function_app_text
+
+    def test_dry_run(self, tmp_path: Path) -> None:
+        runner.invoke(app, ["api", "new", "my-api", "--destination", str(tmp_path)])
+        project_dir = tmp_path / "my-api"
+
+        result = runner.invoke(
+            app,
+            ["advanced", "add-route", "status", "--project-root", str(project_dir), "--dry-run"],
+        )
+        assert result.exit_code == 0
+        assert "Dry run:" in result.stdout
+        assert not (project_dir / "app/functions/status.py").exists()
+
+
+class TestAdvancedAddResource:
+    def test_adds_resource(self, tmp_path: Path) -> None:
+        runner.invoke(app, ["api", "new", "my-api", "--destination", str(tmp_path)])
+        project_dir = tmp_path / "my-api"
+
+        result = runner.invoke(
+            app, ["advanced", "add-resource", "products", "--project-root", str(project_dir)]
+        )
+        assert result.exit_code == 0
+        assert (project_dir / "app/functions/products.py").exists()
+        assert (project_dir / "app/services/products_service.py").exists()
+        assert (project_dir / "app/schemas/products.py").exists()
+        function_app_text = (project_dir / "function_app.py").read_text(encoding="utf-8")
+        assert "products_blueprint" in function_app_text
+
+    def test_dry_run(self, tmp_path: Path) -> None:
+        runner.invoke(app, ["api", "new", "my-api", "--destination", str(tmp_path)])
+        project_dir = tmp_path / "my-api"
+
+        result = runner.invoke(
+            app,
+            [
+                "advanced",
+                "add-resource",
+                "products",
+                "--project-root",
+                str(project_dir),
+                "--dry-run",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "Dry run:" in result.stdout
+        assert not (project_dir / "app/functions/products.py").exists()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -506,6 +506,27 @@ class TestDeriveResourceNames:
         assert result["resource_class"] == "User"
         assert result["store_class"] == "UsersStore"
 
+    def test_no_strip_status(self) -> None:
+        """Names in the no-strip list should keep their trailing 's'."""
+        result = _derive_resource_names("status")
+        assert result["resource_singular"] == "status"
+        assert result["resource_class"] == "Status"
+
+    def test_no_strip_news(self) -> None:
+        result = _derive_resource_names("news")
+        assert result["resource_singular"] == "news"
+        assert result["resource_class"] == "News"
+
+    def test_no_strip_address(self) -> None:
+        result = _derive_resource_names("address")
+        assert result["resource_singular"] == "address"
+        assert result["resource_class"] == "Address"
+
+    def test_no_strip_compound_with_status(self) -> None:
+        """Compound name whose last segment is in the no-strip list."""
+        result = _derive_resource_names("order_status")
+        assert result["resource_singular"] == "order_status"
+        assert result["resource_class"] == "OrderStatus"
 
 # ---------------------------------------------------------------------------
 # add_resource
@@ -541,6 +562,15 @@ def test_add_resource_blueprint_content_is_valid_python(tmp_path: Path) -> None:
     assert "from app.services.products_service import products_store" in blueprint_text
 
 
+def test_add_resource_blueprint_guards_non_dict_json(tmp_path: Path) -> None:
+    """Verify generated blueprint includes isinstance(body, dict) guard."""
+    project_root = scaffold_project("sample", tmp_path)
+    add_resource(project_root=project_root, resource_name="products")
+
+    blueprint_text = (project_root / "app/functions/products.py").read_text(encoding="utf-8")
+    assert "isinstance(body, dict)" in blueprint_text
+    assert "Request body must be a JSON object" in blueprint_text
+
 def test_add_resource_service_content_is_valid_python(tmp_path: Path) -> None:
     project_root = scaffold_project("sample", tmp_path)
     add_resource(project_root=project_root, resource_name="products")
@@ -560,6 +590,7 @@ def test_add_resource_schema_content_is_valid_python(tmp_path: Path) -> None:
     schema_text = (project_root / "app/schemas/products.py").read_text(encoding="utf-8")
     compile(schema_text, "products.py", "exec")
     assert "CreateProductRequest" in schema_text
+    assert "UpdateProductRequest" in schema_text
     assert "ProductResponse" in schema_text
 
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -7,12 +7,17 @@ import pytest
 
 from azure_functions_scaffold.errors import ScaffoldError
 from azure_functions_scaffold.generator import (
+    _derive_resource_names,
     _insert_near_marker,
     _render_function_module,
     _render_function_test,
     _update_function_app,
     add_function,
+    add_resource,
+    add_route,
     describe_add_function,
+    describe_add_resource,
+    describe_add_route,
 )
 from azure_functions_scaffold.scaffolder import scaffold_project
 from azure_functions_scaffold.template_registry import build_project_options
@@ -147,16 +152,17 @@ def test_add_timer_function(tmp_path: Path) -> None:
     # Verify files were created
     assert function_path == project_root / "app/functions/schedule_task.py"
     assert (project_root / "tests/test_schedule_task.py").exists()
-    
+
     # Verify function content contains timer-specific code
     func_content = function_path.read_text(encoding="utf-8")
     assert "schedule=" in func_content
     assert "past_due" in func_content
-    
+
     # Verify test content contains timer-specific code
     test_content = (project_root / "tests/test_schedule_task.py").read_text(encoding="utf-8")
     assert "SimpleNamespace" in test_content
     assert "past_due=False" in test_content
+
 
 @pytest.mark.parametrize("trigger", ["queue", "blob", "servicebus", "eventhub", "cosmosdb"])
 def test_add_function_adds_extension_bundle_for_binding_triggers(
@@ -191,6 +197,7 @@ def test_add_function_skips_extension_bundle_when_already_exists(tmp_path: Path)
 
     # Extension bundle should be the same
     assert host_config_2["extensionBundle"] == original_bundle
+
 
 def test_add_servicebus_function_updates_local_settings_example(tmp_path: Path) -> None:
     project_root = scaffold_project("sample", tmp_path)
@@ -229,19 +236,19 @@ def test_add_function_skips_test_file_when_already_exists(tmp_path: Path) -> Non
 
     # Add first function to create test infrastructure
     add_function(project_root=project_root, trigger="http", function_name="sync-data")
-    
+
     # Now delete the function module but keep the test file
     func_path = project_root / "app" / "functions" / "sync_data.py"
     test_path = project_root / "tests" / "test_sync_data.py"
     _original_test_content = test_path.read_text(encoding="utf-8")
-    
+
     # Modify the test file
     modified_content = "# This test file was manually modified"
     test_path.write_text(modified_content, encoding="utf-8")
-    
+
     # Delete the function module file
     func_path.unlink()
-    
+
     # Also need to remove the function from function_app.py to avoid registration conflict
     func_app_path = project_root / "function_app.py"
     content = func_app_path.read_text(encoding="utf-8")
@@ -249,13 +256,12 @@ def test_add_function_skips_test_file_when_already_exists(tmp_path: Path) -> Non
     content = content.replace("from app.functions.sync_data import sync_data_blueprint\n", "")
     content = content.replace("app.register_functions(sync_data_blueprint)\n", "")
     func_app_path.write_text(content, encoding="utf-8")
-    
+
     # Now add the function again - test file should NOT be overwritten
     add_function(project_root=project_root, trigger="http", function_name="sync-data")
-    
+
     # Verify test file was not overwritten (it should still have our modified content)
     assert test_path.read_text(encoding="utf-8") == modified_content
-
 
 
 def test_describe_add_function_rejects_existing_module(tmp_path: Path) -> None:
@@ -362,7 +368,6 @@ app.register_functions(sync_data_blueprint)
         )
 
 
-
 def test_insert_near_marker_raises_when_fallback_anchor_missing(tmp_path: Path) -> None:
     """Test that _insert_near_marker raises error when fallback anchor not found."""
     content = "some content without any anchor"
@@ -413,7 +418,6 @@ app.register_functions(my_blueprint)"""
     assert "app = FunctionApp()\nnew_line_here" in result
 
 
-
 def test_render_function_module_raises_for_unknown_trigger() -> None:
     """Test that _render_function_module raises error for unknown trigger."""
     with pytest.raises(ScaffoldError, match="No function module template for trigger"):
@@ -455,3 +459,383 @@ def test_add_function_skips_local_settings_when_example_missing(tmp_path: Path) 
 
     # Verify the function was still created
     assert (project_root / "app" / "functions" / "event_handler.py").exists()
+
+
+# ---------------------------------------------------------------------------
+# _derive_resource_names
+# ---------------------------------------------------------------------------
+
+
+class TestDeriveResourceNames:
+    def test_basic_plural_name(self) -> None:
+        result = _derive_resource_names("products")
+        assert result == {
+            "resource_name": "products",
+            "resource_singular": "product",
+            "resource_class": "Product",
+            "route_name": "products",
+            "store_class": "ProductsStore",
+        }
+
+    def test_underscore_name(self) -> None:
+        result = _derive_resource_names("line_items")
+        assert result == {
+            "resource_name": "line_items",
+            "resource_singular": "line_item",
+            "resource_class": "LineItem",
+            "route_name": "line-items",
+            "store_class": "LineItemsStore",
+        }
+
+    def test_short_name_not_stripped(self) -> None:
+        """Names with 3 or fewer characters should not have trailing 's' stripped."""
+        result = _derive_resource_names("bus")
+        assert result["resource_singular"] == "bus"
+        assert result["resource_class"] == "Bus"
+
+    def test_non_plural_name(self) -> None:
+        result = _derive_resource_names("health")
+        assert result["resource_singular"] == "health"
+        assert result["resource_class"] == "Health"
+        assert result["route_name"] == "health"
+        assert result["store_class"] == "HealthStore"
+
+    def test_single_word(self) -> None:
+        result = _derive_resource_names("users")
+        assert result["resource_singular"] == "user"
+        assert result["resource_class"] == "User"
+        assert result["store_class"] == "UsersStore"
+
+
+# ---------------------------------------------------------------------------
+# add_resource
+# ---------------------------------------------------------------------------
+
+
+def test_add_resource_creates_all_files(tmp_path: Path) -> None:
+    project_root = scaffold_project("sample", tmp_path)
+
+    created = add_resource(project_root=project_root, resource_name="products")
+
+    assert (project_root / "app/functions/products.py").exists()
+    assert (project_root / "app/services/products_service.py").exists()
+    assert (project_root / "app/schemas/products.py").exists()
+    assert (project_root / "tests/test_products.py").exists()
+    assert len(created) == 4
+
+
+def test_add_resource_blueprint_content_is_valid_python(tmp_path: Path) -> None:
+    project_root = scaffold_project("sample", tmp_path)
+    add_resource(project_root=project_root, resource_name="products")
+
+    blueprint_text = (project_root / "app/functions/products.py").read_text(encoding="utf-8")
+    # Verify it compiles (valid Python syntax)
+    compile(blueprint_text, "products.py", "exec")
+    # Verify key content
+    assert "products_blueprint" in blueprint_text
+    assert "list_products" in blueprint_text
+    assert "get_product" in blueprint_text
+    assert "create_product" in blueprint_text
+    assert "update_product" in blueprint_text
+    assert "delete_product" in blueprint_text
+    assert "from app.services.products_service import products_store" in blueprint_text
+
+
+def test_add_resource_service_content_is_valid_python(tmp_path: Path) -> None:
+    project_root = scaffold_project("sample", tmp_path)
+    add_resource(project_root=project_root, resource_name="products")
+
+    service_text = (project_root / "app/services/products_service.py").read_text(encoding="utf-8")
+    compile(service_text, "products_service.py", "exec")
+    assert "ProductsStore" in service_text
+    assert "products_store" in service_text
+    assert "def create" in service_text
+    assert "def delete" in service_text
+
+
+def test_add_resource_schema_content_is_valid_python(tmp_path: Path) -> None:
+    project_root = scaffold_project("sample", tmp_path)
+    add_resource(project_root=project_root, resource_name="products")
+
+    schema_text = (project_root / "app/schemas/products.py").read_text(encoding="utf-8")
+    compile(schema_text, "products.py", "exec")
+    assert "CreateProductRequest" in schema_text
+    assert "ProductResponse" in schema_text
+
+
+def test_add_resource_test_content_is_valid_python(tmp_path: Path) -> None:
+    project_root = scaffold_project("sample", tmp_path)
+    add_resource(project_root=project_root, resource_name="products")
+
+    test_text = (project_root / "tests/test_products.py").read_text(encoding="utf-8")
+    compile(test_text, "test_products.py", "exec")
+    assert "TestListProduct" in test_text
+    assert "TestCreateProduct" in test_text
+    assert "TestDeleteProduct" in test_text
+
+
+def test_add_resource_registers_blueprint(tmp_path: Path) -> None:
+    project_root = scaffold_project("sample", tmp_path)
+    add_resource(project_root=project_root, resource_name="products")
+
+    function_app_text = (project_root / "function_app.py").read_text(encoding="utf-8")
+    assert "from app.functions.products import products_blueprint" in function_app_text
+    assert "app.register_functions(products_blueprint)" in function_app_text
+
+
+def test_add_resource_rejects_existing_blueprint(tmp_path: Path) -> None:
+    project_root = scaffold_project("sample", tmp_path)
+    add_resource(project_root=project_root, resource_name="products")
+
+    with pytest.raises(ScaffoldError, match="File already exists"):
+        add_resource(project_root=project_root, resource_name="products")
+
+
+def test_add_resource_rejects_non_scaffold_project(tmp_path: Path) -> None:
+    project_root = tmp_path / "not-a-project"
+    project_root.mkdir()
+
+    with pytest.raises(
+        ScaffoldError,
+        match="does not look like a scaffolded Azure Functions project",
+    ):
+        add_resource(project_root=project_root, resource_name="products")
+
+
+def test_add_resource_rejects_missing_project_root(tmp_path: Path) -> None:
+    with pytest.raises(ScaffoldError, match="Project root does not exist"):
+        add_resource(project_root=tmp_path / "missing", resource_name="products")
+
+
+@pytest.mark.parametrize("resource_name", ["", "***", "123-sync"])
+def test_add_resource_rejects_invalid_names(tmp_path: Path, resource_name: str) -> None:
+    project_root = scaffold_project("sample", tmp_path)
+
+    with pytest.raises(ScaffoldError):
+        add_resource(project_root=project_root, resource_name=resource_name)
+
+
+def test_add_resource_skips_test_when_no_tests_dir(tmp_path: Path) -> None:
+    project_root = scaffold_project(
+        "sample",
+        tmp_path,
+        options=build_project_options(
+            preset_name="minimal",
+            python_version="3.10",
+            include_github_actions=False,
+            initialize_git=False,
+        ),
+    )
+
+    created = add_resource(project_root=project_root, resource_name="products")
+
+    # Blueprint + service + schema = 3 files, no test
+    assert len(created) == 3
+    assert not (project_root / "tests/test_products.py").exists()
+
+
+def test_add_resource_with_hyphenated_name(tmp_path: Path) -> None:
+    project_root = scaffold_project("sample", tmp_path)
+    add_resource(project_root=project_root, resource_name="line-items")
+
+    assert (project_root / "app/functions/line_items.py").exists()
+    assert (project_root / "app/services/line_items_service.py").exists()
+    assert (project_root / "app/schemas/line_items.py").exists()
+    blueprint_text = (project_root / "app/functions/line_items.py").read_text(encoding="utf-8")
+    assert "line_items_blueprint" in blueprint_text
+    assert "LineItem" in blueprint_text  # resource_class from singular
+
+
+def test_add_multiple_resources(tmp_path: Path) -> None:
+    project_root = scaffold_project("sample", tmp_path)
+    add_resource(project_root=project_root, resource_name="products")
+    add_resource(project_root=project_root, resource_name="orders")
+
+    function_app_text = (project_root / "function_app.py").read_text(encoding="utf-8")
+    assert "products_blueprint" in function_app_text
+    assert "orders_blueprint" in function_app_text
+
+
+# ---------------------------------------------------------------------------
+# describe_add_resource
+# ---------------------------------------------------------------------------
+
+
+def test_describe_add_resource_reports_expected_changes(tmp_path: Path) -> None:
+    project_root = scaffold_project("sample", tmp_path)
+
+    lines = describe_add_resource(project_root=project_root, resource_name="products")
+
+    assert lines[0] == "Dry run: add resource 'products'"
+    assert "  - app/functions/products.py" in lines
+    assert "  - app/services/products_service.py" in lines
+    assert "  - app/schemas/products.py" in lines
+    assert "  - tests/test_products.py" in lines
+    assert "  - function_app.py import registration" in lines
+
+
+def test_describe_add_resource_rejects_existing_files(tmp_path: Path) -> None:
+    project_root = scaffold_project("sample", tmp_path)
+    add_resource(project_root=project_root, resource_name="products")
+
+    with pytest.raises(ScaffoldError, match="File already exists"):
+        describe_add_resource(project_root=project_root, resource_name="products")
+
+
+def test_describe_add_resource_excludes_test_when_no_tests_dir(tmp_path: Path) -> None:
+    project_root = scaffold_project(
+        "sample",
+        tmp_path,
+        options=build_project_options(
+            preset_name="minimal",
+            python_version="3.10",
+            include_github_actions=False,
+            initialize_git=False,
+        ),
+    )
+
+    lines = describe_add_resource(project_root=project_root, resource_name="products")
+
+    assert not any("test_products.py" in line for line in lines)
+
+
+# ---------------------------------------------------------------------------
+# add_route
+# ---------------------------------------------------------------------------
+
+
+def test_add_route_creates_blueprint_and_test(tmp_path: Path) -> None:
+    project_root = scaffold_project("sample", tmp_path)
+
+    route_path = add_route(project_root=project_root, route_name="status")
+
+    assert route_path == project_root / "app/functions/status.py"
+    assert (project_root / "tests/test_status.py").exists()
+
+
+def test_add_route_blueprint_content_is_valid_python(tmp_path: Path) -> None:
+    project_root = scaffold_project("sample", tmp_path)
+    add_route(project_root=project_root, route_name="status")
+
+    blueprint_text = (project_root / "app/functions/status.py").read_text(encoding="utf-8")
+    compile(blueprint_text, "status.py", "exec")
+    assert "status_blueprint" in blueprint_text
+    assert 'route="status"' in blueprint_text
+    assert 'body="TODO: implement status"' in blueprint_text
+
+
+def test_add_route_test_content_is_valid_python(tmp_path: Path) -> None:
+    project_root = scaffold_project("sample", tmp_path)
+    add_route(project_root=project_root, route_name="status")
+
+    test_text = (project_root / "tests/test_status.py").read_text(encoding="utf-8")
+    compile(test_text, "test_status.py", "exec")
+    assert "test_status_returns_placeholder_response" in test_text
+
+
+def test_add_route_registers_blueprint(tmp_path: Path) -> None:
+    project_root = scaffold_project("sample", tmp_path)
+    add_route(project_root=project_root, route_name="status")
+
+    function_app_text = (project_root / "function_app.py").read_text(encoding="utf-8")
+    assert "from app.functions.status import status_blueprint" in function_app_text
+    assert "app.register_functions(status_blueprint)" in function_app_text
+
+
+def test_add_route_rejects_existing_module(tmp_path: Path) -> None:
+    project_root = scaffold_project("sample", tmp_path)
+    add_route(project_root=project_root, route_name="status")
+
+    with pytest.raises(ScaffoldError, match="Function module already exists"):
+        add_route(project_root=project_root, route_name="status")
+
+
+def test_add_route_rejects_non_scaffold_project(tmp_path: Path) -> None:
+    project_root = tmp_path / "not-a-project"
+    project_root.mkdir()
+
+    with pytest.raises(
+        ScaffoldError,
+        match="does not look like a scaffolded Azure Functions project",
+    ):
+        add_route(project_root=project_root, route_name="status")
+
+
+def test_add_route_with_hyphenated_name(tmp_path: Path) -> None:
+    project_root = scaffold_project("sample", tmp_path)
+    route_path = add_route(project_root=project_root, route_name="health-check")
+
+    assert route_path == project_root / "app/functions/health_check.py"
+    blueprint_text = (project_root / "app/functions/health_check.py").read_text(encoding="utf-8")
+    assert "health_check_blueprint" in blueprint_text
+    assert 'route="health-check"' in blueprint_text
+
+
+def test_add_route_skips_test_when_no_tests_dir(tmp_path: Path) -> None:
+    project_root = scaffold_project(
+        "sample",
+        tmp_path,
+        options=build_project_options(
+            preset_name="minimal",
+            python_version="3.10",
+            include_github_actions=False,
+            initialize_git=False,
+        ),
+    )
+
+    add_route(project_root=project_root, route_name="status")
+
+    assert (project_root / "app/functions/status.py").exists()
+    assert not (project_root / "tests/test_status.py").exists()
+
+
+def test_add_route_and_resource_coexist(tmp_path: Path) -> None:
+    """Verify a route and a resource can be added to the same project."""
+    project_root = scaffold_project("sample", tmp_path)
+    add_route(project_root=project_root, route_name="status")
+    add_resource(project_root=project_root, resource_name="products")
+
+    function_app_text = (project_root / "function_app.py").read_text(encoding="utf-8")
+    assert "status_blueprint" in function_app_text
+    assert "products_blueprint" in function_app_text
+
+
+# ---------------------------------------------------------------------------
+# describe_add_route
+# ---------------------------------------------------------------------------
+
+
+def test_describe_add_route_reports_expected_changes(tmp_path: Path) -> None:
+    project_root = scaffold_project("sample", tmp_path)
+
+    lines = describe_add_route(project_root=project_root, route_name="status")
+
+    assert lines[0] == "Dry run: add route 'status'"
+    assert "  - app/functions/status.py" in lines
+    assert "  - tests/test_status.py" in lines
+    assert "  - function_app.py import registration" in lines
+
+
+def test_describe_add_route_rejects_existing_module(tmp_path: Path) -> None:
+    project_root = scaffold_project("sample", tmp_path)
+    add_route(project_root=project_root, route_name="status")
+
+    with pytest.raises(ScaffoldError, match="Function module already exists"):
+        describe_add_route(project_root=project_root, route_name="status")
+
+
+def test_describe_add_route_excludes_test_when_no_tests_dir(tmp_path: Path) -> None:
+    project_root = scaffold_project(
+        "sample",
+        tmp_path,
+        options=build_project_options(
+            preset_name="minimal",
+            python_version="3.10",
+            include_github_actions=False,
+            initialize_git=False,
+        ),
+    )
+
+    lines = describe_add_route(project_root=project_root, route_name="status")
+
+    assert not any("test_status.py" in line for line in lines)

--- a/tests/test_scaffolder.py
+++ b/tests/test_scaffolder.py
@@ -558,7 +558,6 @@ def test_describe_scaffold_project_excludes_azd_when_disabled(tmp_path: Path) ->
     assert "  - azure.yaml" not in lines
 
 
-
 def test_scaffold_project_renders_langgraph_template(tmp_path: Path) -> None:
     project_path = scaffold_project(
         "agent-sample",


### PR DESCRIPTION
## Summary

Adds `afs api add-route` and `afs api add-resource` commands (plus `afs advanced` equivalents) for expanding scaffolded projects with new endpoints and full CRUD resources.

- `add_resource()` creates 4 files using Jinja partials: CRUD blueprint, service, schema, and test
- `add_route()` creates 2 files: simple GET route blueprint and test
- Both register blueprints in `function_app.py` via existing marker injection
- 6 new Jinja partial templates under `templates/partials/`
- 216 tests pass, 97.45% coverage

Closes #53