### PR TITLE
feat: add top-level afs new alias and README front door redesign

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Starting a new Azure Functions project means setting up boilerplate: `host.json`
 ```mermaid
 flowchart LR
     Dev(["Developer"])
-    CLI["afs api new my-api"]
+    CLI["afs new my-api"]
     T["Templates"]
     P["Generated Project"]
     VAL["azure-functions-validation"]
@@ -52,11 +52,12 @@ This package does not own:
 
 ## Features
 
+- Top-level shortcut: `afs new` creates an API project with production defaults
 - Intent-based command groups: `afs api`, `afs worker`, `afs ai`, and `afs advanced`
-- API project commands: `afs api new` and `afs api add`
+- API project commands: `afs api new`, `afs api add`, `afs api add-route`, and `afs api add-resource`
 - Worker project commands: `afs worker timer|queue|blob|servicebus|eventhub`
 - AI project command: `afs ai agent` for LangGraph scaffolds
-- Advanced power-user commands: `afs advanced new` and `afs advanced add`
+- Advanced power-user commands: `afs advanced new`, `afs advanced add`, `afs advanced add-route`, and `afs advanced add-resource`
 - Optional feature flags (`--with-openapi`, `--with-validation`, `--with-doctor`) and `--preset minimal|standard|strict` available via `afs advanced new`
 - Discovery commands: `afs templates` and `afs presets`
 - Short alias: `afs` is the primary CLI entry point for `azure-functions-scaffold`
@@ -77,7 +78,7 @@ Use this 4-step flow to create and run a local HTTP function:
 4. Start the local Functions runtime.
 
 ```bash
-afs api new my-api
+afs new my-api
 cd my-api
 pip install -e .
 func start
@@ -137,7 +138,7 @@ Why this layout works:
 
 | Template | Command | Use Case |
 | --- | --- | --- |
-| http | `afs api new my-api` | REST APIs, webhooks |
+| http | `afs new my-api` | REST APIs, webhooks |
 | timer | `afs worker timer my-job` | Scheduled tasks, cron |
 | queue | `afs worker queue my-worker` | Message processing (Azurite) |
 | blob | `afs worker blob my-blob` | File processing (Azurite) |
@@ -158,7 +159,7 @@ Template defaults:
 
 Intent commands pre-select optional features based on project intent:
 
-- `afs api new <name>` includes OpenAPI, validation, and doctor integration
+- `afs api new <name>` (or `afs new <name>`) includes OpenAPI, validation, and doctor integration
 - `afs worker <trigger> <name>` and `afs ai agent <name>` apply trigger-specific defaults
 
 Use `afs advanced new <name>` when you need direct control over feature flags:
@@ -168,12 +169,36 @@ Use `afs advanced new <name>` when you need direct control over feature flags:
 - `--with-doctor` - Health check diagnostics
 - `--with-db` - Database bindings (SQLAlchemy) *(planned — currently not wired)*
 - `--preset minimal|standard|strict` - Tooling level
+
 ## Expand Your Project
 
-Add functions to an existing scaffolded project:
+### Add a route
+
+Add a lightweight HTTP endpoint (blueprint + test):
+
+```bash
+afs api add-route status --project-root ./my-api
+```
+
+### Add a resource
+
+Add a full CRUD resource with blueprint, service, schema, and test:
+
+```bash
+afs api add-resource products --project-root ./my-api
+```
+
+### Add a function
+
+Add a single HTTP function module:
 
 ```bash
 afs api add get-user --project-root ./my-api
+```
+
+### Add non-HTTP triggers
+
+```bash
 afs advanced add timer cleanup --project-root ./my-api
 afs advanced add queue sync-jobs --project-root ./my-api
 afs advanced add blob ingest-reports --project-root ./my-api
@@ -183,15 +208,16 @@ afs advanced add servicebus process-events --project-root ./my-api
 Preview additions before writing files:
 
 ```bash
-afs advanced add servicebus process-events --project-root ./my-api --dry-run
+afs api add-resource products --project-root ./my-api --dry-run
 ```
 
 Common expansion flow:
 
-1. Add API endpoints with `afs api add <name>` or non-HTTP triggers with `afs advanced add <trigger> <name>`.
-2. Implement business logic under `app/services`.
-3. Update contracts in `app/schemas` if needed.
-4. Add or update tests in `tests`.
+1. Add API endpoints with `afs api add-route <name>` for simple routes or `afs api add-resource <name>` for full CRUD.
+2. Add non-HTTP triggers with `afs advanced add <trigger> <name>`.
+3. Implement business logic under `app/services`.
+4. Update contracts in `app/schemas` if needed.
+5. Add or update tests in `tests`.
 
 ## Deploy
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -37,8 +37,22 @@ Root options:
 - `-h`, `--help` — Show help
 
 Top-level utility commands:
+- `afs new <project_name>` — **Shortcut** to create an API project (delegates to `afs api new`)
 - `afs templates` — List available scaffold templates
 - `afs presets` — List available project presets
+
+#### `afs new <project_name>` (top-level shortcut)
+
+Create an HTTP API project with production defaults. This is a shortcut for `afs api new`.
+
+```bash
+afs new <project_name> [OPTIONS]
+```
+
+Arguments:
+- `project_name` (required) — Directory name for the new project
+
+Options: Same as `afs api new` (see below).
 
 ### Subcommand Group: `api`
 
@@ -68,7 +82,6 @@ Options:
 - `--overwrite` (default: `False`)
 
 #### `afs api add <function_name>`
-#### `afs api add <function_name>`
 
 Add an HTTP function module to an existing scaffolded project.
 
@@ -83,6 +96,35 @@ Options:
 - `--project-root PATH` (default: `.`)
 - `--dry-run` (default: `False`)
 
+#### `afs api add-route <route_name>`
+
+Add a simple HTTP route (blueprint + test) to an existing scaffolded project.
+
+```bash
+afs api add-route <route_name> [OPTIONS]
+```
+
+Arguments:
+- `route_name` (required) — Route name to add
+
+Options:
+- `--project-root PATH` (default: `.`)
+- `--dry-run` (default: `False`)
+
+#### `afs api add-resource <resource_name>`
+
+Add a full CRUD resource (blueprint, service, schema, test) to an existing scaffolded project.
+
+```bash
+afs api add-resource <resource_name> [OPTIONS]
+```
+
+Arguments:
+- `resource_name` (required) — Resource name to add (e.g. products)
+
+Options:
+- `--project-root PATH` (default: `.`)
+- `--dry-run` (default: `False`)
 ### Subcommand Group: `worker`
 
 Purpose: intent-based worker scaffolding for non-HTTP triggers.
@@ -200,26 +242,48 @@ Alias command under advanced group to list presets.
 afs advanced presets
 ```
 
+#### `afs advanced add-route <route_name>`
+
+Add a simple HTTP route to an existing scaffolded project (advanced group).
+
+```bash
+afs advanced add-route <route_name> [OPTIONS]
+```
+
+Arguments:
+- `route_name` (required) — Route name to add
+
+Options:
+- `--project-root PATH` (default: `.`)
+- `--dry-run` (default: `False`)
+
+#### `afs advanced add-resource <resource_name>`
+
+Add a full CRUD resource (blueprint, service, schema, test) to an existing scaffolded project (advanced group).
+
+```bash
+afs advanced add-resource <resource_name> [OPTIONS]
+```
+
+Arguments:
+- `resource_name` (required) — Resource name to add (e.g. products)
+
+Options:
+- `--project-root PATH` (default: `.`)
+- `--dry-run` (default: `False`)
+
 ## Common Workflows
 
 ### Workflow 1: API project with strict defaults
 
 ```bash
-afs api new my-api
+afs new my-api
 cd my-api
 pip install -e .
 func start
 ```
 
-This intent command replaces the old explicit flag-heavy pattern:
-
-```bash
-# before (manual feature composition)
-afs advanced new my-api --preset strict --with-openapi --with-validation
-
-# now (intent auto-selects features)
-afs api new my-api
-```
+The top-level `afs new` is the fastest way to start. Equivalent to `afs api new`.
 
 ### Workflow 2: Worker project by trigger intent
 ### Workflow 3: Worker project by trigger intent
@@ -236,18 +300,25 @@ Use trigger-specific worker intents instead of manually selecting templates.
 
 ```bash
 cd my-api
+# Add a simple route
+afs api add-route status
+# Add a full CRUD resource
+afs api add-resource products
+# Add HTTP function
 afs api add get_orders
+# Add non-HTTP triggers
 afs advanced add queue sync_jobs
 afs advanced add servicebus process_events
 ```
 
-Use `api add` for HTTP endpoints and `advanced add` for any trigger type.
+Use `api add-route` for simple endpoints, `api add-resource` for full CRUD, and `advanced add` for non-HTTP triggers.
 
 ### Workflow 5: Dry run preview
 
 ```bash
-afs api new my-api --dry-run
+afs new my-api --dry-run
 afs advanced new my-custom --template durable --dry-run
+afs api add-resource products --project-root ./my-api --dry-run
 afs advanced add blob ingest_reports --project-root ./my-api --dry-run
 ```
 
@@ -334,9 +405,11 @@ Copy to `local.settings.json` and adjust connection values for local development
 ## Tips for LLM Integration
 
 - This package is a CLI-first scaffold generator
+- Use `afs new my-api` as the fastest way to create a project
 - Prefer intent commands (`api`, `worker`, `ai`) for default best-practice setups
 - Use `advanced` commands only when direct template/feature control is required
 - Use `--dry-run` to inspect planned file operations before writing
-- `afs api new my-api` already includes strict API defaults; do not add manual strict/OpenAPI/validation flags unless you intentionally switch to `afs advanced new`
+- `afs new my-api` (or `afs api new my-api`) already includes strict API defaults; do not add manual strict/OpenAPI/validation flags unless you intentionally switch to `afs advanced new`
+- Use `afs api add-route` for lightweight endpoints and `afs api add-resource` for full CRUD expansion
 - Generated projects keep business logic in `app/services` and trigger bindings in `app/functions`
 - Project configuration is centered in `pyproject.toml` and `host.json`

--- a/llms.txt
+++ b/llms.txt
@@ -26,8 +26,11 @@ afs [GROUP] [COMMAND] [OPTIONS]                    # Short alias
 
 ### Main Commands
 
+- `afs new <name>` — **Top-level shortcut** for `afs api new` (creates HTTP API project with strict preset, OpenAPI, validation, and doctor)
 - `afs api new <name>` — Create HTTP API project with strict preset, OpenAPI, validation, and doctor
 - `afs api add <name>` — Add HTTP function to an existing project
+- `afs api add-route <name>` — Add a simple HTTP route (blueprint + test)
+- `afs api add-resource <name>` — Add a full CRUD resource (blueprint, service, schema, test)
 - `afs worker timer <name>` — Create timer-trigger worker project
 - `afs worker queue <name>` — Create queue-trigger worker project
 - `afs worker blob <name>` — Create blob-trigger worker project
@@ -36,9 +39,10 @@ afs [GROUP] [COMMAND] [OPTIONS]                    # Short alias
 - `afs ai agent <name>` — Create LangGraph AI agent project
 - `afs advanced new <name>` — Power-user mode with direct flag control
 - `afs advanced add <trigger> <name>` — Add any trigger function to an existing project
+- `afs advanced add-route <name>` — Add a simple HTTP route (advanced group)
+- `afs advanced add-resource <name>` — Add a full CRUD resource (advanced group)
 - `afs templates` — List available templates
 - `afs presets` — List available presets
-
 ### Common options (project creation commands)
 
 - `--destination`, `-d` — Base directory where project folder is created
@@ -67,7 +71,7 @@ afs [GROUP] [COMMAND] [OPTIONS]                    # Short alias
 
 | Template | Command | Use Case |
 | --- | --- | --- |
-| http | `afs api new my-api` | REST APIs, webhooks |
+| http | `afs new my-api` | REST APIs, webhooks |
 | timer | `afs worker timer my-job` | Scheduled tasks, cron |
 | queue | `afs worker queue my-worker` | Message processing (Azurite) |
 | blob | `afs worker blob my-blob` | File processing (Azurite) |
@@ -90,7 +94,7 @@ Presets combine tooling levels and best practices:
 pip install azure-functions-scaffold
 
 # Step 2: Create project
-afs api new my-api
+afs new my-api
 
 # Step 3: Install dependencies
 cd my-api
@@ -106,7 +110,7 @@ func start
 
 Intent commands auto-select features based on project goal:
 
-- `afs api new <name>` automatically enables OpenAPI, validation, and doctor
+- `afs new <name>` (or `afs api new <name>`) automatically enables OpenAPI, validation, and doctor
 - `afs worker <trigger> <name>` and `afs ai agent <name>` apply trigger-specific defaults
 
 Use `afs advanced new <name>` for explicit feature control:

--- a/src/azure_functions_scaffold/cli.py
+++ b/src/azure_functions_scaffold/cli.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Annotated
 
 import typer
@@ -8,6 +9,16 @@ from azure_functions_scaffold import __version__
 from azure_functions_scaffold.cli_advanced import advanced_app
 from azure_functions_scaffold.cli_ai import ai_app
 from azure_functions_scaffold.cli_api import api_app
+from azure_functions_scaffold.cli_common import (
+    AzdOption,
+    DestinationOption,
+    DryRunOption,
+    GithubActionsOption,
+    GitOption,
+    OverwriteOption,
+    PythonVersionOption,
+    run_intent,
+)
 from azure_functions_scaffold.cli_worker import worker_app
 from azure_functions_scaffold.template_registry import list_presets, list_templates
 
@@ -56,6 +67,31 @@ def show_presets() -> None:
     for preset in list_presets():
         tooling = ", ".join(preset.tooling) or "none"
         typer.echo(f"{preset.name}: {preset.description} [tooling: {tooling}]")
+
+
+@app.command("new")
+def new(
+    project_name: str = typer.Argument(..., help="Directory name for the new project."),
+    destination: DestinationOption = Path("."),
+    python_version: PythonVersionOption = "3.10",
+    include_github_actions: GithubActionsOption = False,
+    initialize_git: GitOption = False,
+    include_azd: AzdOption = False,
+    dry_run: DryRunOption = False,
+    overwrite: OverwriteOption = False,
+) -> None:
+    """Create a new API project (shortcut for 'afs api new')."""
+    run_intent(
+        "api/new",
+        project_name,
+        destination=destination,
+        python_version=python_version,
+        include_github_actions=include_github_actions,
+        initialize_git=initialize_git,
+        include_azd=include_azd,
+        dry_run=dry_run,
+        overwrite=overwrite,
+    )
 
 
 def main() -> None:

--- a/tests/test_cli_intents.py
+++ b/tests/test_cli_intents.py
@@ -94,6 +94,98 @@ class TestApiNew:
 
 
 # ---------------------------------------------------------------------------
+# afs new (top-level alias for afs api new)
+# ---------------------------------------------------------------------------
+
+
+class TestNew:
+    """Tests for `afs new` — the top-level shortcut for `afs api new`."""
+
+    def test_creates_api_project(self, tmp_path: Path) -> None:
+        result = runner.invoke(app, ["new", "my-api", "--destination", str(tmp_path)])
+
+        assert result.exit_code == 0
+
+        project_dir = tmp_path / "my-api"
+        assert project_dir.exists()
+        pyproject_text = (project_dir / "pyproject.toml").read_text(encoding="utf-8")
+        function_app_text = (project_dir / "function_app.py").read_text(encoding="utf-8")
+        # Same defaults as afs api new: strict + openapi + validation + doctor
+        assert "azure-functions-openapi>=0.17.0" in pyproject_text
+        assert "azure-functions-validation>=0.7.0" in pyproject_text
+        assert "azure-functions-doctor>=0.16.0" in pyproject_text
+        assert "mypy>=1.17.1" in pyproject_text  # strict preset
+        assert (project_dir / "app/functions/health.py").exists()
+        assert (project_dir / "app/functions/users.py").exists()
+        assert "health_blueprint" in function_app_text
+        assert "users_blueprint" in function_app_text
+
+    def test_dry_run(self, tmp_path: Path) -> None:
+        result = runner.invoke(
+            app, ["new", "dry-api", "--destination", str(tmp_path), "--dry-run"]
+        )
+        assert result.exit_code == 0
+        assert "Dry run: create project at" in result.stdout
+        assert not (tmp_path / "dry-api").exists()
+
+    def test_overwrite(self, tmp_path: Path) -> None:
+        project_dir = tmp_path / "my-api"
+        project_dir.mkdir()
+        (project_dir / "stale.txt").write_text("stale", encoding="utf-8")
+
+        result = runner.invoke(
+            app, ["new", "my-api", "--destination", str(tmp_path), "--overwrite"]
+        )
+        assert result.exit_code == 0
+        assert not (project_dir / "stale.txt").exists()
+        assert (project_dir / "function_app.py").exists()
+
+    def test_with_azd_flag(self, tmp_path: Path) -> None:
+        result = runner.invoke(
+            app, ["new", "azd-api", "--destination", str(tmp_path), "--azd"]
+        )
+        assert result.exit_code == 0
+        assert (tmp_path / "azd-api" / "azure.yaml").exists()
+
+    def test_custom_python_version(self, tmp_path: Path) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "new",
+                "py312-api",
+                "--destination",
+                str(tmp_path),
+                "--python-version",
+                "3.12",
+            ],
+        )
+        assert result.exit_code == 0
+        pyproject_text = (tmp_path / "py312-api" / "pyproject.toml").read_text(encoding="utf-8")
+        assert 'requires-python = ">=3.12,<3.13"' in pyproject_text
+
+    def test_produces_same_output_as_api_new(self, tmp_path: Path) -> None:
+        """Verify `afs new` and `afs api new` generate identical project structures."""
+        api_dir = tmp_path / "via-api"
+        new_dir = tmp_path / "via-new"
+        api_dir.mkdir()
+        new_dir.mkdir()
+
+        runner.invoke(app, ["api", "new", "proj", "--destination", str(api_dir)])
+        runner.invoke(app, ["new", "proj", "--destination", str(new_dir)])
+
+        api_files = sorted(
+            str(p.relative_to(api_dir / "proj"))
+            for p in (api_dir / "proj").rglob("*")
+            if p.is_file()
+        )
+        new_files = sorted(
+            str(p.relative_to(new_dir / "proj"))
+            for p in (new_dir / "proj").rglob("*")
+            if p.is_file()
+        )
+        assert api_files == new_files
+
+# ---------------------------------------------------------------------------
 # afs api add
 # ---------------------------------------------------------------------------
 
@@ -468,11 +560,6 @@ class TestAdvancedAddResource:
 
 
 class TestLegacyRemoved:
-    def test_legacy_new_command_not_available(self) -> None:
-        result = runner.invoke(app, ["new", "my-api"])
-        assert result.exit_code != 0
-        assert "No such command" in result.stdout or "No such command" in (result.stderr or "")
-
     def test_legacy_add_command_not_available(self) -> None:
         result = runner.invoke(app, ["add", "http", "get-user"])
         assert result.exit_code != 0

--- a/tests/test_cli_intents.py
+++ b/tests/test_cli_intents.py
@@ -170,8 +170,11 @@ class TestNew:
         api_dir.mkdir()
         new_dir.mkdir()
 
-        runner.invoke(app, ["api", "new", "proj", "--destination", str(api_dir)])
-        runner.invoke(app, ["new", "proj", "--destination", str(new_dir)])
+        result_api = runner.invoke(app, ["api", "new", "proj", "--destination", str(api_dir)])
+        result_new = runner.invoke(app, ["new", "proj", "--destination", str(new_dir)])
+
+        assert result_api.exit_code == 0, result_api.stdout
+        assert result_new.exit_code == 0, result_new.stdout
 
         api_files = sorted(
             str(p.relative_to(api_dir / "proj"))


### PR DESCRIPTION
## Summary

Add `afs new <name>` as a top-level shortcut for `afs api new` and redesign the README front door to lead with the product promise.

**PR 3.3 of 3** for Phase 3 — Generated Output Redesign.

## Changes

### CLI (`cli.py`)
- Add `@app.command("new")` top-level command that delegates to `run_intent("api/new")` with identical options to `afs api new`

### README
- `afs new my-api` is now the primary command in Quick Start, mermaid diagram, and templates table
- New "Expand Your Project" section documents `add-route`, `add-resource`, `add`, and non-HTTP trigger expansion
- Features list updated to include `afs new`, `add-route`, `add-resource`

### LLM Reference (`llms.txt`, `llms-full.txt`)
- Added `afs new` as top-level shortcut in main commands
- Added `afs api add-route`, `afs api add-resource`
- Added `afs advanced add-route`, `afs advanced add-resource`
- Updated workflows and tips sections

### Tests
- 6 new tests for `afs new`: create, dry-run, overwrite, azd flag, custom python version, parity with `afs api new`
- Removed legacy `test_legacy_new_command_not_available` (now a real command)
- All 233 tests pass, lint clean, typecheck clean, 97% coverage

## Verification

```
make test     → 233 passed, 3 skipped
make lint     → no issues
make typecheck → no issues
```

Closes #54