### PR TITLE
feat: add structured logging and fix Oracle-identified bugs

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -63,7 +63,7 @@ func start
 期待されるレスポンス:
 
 ```json
-{"status": "healthy"}
+{"status": "ok"}
 ```
 
 プロジェクト名は英数字で始める必要があり、使用できるのは文字、数字、
@@ -133,7 +133,7 @@ my-api/
 - `--with-openapi` - Swagger UI + OpenAPI 仕様エンドポイント
 - `--with-validation` - Pydantic リクエスト/レスポンス検証
 - `--with-doctor` - ヘルスチェック診断
-- `--with-db` - データベースバインディング (SQLAlchemy) *(計画 — 現在未対応)*
+- `--with-db` - データベースバインディング (SQLAlchemy) *(計画 — CLIでは未対応)*
 - `--preset minimal|standard|strict` - ツーリングレベル
 
 意図中心コマンドは一般的な機能構成を事前選択します。フラグを直接制御したい場合は `afs advanced new <name>` を使用してください。

--- a/README.ko.md
+++ b/README.ko.md
@@ -63,7 +63,7 @@ func start
 예상 응답:
 
 ```json
-{"status": "healthy"}
+{"status": "ok"}
 ```
 
 프로젝트 이름은 영문자 또는 숫자로 시작해야 하며 문자, 숫자,
@@ -133,7 +133,7 @@ my-api/
 - `--with-openapi` - Swagger UI + OpenAPI 사양 엔드포인트
 - `--with-validation` - Pydantic 요청/응답 검증
 - `--with-doctor` - 상태 확인 진단
-- `--with-db` - 데이터베이스 바인딩 (SQLAlchemy) *(계획 — 현재 미연결)*
+- `--with-db` - 데이터베이스 바인딩 (SQLAlchemy) *(계획 — CLI에서 아직 사용 불가)*
 - `--preset minimal|standard|strict` - 도구 구성 수준
 
 의도 중심 명령은 일반적인 기능 조합을 미리 선택합니다. 세부 플래그를 직접 제어하려면 `afs advanced new <name>`을 사용하세요.

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Open `http://localhost:7071/api/health` in your browser.
 Expected response:
 
 ```json
-{"status": "healthy"}
+{"status": "ok"}
 ```
 
 Project names must start with an alphanumeric character and use only letters,
@@ -167,7 +167,7 @@ Use `afs advanced new <name>` when you need direct control over feature flags:
 - `--with-openapi` - Swagger UI + OpenAPI spec endpoints
 - `--with-validation` - Pydantic request/response validation
 - `--with-doctor` - Health check diagnostics
-- `--with-db` - Database bindings (SQLAlchemy) *(planned — currently not wired)*
+- `--with-db` - Database bindings (SQLAlchemy) *(planned — not yet available in CLI)*
 - `--preset minimal|standard|strict` - Tooling level
 
 ## Expand Your Project

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -63,7 +63,7 @@ func start
 预期响应:
 
 ```json
-{"status": "healthy"}
+{"status": "ok"}
 ```
 
 项目名称必须以字母或数字开头，并且只能使用字母、数字、
@@ -133,7 +133,7 @@ my-api/
 - `--with-openapi` - Swagger UI + OpenAPI 规范端点
 - `--with-validation` - Pydantic 请求/响应校验
 - `--with-doctor` - 健康检查诊断
-- `--with-db` - 数据库绑定 (SQLAlchemy) *(计划中 — 当前未启用)*
+- `--with-db` - 数据库绑定 (SQLAlchemy) *(计划中 — CLI中尚未可用)*
 - `--preset minimal|standard|strict` - 工具配置等级
 
 意图驱动命令会预先选择常见功能组合。如果需要直接控制参数，请使用 `afs advanced new <name>`。

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -202,7 +202,7 @@ Options (full set):
 - `--with-openapi/--no-openapi` (default: `--no-openapi`)
 - `--with-validation/--no-validation` (default: `--no-validation`)
 - `--with-doctor/--no-doctor` (default: `--no-doctor`)
-- `--with-db/--no-db` (default: `--no-db`) *(planned)*
+- `--with-db/--no-db` (default: `--no-db`) *(planned — not yet available in CLI)*
 - `--azd/--no-azd` (default: `--no-azd`)
 - `--dry-run` (default: `False`)
 - `--overwrite` (default: `False`)

--- a/llms.txt
+++ b/llms.txt
@@ -60,7 +60,7 @@ afs [GROUP] [COMMAND] [OPTIONS]                    # Short alias
 - `--with-openapi/--no-openapi` — Include OpenAPI support (HTTP template)
 - `--with-validation/--no-validation` — Include request validation support (HTTP template)
 - `--with-doctor/--no-doctor` — Include `azure-functions-doctor`
-- `--with-db/--no-db` — Include `azure-functions-db` bindings *(planned)*
+- `--with-db/--no-db` — Include `azure-functions-db` bindings *(planned — not yet available in CLI)*
 
 ### Global options
 
@@ -118,7 +118,7 @@ Use `afs advanced new <name>` for explicit feature control:
 - `--with-openapi` — Swagger UI + OpenAPI spec endpoints
 - `--with-validation` — Pydantic request/response validation
 - `--with-doctor` — azure-functions-doctor health checks
-- `--with-db` — Database bindings *(planned)*
+- `--with-db` — Database bindings *(planned — not yet available in CLI)*
 
 ## Generated Project Layout
 

--- a/src/azure_functions_scaffold/cli_common.py
+++ b/src/azure_functions_scaffold/cli_common.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Annotated
 
@@ -11,6 +12,8 @@ from azure_functions_scaffold.errors import ScaffoldError
 from azure_functions_scaffold.models import ProjectOptions
 from azure_functions_scaffold.scaffolder import describe_scaffold_project, scaffold_project
 from azure_functions_scaffold.template_registry import INTENT_SPECS, build_project_options
+
+logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
 # Reusable Typer option types
@@ -97,6 +100,12 @@ def run_intent(
         spec = INTENT_SPECS.get(intent_key)
         if spec is None:
             raise ScaffoldError(f"Unknown intent '{intent_key}'.")
+        logger.debug(
+            "Resolving intent '%s' with preset=%s, features=%s",
+            intent_key,
+            spec.preset,
+            spec.features,
+        )
 
         options = build_project_options(
             preset_name=spec.preset,
@@ -132,6 +141,12 @@ def run_scaffold(
     overwrite: bool = False,
 ) -> None:
     """Execute scaffold_project (or describe if dry_run) with unified error handling."""
+    logger.debug(
+        "Running scaffold: project=%s, template=%s, dry_run=%s",
+        project_name,
+        template_name,
+        dry_run,
+    )
 
     try:
         if dry_run:

--- a/src/azure_functions_scaffold/generator.py
+++ b/src/azure_functions_scaffold/generator.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 import re
 
@@ -13,7 +14,44 @@ FUNCTION_IMPORT_MARKER = "# azure-functions-scaffold: function imports"
 FUNCTION_REGISTRATION_MARKER = "# azure-functions-scaffold: function registrations"
 SUPPORTED_TRIGGERS = tuple(template.name for template in list_templates())
 PARTIALS_ROOT = Path(__file__).parent / "templates" / "partials"
+logger = logging.getLogger(__name__)
 
+
+def _validate_function_app_updatable(
+    function_app_path: Path,
+    *,
+    import_stmt: str,
+    registration_stmt: str,
+) -> None:
+    """Pre-validate that function_app.py can be updated before writing files.
+
+    Raises ScaffoldError if markers/anchors are missing or the function is
+    already registered.  This must be called **before** creating any files so
+    that a failure never leaves the project in a half-applied state.
+    """
+    content = function_app_path.read_text(encoding="utf-8")
+
+    if import_stmt in content or registration_stmt in content:
+        raise ScaffoldError("Function is already registered in function_app.py.")
+
+    has_import_target = (
+        FUNCTION_IMPORT_MARKER in content or "configure_logging()" in content
+    )
+    has_registration_target = (
+        FUNCTION_REGISTRATION_MARKER in content
+        or "app = func.FunctionApp()" in content
+    )
+
+    if not has_import_target:
+        raise ScaffoldError(
+            "Cannot update function_app.py: neither the import marker nor "
+            "'configure_logging()' was found."
+        )
+    if not has_registration_target:
+        raise ScaffoldError(
+            "Cannot update function_app.py: neither the registration marker nor "
+            "'app = func.FunctionApp()' was found."
+        )
 
 def add_function(
     *,
@@ -21,6 +59,7 @@ def add_function(
     trigger: str,
     function_name: str,
 ) -> Path:
+    logger.info("Adding %s function '%s' to %s", trigger, function_name, project_root)
     normalized_trigger = _normalize_trigger(trigger)
     normalized_name = _normalize_function_name(function_name)
 
@@ -30,11 +69,18 @@ def add_function(
     if function_path.exists():
         raise ScaffoldError(f"Function module already exists: {function_path}")
 
+    _validate_function_app_updatable(
+        project_root / "function_app.py",
+        import_stmt=f"from app.functions.{normalized_name} import {normalized_name}_blueprint",
+        registration_stmt=f"app.register_functions({normalized_name}_blueprint)",
+    )
+
     function_path.parent.mkdir(parents=True, exist_ok=True)
     function_path.write_text(
         _render_function_module(normalized_trigger, normalized_name),
         encoding="utf-8",
     )
+    logger.debug("Created function module: %s", function_path)
 
     if (project_root / "tests").is_dir():
         test_path = project_root / "tests" / f"test_{normalized_name}.py"
@@ -43,6 +89,7 @@ def add_function(
                 _render_function_test(normalized_trigger, normalized_name),
                 encoding="utf-8",
             )
+            logger.debug("Created test: %s", test_path)
 
     _update_function_app(
         project_root / "function_app.py",
@@ -143,6 +190,7 @@ def _update_function_app(
     import_stmt: str,
     registration_stmt: str,
 ) -> None:
+    logger.debug("Updating function_app.py: %s", import_stmt)
     content = function_app_path.read_text(encoding="utf-8")
 
     if import_stmt in content or registration_stmt in content:
@@ -589,6 +637,7 @@ def _ensure_host_extensions(host_json_path: Path, trigger: str) -> None:
         "id": "Microsoft.Azure.Functions.ExtensionBundle",
         "version": "[4.*, 5.0.0)",
     }
+    logger.debug("Adding extensionBundle to host.json")
     host_json_path.write_text(f"{json.dumps(host_config, indent=2)}\n", encoding="utf-8")
 
 
@@ -619,6 +668,7 @@ def _ensure_local_settings_values(project_root: Path, trigger: str) -> None:
     values = local_settings.setdefault("Values", {})
     key, default = connection_keys[trigger]
     values.setdefault(key, default)
+    logger.debug("Adding %s to local.settings.json.example", key)
     local_settings_path.write_text(
         f"{json.dumps(local_settings, indent=2)}\n",
         encoding="utf-8",
@@ -659,17 +709,20 @@ def _derive_resource_names(resource_name: str) -> dict[str, str]:
     store_class = "".join(part.capitalize() for part in resource_name.split("_")) + "Store"
     route_name = resource_name.replace("_", "-")
 
-    return {
+    result = {
         "resource_name": resource_name,
         "resource_singular": singular,
         "resource_class": class_name,
         "route_name": route_name,
         "store_class": store_class,
     }
+    logger.debug("Derived resource names for '%s': %s", resource_name, result)
+    return result
 
 
 def _render_partial(template_name: str, context: dict[str, str]) -> str:
     """Render a Jinja partial template with the given context."""
+    logger.debug("Rendering partial template: %s", template_name)
     env = Environment(
         loader=FileSystemLoader(str(PARTIALS_ROOT)),
         autoescape=select_autoescape(
@@ -700,6 +753,7 @@ def add_resource(
 
     Returns the list of created file paths.
     """
+    logger.info("Adding resource '%s' to %s", resource_name, project_root)
     normalized = _normalize_function_name(resource_name)
     _validate_project_root(project_root)
     names = _derive_resource_names(normalized)
@@ -713,26 +767,37 @@ def add_resource(
         if path.exists():
             raise ScaffoldError(f"File already exists: {path}")
 
+    # Pre-validate function_app.py can be updated before writing files.
+    _validate_function_app_updatable(
+        project_root / "function_app.py",
+        import_stmt=f"from app.functions.{normalized} import {normalized}_blueprint",
+        registration_stmt=f"app.register_functions({normalized}_blueprint)",
+    )
+
     # Render and write files.
     created: list[Path] = []
 
     blueprint_path.parent.mkdir(parents=True, exist_ok=True)
     blueprint_path.write_text(_render_partial("resource_blueprint.py.j2", names), encoding="utf-8")
     created.append(blueprint_path)
+    logger.debug("Created %s", blueprint_path)
 
     service_path.parent.mkdir(parents=True, exist_ok=True)
     service_path.write_text(_render_partial("resource_service.py.j2", names), encoding="utf-8")
     created.append(service_path)
+    logger.debug("Created %s", service_path)
 
     schema_path.parent.mkdir(parents=True, exist_ok=True)
     schema_path.write_text(_render_partial("resource_schema.py.j2", names), encoding="utf-8")
     created.append(schema_path)
+    logger.debug("Created %s", schema_path)
 
     if (project_root / "tests").is_dir():
         test_path = project_root / "tests" / f"test_{normalized}.py"
         if not test_path.exists():
             test_path.write_text(_render_partial("resource_test.py.j2", names), encoding="utf-8")
             created.append(test_path)
+            logger.debug("Created %s", test_path)
 
     _update_function_app(
         project_root / "function_app.py",
@@ -802,12 +867,19 @@ def add_route(
 
     Returns the path to the created blueprint file.
     """
+    logger.info("Adding route '%s' to %s", route_name, project_root)
     normalized = _normalize_function_name(route_name)
     _validate_project_root(project_root)
 
     blueprint_path = project_root / "app" / "functions" / f"{normalized}.py"
     if blueprint_path.exists():
         raise ScaffoldError(f"Function module already exists: {blueprint_path}")
+
+    _validate_function_app_updatable(
+        project_root / "function_app.py",
+        import_stmt=f"from app.functions.{normalized} import {normalized}_blueprint",
+        registration_stmt=f"app.register_functions({normalized}_blueprint)",
+    )
 
     names = {
         "resource_name": normalized,
@@ -816,11 +888,13 @@ def add_route(
 
     blueprint_path.parent.mkdir(parents=True, exist_ok=True)
     blueprint_path.write_text(_render_partial("route_blueprint.py.j2", names), encoding="utf-8")
+    logger.debug("Created %s", blueprint_path)
 
     if (project_root / "tests").is_dir():
         test_path = project_root / "tests" / f"test_{normalized}.py"
         if not test_path.exists():
             test_path.write_text(_render_partial("route_test.py.j2", names), encoding="utf-8")
+            logger.debug("Created %s", test_path)
 
     _update_function_app(
         project_root / "function_app.py",

--- a/src/azure_functions_scaffold/scaffolder.py
+++ b/src/azure_functions_scaffold/scaffolder.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 import re
 import shutil
@@ -10,6 +11,8 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 from azure_functions_scaffold.errors import ScaffoldError
 from azure_functions_scaffold.models import ProjectOptions, TemplateContext, TemplateSpec
 from azure_functions_scaffold.template_registry import build_project_options, get_template
+
+logger = logging.getLogger(__name__)
 
 
 def scaffold_project(
@@ -25,11 +28,19 @@ def scaffold_project(
         template_name=template_name,
         options=options,
     )
+    logger.info(
+        "Scaffolding project '%s' at %s (template=%s, preset=%s)",
+        project_name,
+        target_dir,
+        template.name,
+        context.preset_name,
+    )
     if target_dir.exists():
         if not overwrite:
             raise ScaffoldError(
                 f"Target directory already exists: {target_dir}. Use --overwrite to replace it."
             )
+        logger.warning("Overwriting existing directory: %s", target_dir)
         shutil.rmtree(target_dir)
 
     template_root = template.root
@@ -74,11 +85,13 @@ def scaffold_project(
             rendered_path=rendered_path,
             rendered_content=rendered_content,
         )
+        logger.debug("Rendering template: %s -> %s", template_rel_name, output_path)
         output_path.write_text(rendered_content, encoding="utf-8")
 
     if context.initialize_git:
         _initialize_git_repository(target_dir)
 
+    logger.info("Project scaffolded successfully: %s", target_dir)
     return target_dir
 
 
@@ -279,6 +292,7 @@ def _resolve_scaffold_inputs(
 
 
 def _initialize_git_repository(project_root: Path) -> None:
+    logger.debug("Initializing git repository in %s", project_root)
     git_executable = shutil.which("git")
     if not git_executable:
         raise ScaffoldError("Git is not installed or not available on PATH.")

--- a/src/azure_functions_scaffold/templates/http/app/functions/health.py.j2
+++ b/src/azure_functions_scaffold/templates/http/app/functions/health.py.j2
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 
 import azure.functions as func
 {%- if include_openapi %}
@@ -25,6 +26,7 @@ health_blueprint = func.Blueprint()  # type: ignore[no-untyped-call]
     )
 {% endif -%}
 def health(req: func.HttpRequest) -> func.HttpResponse:
+    logging.info("Health check requested")
     result = check_health()
     return func.HttpResponse(
         body=json.dumps(result),

--- a/src/azure_functions_scaffold/templates/http/app/functions/users.py.j2
+++ b/src/azure_functions_scaffold/templates/http/app/functions/users.py.j2
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 
 import azure.functions as func
 {%- if include_openapi %}
@@ -35,6 +36,7 @@ users_blueprint = func.Blueprint()  # type: ignore[no-untyped-call]
 )
 {% endif -%}
 def list_users(req: func.HttpRequest) -> func.HttpResponse:
+    logging.info("Listing all users")
     return func.HttpResponse(
         body=json.dumps(users_store.list_all()),
         mimetype="application/json",
@@ -60,8 +62,10 @@ def list_users(req: func.HttpRequest) -> func.HttpResponse:
 {% endif -%}
 def get_user(req: func.HttpRequest) -> func.HttpResponse:
     user_id = req.route_params.get("user_id", "")
+    logging.info("Getting user: %s", user_id)
     user = users_store.get(user_id)
     if user is None:
+        logging.warning("User not found: %s", user_id)
         return func.HttpResponse(
             body=json.dumps({"error": "User not found"}),
             mimetype="application/json",
@@ -100,7 +104,9 @@ def get_user(req: func.HttpRequest) -> func.HttpResponse:
 {% endif -%}
 {% if include_validation -%}
 def create_user(req: func.HttpRequest, body: CreateUserRequest) -> func.HttpResponse:
-    user = users_store.create(body.name, body.email)
+    name = body.name
+    logging.info("Creating user: name=%s", name)
+    user = users_store.create(name, body.email)
     return func.HttpResponse(
         body=UserResponse(**user).model_dump_json(),
         mimetype="application/json",
@@ -116,8 +122,15 @@ def create_user(req: func.HttpRequest) -> func.HttpResponse:
             mimetype="application/json",
             status_code=400,
         )
+    if not isinstance(body, dict):
+        return func.HttpResponse(
+            body=json.dumps({"error": "Request body must be a JSON object"}),
+            mimetype="application/json",
+            status_code=400,
+        )
     name = body.get("name", "")
     email = body.get("email", "")
+    logging.info("Creating user: name=%s", name)
     if not name or not email:
         return func.HttpResponse(
             body=json.dumps({"error": "name and email are required"}),
@@ -159,8 +172,10 @@ def create_user(req: func.HttpRequest) -> func.HttpResponse:
 {% if include_validation -%}
 def update_user(req: func.HttpRequest, body: UpdateUserRequest) -> UserResponse | func.HttpResponse:
     user_id = req.route_params.get("user_id", "")
+    logging.info("Updating user: %s", user_id)
     user = users_store.update(user_id, name=body.name, email=body.email)
     if user is None:
+        logging.warning("User not found for update: %s", user_id)
         return func.HttpResponse(
             body=json.dumps({"error": "User not found"}),
             mimetype="application/json",
@@ -170,6 +185,7 @@ def update_user(req: func.HttpRequest, body: UpdateUserRequest) -> UserResponse 
 {%- else -%}
 def update_user(req: func.HttpRequest) -> func.HttpResponse:
     user_id = req.route_params.get("user_id", "")
+    logging.info("Updating user: %s", user_id)
     try:
         body = req.get_json()
     except ValueError:
@@ -178,8 +194,15 @@ def update_user(req: func.HttpRequest) -> func.HttpResponse:
             mimetype="application/json",
             status_code=400,
         )
+    if not isinstance(body, dict):
+        return func.HttpResponse(
+            body=json.dumps({"error": "Request body must be a JSON object"}),
+            mimetype="application/json",
+            status_code=400,
+        )
     user = users_store.update(user_id, name=body.get("name"), email=body.get("email"))
     if user is None:
+        logging.warning("User not found for update: %s", user_id)
         return func.HttpResponse(
             body=json.dumps({"error": "User not found"}),
             mimetype="application/json",
@@ -211,8 +234,10 @@ def update_user(req: func.HttpRequest) -> func.HttpResponse:
 {% endif -%}
 def delete_user(req: func.HttpRequest) -> func.HttpResponse:
     user_id = req.route_params.get("user_id", "")
+    logging.info("Deleting user: %s", user_id)
     deleted = users_store.delete(user_id)
     if not deleted:
+        logging.warning("User not found for deletion: %s", user_id)
         return func.HttpResponse(
             body=json.dumps({"error": "User not found"}),
             mimetype="application/json",

--- a/src/azure_functions_scaffold/templates/http/tests/test_users.py.j2
+++ b/src/azure_functions_scaffold/templates/http/tests/test_users.py.j2
@@ -94,6 +94,35 @@ class TestCreateUser:
         assert body["email"] == "carol@example.com"
         assert "id" in body
 
+    def test_returns_400_for_invalid_json(self) -> None:
+        users_store._users.clear()
+
+        request = _make_request(
+            "POST",
+            "http://localhost/api/users",
+            body=b"not-json",
+            headers={"Content-Type": "application/json"},
+        )
+        response = create_user(request)
+
+        assert response.status_code == 400
+
+{% if not include_validation %}
+    def test_returns_400_for_non_object_json(self) -> None:
+        users_store._users.clear()
+
+        request = _make_request(
+            "POST",
+            "http://localhost/api/users",
+            body=json.dumps(["not", "an", "object"]).encode(),
+            headers={"Content-Type": "application/json"},
+        )
+        response = create_user(request)
+
+        assert response.status_code == 400
+        body = json.loads(response.get_body())
+        assert "JSON object" in body["error"]
+{% endif %}
 class TestUpdateUser:
     def test_updates_existing_user(self) -> None:
         users_store._users.clear()
@@ -142,6 +171,24 @@ class TestUpdateUser:
 
         assert response.status_code == 400
 
+{% if not include_validation %}
+    def test_returns_400_for_non_object_json(self) -> None:
+        users_store._users.clear()
+        user = users_store.create("Frank", "frank@example.com")
+
+        request = _make_request(
+            "PUT",
+            f"http://localhost/api/users/{user['id']}",
+            body=json.dumps(["not", "an", "object"]).encode(),
+            route_params={"user_id": user["id"]},
+            headers={"Content-Type": "application/json"},
+        )
+        response = update_user(request)
+
+        assert response.status_code == 400
+        body = json.loads(response.get_body())
+        assert "JSON object" in body["error"]
+{% endif %}
 class TestDeleteUser:
     def test_deletes_existing_user(self) -> None:
         users_store._users.clear()

--- a/src/azure_functions_scaffold/templates/partials/resource_blueprint.py.j2
+++ b/src/azure_functions_scaffold/templates/partials/resource_blueprint.py.j2
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 
 import azure.functions as func
 
@@ -19,6 +20,7 @@ from app.services.{{ resource_name }}_service import {{ resource_name }}_store
     auth_level=func.AuthLevel.ANONYMOUS,
 )
 def list_{{ resource_name }}(req: func.HttpRequest) -> func.HttpResponse:
+    logging.info("Listing all {{ route_name }}")
     return func.HttpResponse(
         body=json.dumps({{ resource_name }}_store.list_all()),
         mimetype="application/json",
@@ -37,8 +39,10 @@ def list_{{ resource_name }}(req: func.HttpRequest) -> func.HttpResponse:
 )
 def get_{{ resource_singular }}(req: func.HttpRequest) -> func.HttpResponse:
     item_id = req.route_params.get("item_id", "")
+    logging.info("Getting {{ resource_singular }}: %s", item_id)
     item = {{ resource_name }}_store.get(item_id)
     if item is None:
+        logging.warning("{{ resource_class }} not found: %s", item_id)
         return func.HttpResponse(
             body=json.dumps({"error": "{{ resource_class }} not found"}),
             mimetype="application/json",
@@ -76,6 +80,7 @@ def create_{{ resource_singular }}(req: func.HttpRequest) -> func.HttpResponse:
             status_code=400,
         )
     name = body.get("name", "")
+    logging.info("Creating {{ resource_singular }}: name=%s", name)
     if not name:
         return func.HttpResponse(
             body=json.dumps({"error": "name is required"}),
@@ -101,6 +106,7 @@ def create_{{ resource_singular }}(req: func.HttpRequest) -> func.HttpResponse:
 )
 def update_{{ resource_singular }}(req: func.HttpRequest) -> func.HttpResponse:
     item_id = req.route_params.get("item_id", "")
+    logging.info("Updating {{ resource_singular }}: %s", item_id)
     try:
         body = req.get_json()
     except ValueError:
@@ -117,6 +123,7 @@ def update_{{ resource_singular }}(req: func.HttpRequest) -> func.HttpResponse:
         )
     item = {{ resource_name }}_store.update(item_id, name=body.get("name"))
     if item is None:
+        logging.warning("{{ resource_class }} not found for update: %s", item_id)
         return func.HttpResponse(
             body=json.dumps({"error": "{{ resource_class }} not found"}),
             mimetype="application/json",
@@ -140,8 +147,10 @@ def update_{{ resource_singular }}(req: func.HttpRequest) -> func.HttpResponse:
 )
 def delete_{{ resource_singular }}(req: func.HttpRequest) -> func.HttpResponse:
     item_id = req.route_params.get("item_id", "")
+    logging.info("Deleting {{ resource_singular }}: %s", item_id)
     deleted = {{ resource_name }}_store.delete(item_id)
     if not deleted:
+        logging.warning("{{ resource_class }} not found for deletion: %s", item_id)
         return func.HttpResponse(
             body=json.dumps({"error": "{{ resource_class }} not found"}),
             mimetype="application/json",

--- a/src/azure_functions_scaffold/templates/partials/route_blueprint.py.j2
+++ b/src/azure_functions_scaffold/templates/partials/route_blueprint.py.j2
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import azure.functions as func
+import logging
 
 {{ resource_name }}_blueprint = func.Blueprint()  # type: ignore[no-untyped-call]
 
@@ -11,6 +12,7 @@ import azure.functions as func
     auth_level=func.AuthLevel.ANONYMOUS,
 )
 def {{ resource_name }}(req: func.HttpRequest) -> func.HttpResponse:
+    logging.info("{{ route_name }} endpoint called")
     return func.HttpResponse(
         body="TODO: implement {{ route_name }}",
         status_code=200,

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -83,9 +83,21 @@ def test_add_function_rejects_uneditable_function_app(tmp_path: Path) -> None:
     function_app_path = project_root / "function_app.py"
     function_app_path.write_text("import azure.functions as func\n", encoding="utf-8")
 
-    with pytest.raises(ScaffoldError, match="Could not update function_app.py"):
+    with pytest.raises(ScaffoldError, match="Cannot update function_app.py"):
         add_function(project_root=project_root, trigger="http", function_name="sync-data")
 
+
+def test_add_function_does_not_create_files_when_function_app_uneditable(tmp_path: Path) -> None:
+    """Verify no files are left behind when function_app.py cannot be updated."""
+    project_root = scaffold_project("sample", tmp_path)
+    function_app_path = project_root / "function_app.py"
+    function_app_path.write_text("import azure.functions as func\n", encoding="utf-8")
+
+    with pytest.raises(ScaffoldError):
+        add_function(project_root=project_root, trigger="http", function_name="orphan")
+
+    assert not (project_root / "app/functions/orphan.py").exists()
+    assert not (project_root / "tests/test_orphan.py").exists()
 
 def test_add_function_can_skip_test_generation_for_minimal_preset(tmp_path: Path) -> None:
     project_root = scaffold_project(
@@ -646,6 +658,20 @@ def test_add_resource_rejects_invalid_names(tmp_path: Path, resource_name: str) 
         add_resource(project_root=project_root, resource_name=resource_name)
 
 
+def test_add_resource_does_not_create_files_when_function_app_uneditable(tmp_path: Path) -> None:
+    """Verify no files are left behind when function_app.py cannot be updated."""
+    project_root = scaffold_project("sample", tmp_path)
+    function_app_path = project_root / "function_app.py"
+    function_app_path.write_text("import azure.functions as func\n", encoding="utf-8")
+
+    with pytest.raises(ScaffoldError):
+        add_resource(project_root=project_root, resource_name="orphans")
+
+    assert not (project_root / "app/functions/orphans.py").exists()
+    assert not (project_root / "app/services/orphans_service.py").exists()
+    assert not (project_root / "app/schemas/orphans.py").exists()
+    assert not (project_root / "tests/test_orphans.py").exists()
+
 def test_add_resource_skips_test_when_no_tests_dir(tmp_path: Path) -> None:
     project_root = scaffold_project(
         "sample",
@@ -791,6 +817,17 @@ def test_add_route_rejects_non_scaffold_project(tmp_path: Path) -> None:
     ):
         add_route(project_root=project_root, route_name="status")
 
+def test_add_route_does_not_create_files_when_function_app_uneditable(tmp_path: Path) -> None:
+    """Verify no files are left behind when function_app.py cannot be updated."""
+    project_root = scaffold_project("sample", tmp_path)
+    function_app_path = project_root / "function_app.py"
+    function_app_path.write_text("import azure.functions as func\n", encoding="utf-8")
+
+    with pytest.raises(ScaffoldError):
+        add_route(project_root=project_root, route_name="orphan")
+
+    assert not (project_root / "app/functions/orphan.py").exists()
+    assert not (project_root / "tests/test_orphan.py").exists()
 
 def test_add_route_with_hyphenated_name(tmp_path: Path) -> None:
     project_root = scaffold_project("sample", tmp_path)


### PR DESCRIPTION
## Summary

Adds structured logging across the scaffold tool and generated HTTP templates, while fixing critical bugs identified in Oracle's comprehensive Phase 3 review.

Closes #58

## Changes

### Logging (7 files)
- **Scaffold internals**: `generator.py` (17 log calls), `scaffolder.py` (6), `cli_common.py` (3)
- **Generated templates**: `health.py.j2`, `users.py.j2`, `resource_blueprint.py.j2`, `route_blueprint.py.j2`
- Pattern: `logger = logging.getLogger(__name__)` for tool internals; bare `logging.info()` for generated templates (matching existing worker pattern)

### Bug Fixes (Oracle MUST-FIX)
1. **Non-object JSON body causing 500** — `users.py.j2` non-validation `create_user`/`update_user` paths call `.get()` on `req.get_json()` without checking it's a `dict`. A JSON array payload caused `AttributeError`. Fixed with `isinstance(body, dict)` guard returning 400.
2. **Half-applied state on uneditable function_app.py** — `add-route`/`add-resource`/`add-function` write files before validating `function_app.py` markers, leaving orphan files on failure. Fixed with `_validate_function_app_updatable()` pre-check called before any file writes.

### Doc Fixes (Oracle SHOULD-FIX)
3. **README health status mismatch** — README examples showed `{"status": "healthy"}` but generated code returns `{"status": "ok"}`. Fixed in all 4 locale READMEs.
4. **Stale `--with-db` wording** — Updated READMEs and llms files to clarify `--with-db` is not yet available in CLI.

### Tests (+5 new)
- 2 non-object JSON body tests (`test_users.py.j2`) — conditional on `{% if not include_validation %}` since validation path returns 422 via Pydantic
- 3 no-orphan-files tests (`test_generator.py`) — verify `add_function`, `add_route`, `add_resource` don't leave files when `function_app.py` is uneditable

## Verification
- 236 passed, 3 skipped, 97.20% coverage
- Lint: clean
- Typecheck: clean

## Oracle Review Status
- Phase 3 comprehensive review: 2 MUST-FIX ✅, 2 SHOULD-FIX ✅, 1 SHOULD-FIX deferred (resource partials), 1 SHOULD-FIX deferred (plural engine), 2 NITs pending