### PR TITLE
docs: add example walkthroughs for all remaining templates

### DIFF
--- a/docs/examples/ai_agents.md
+++ b/docs/examples/ai_agents.md
@@ -1,0 +1,291 @@
+# AI Agents Example
+
+Two templates serve AI workloads: **ai** for direct Azure OpenAI integration
+and **langgraph** for LangGraph agent deployment. This walkthrough covers both.
+
+## What You Will Build
+
+By the end, you will have:
+
+- an Azure OpenAI chat endpoint that accepts prompts and returns completions
+- or a LangGraph agent deployed as an Azure Functions app
+- local run and test verification for either template
+
+## 1) Generate an Azure OpenAI Project
+
+```bash
+afs advanced new --template ai --preset standard my-ai-api
+```
+
+Set up environment and dependencies:
+
+```bash
+cd my-ai-api
+python -m venv .venv
+. .venv/bin/activate
+pip install -e .[dev]
+```
+
+Run quality checks:
+
+```bash
+make check-all
+```
+
+## 2) Understand the Chat Endpoint
+
+The generated function exposes a `POST /api/chat` endpoint:
+
+```python
+@ai_blueprint.route(
+    route="chat",
+    methods=["POST"],
+    auth_level=func.AuthLevel.ANONYMOUS,
+)
+async def chat(req: func.HttpRequest) -> func.HttpResponse:
+    try:
+        body = req.get_json()
+        prompt = body.get("prompt", "")
+    except ValueError:
+        return func.HttpResponse(
+            body=json.dumps({"error": "Invalid JSON body."}),
+            status_code=400,
+            mimetype="application/json",
+        )
+
+    if not prompt:
+        return func.HttpResponse(
+            body=json.dumps({"error": "Missing 'prompt' field."}),
+            status_code=400,
+            mimetype="application/json",
+        )
+
+    result = await generate_completion(prompt)
+    logging.info("Generated completion for prompt: %s", prompt[:50])
+    return func.HttpResponse(
+        body=json.dumps({"response": result}),
+        status_code=200,
+        mimetype="application/json",
+    )
+```
+
+The service layer uses `AsyncAzureOpenAI` from the `openai` package:
+
+```python
+async def generate_completion(prompt: str) -> str:
+    client = AsyncAzureOpenAI(
+        azure_endpoint=os.environ["AZURE_OPENAI_ENDPOINT"],
+        api_key=os.environ["AZURE_OPENAI_API_KEY"],
+        api_version="2024-02-01",
+    )
+    response = await client.chat.completions.create(
+        model=os.environ.get("AZURE_OPENAI_DEPLOYMENT", "gpt-4o"),
+        messages=[{"role": "user", "content": prompt}],
+        max_tokens=500,
+    )
+    return response.choices[0].message.content or ""
+```
+
+## 3) Configure Azure OpenAI Credentials
+
+```bash
+cp local.settings.json.example local.settings.json
+```
+
+Edit `local.settings.json` with your Azure OpenAI resource values:
+
+| Setting | Description |
+| :--- | :--- |
+| `AZURE_OPENAI_ENDPOINT` | Your Azure OpenAI resource endpoint URL. |
+| `AZURE_OPENAI_API_KEY` | API key for authentication. |
+| `AZURE_OPENAI_DEPLOYMENT` | Model deployment name (defaults to `gpt-4o`). |
+
+## 4) Run and Test the Chat Endpoint
+
+```bash
+func start
+```
+
+In a second terminal:
+
+```bash
+curl -X POST "http://localhost:7071/api/chat" \
+  -H "Content-Type: application/json" \
+  -d '{"prompt":"What is Azure Functions?"}'
+```
+
+Expected response shape:
+
+```json
+{"response": "Azure Functions is a serverless compute service..."}
+```
+
+## 5) AI Template Testing Strategy
+
+The generated test validates input handling without calling Azure OpenAI:
+
+```python
+def test_chat_rejects_missing_prompt() -> None:
+    request = func.HttpRequest(
+        method="POST",
+        url="http://localhost/api/chat",
+        params={},
+        body=json.dumps({"prompt": ""}).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+
+    import asyncio
+
+    response = asyncio.run(chat(request))
+
+    assert response.status_code == 400
+```
+
+Run tests:
+
+```bash
+pytest
+```
+
+!!! tip "Testing with mocks"
+    For integration-level tests, mock `generate_completion` to avoid
+    real API calls. Test service logic separately in `app/services/`.
+
+## 6) Generate a LangGraph Agent Project
+
+```bash
+afs ai agent my-agent
+```
+
+Set up environment and dependencies:
+
+```bash
+cd my-agent
+python -m venv .venv
+. .venv/bin/activate
+pip install -e .[dev]
+```
+
+Run quality checks:
+
+```bash
+make check-all
+```
+
+## 7) Understand the LangGraph Scaffold
+
+The generated project has a different structure from other templates.
+
+`app/graphs/echo_agent.py` defines a `StateGraph` with a single echo node:
+
+```python
+class AgentState(TypedDict):
+    messages: list[dict[str, str]]
+
+
+def chat(state: AgentState) -> dict:
+    user_msg = state["messages"][-1]["content"]
+    return {
+        "messages": state["messages"]
+        + [{"role": "assistant", "content": f"Echo: {user_msg}"}]
+    }
+
+
+builder = StateGraph(AgentState)
+builder.add_node("chat", chat)
+builder.add_edge(START, "chat")
+builder.add_edge("chat", END)
+graph = builder.compile()
+```
+
+`function_app.py` uses `LangGraphApp` from `azure_functions_langgraph` to
+expose the graph as Azure Functions endpoints:
+
+```python
+from azure_functions_langgraph import LangGraphApp
+from app.graphs.echo_agent import graph
+
+lg_app = LangGraphApp(auth_level=func.AuthLevel.ANONYMOUS)
+lg_app.register(graph=graph, name="echo_agent")
+func_app = lg_app.function_app
+```
+
+## 8) Run and Test the Agent
+
+```bash
+func start
+```
+
+Invoke the agent endpoint from a second terminal:
+
+```bash
+curl -X POST "http://localhost:7071/api/echo_agent" \
+  -H "Content-Type: application/json" \
+  -d '{"messages":[{"role":"human","content":"Hello!"}]}'
+```
+
+The generated test invokes the graph directly without running the server:
+
+```python
+def test_echo_agent_invokes_successfully() -> None:
+    result = graph.invoke(
+        {"messages": [{"role": "human", "content": "Hello!"}]}
+    )
+    assert len(result["messages"]) == 2
+    assert result["messages"][-1]["role"] == "assistant"
+    assert "Echo: Hello!" in result["messages"][-1]["content"]
+```
+
+Run tests:
+
+```bash
+pytest
+```
+
+!!! note "LangGraph documentation"
+    For deeper LangGraph configuration — tools, multi-step graphs, LLM
+    integration — see the
+    [azure-functions-langgraph](https://github.com/yeongseon/azure-functions-langgraph)
+    documentation.
+
+## 9) Customization Patterns
+
+**AI template**:
+
+- Swap the model deployment name via `AZURE_OPENAI_DEPLOYMENT`.
+- Add a system prompt to the `messages` list in `generate_completion`.
+- Integrate with other Azure AI services by adding service functions.
+
+**LangGraph template**:
+
+- Replace the echo node with a real LLM-backed node.
+- Add tool nodes for retrieval, API calls, or database access.
+- Build multi-step graphs by adding nodes and edges to the `StateGraph`.
+
+!!! tip "Keep graphs in app/graphs/"
+    Follow the generated pattern: define graphs in `app/graphs/`, register
+    them in `function_app.py`, and test graph logic independently of the
+    Azure Functions runtime.
+
+## Troubleshooting Notes
+
+!!! warning "401 Unauthorized from Azure OpenAI"
+    Verify `AZURE_OPENAI_ENDPOINT` and `AZURE_OPENAI_API_KEY` in
+    `local.settings.json`. Confirm the API key is active and the endpoint
+    URL is correct.
+
+!!! warning "Module not found errors"
+    Confirm all dependencies are installed. The AI template requires the
+    `openai` package. The LangGraph template requires `langgraph` and
+    `azure-functions-langgraph`.
+
+!!! warning "Empty response from chat endpoint"
+    Check that `AZURE_OPENAI_DEPLOYMENT` matches an existing deployment in
+    your Azure OpenAI resource.
+
+## Next Steps
+
+- See [HTTP API](http_api.md) for REST API patterns with OpenAPI and validation.
+- See [Full Stack](full_stack.md) for production baseline configuration.
+- See [Templates](../guide/templates.md) for the full template list.
+- See [Troubleshooting](../guide/troubleshooting.md) for runtime diagnostics.

--- a/docs/examples/cosmosdb_change_feed.md
+++ b/docs/examples/cosmosdb_change_feed.md
@@ -1,0 +1,203 @@
+# CosmosDB Change Feed Example
+
+This walkthrough creates a CosmosDB change feed processor that reacts to
+document changes, then runs and tests it locally with the CosmosDB emulator.
+
+## What You Will Build
+
+You will create a change feed processor that:
+
+- triggers on document inserts and updates in a CosmosDB container
+- processes batches of changed documents
+- uses a lease container to track processing state
+- is testable with pytest
+
+## 1) Generate the Project
+
+```bash
+afs advanced new --template cosmosdb --preset standard my-change-processor
+```
+
+Set up environment and dependencies:
+
+```bash
+cd my-change-processor
+python -m venv .venv
+. .venv/bin/activate
+pip install -e .[dev]
+```
+
+Run quality checks:
+
+```bash
+make check-all
+```
+
+## 2) Understand CosmosDB Trigger Defaults
+
+The generated trigger function:
+
+```python
+@cosmosdb_blueprint.cosmos_db_trigger_v3(
+    arg_name="documents",
+    container_name="my-container",
+    database_name="my-database",
+    connection="CosmosDBConnection",
+    lease_container_name="leases",
+    create_lease_container_if_not_exists=True,
+)
+def process_cosmos_changes(documents: func.DocumentList) -> None:
+    count = describe_documents(documents)
+    logging.info("Processed %s Cosmos DB change(s).", count)
+```
+
+!!! note "Lease container"
+    The lease container tracks which changes have been processed. It enables
+    multiple instances to share the change feed without duplicating work. The
+    `create_lease_container_if_not_exists=True` flag creates it automatically.
+
+## 3) Generated Layout
+
+```text
+my-change-processor/
+├── function_app.py
+├── app/
+│   ├── functions/cosmosdb.py
+│   └── services/cosmosdb_service.py
+├── tests/test_cosmosdb.py
+├── local.settings.json.example
+└── pyproject.toml
+```
+
+- `app/functions/cosmosdb.py` — trigger handler that receives document batches.
+- `app/services/cosmosdb_service.py` — service function (`describe_documents` returns document count).
+- `tests/test_cosmosdb.py` — smoke test passing a plain list as the document batch.
+
+## 4) Local Prerequisites
+
+CosmosDB triggers require the CosmosDB emulator for local development.
+
+Using Docker (Linux):
+
+```bash
+docker run --rm -p 8081:8081 -p 10250-10255:10250-10255 \
+  mcr.microsoft.com/cosmosdb/linux/azure-cosmos-emulator:latest
+```
+
+!!! note "Windows"
+    On Windows, use the native CosmosDB Emulator installer from the Azure
+    documentation.
+
+Create active local settings file and configure the connection:
+
+```bash
+cp local.settings.json.example local.settings.json
+```
+
+The template includes a placeholder connection string:
+
+```json
+{
+  "CosmosDBConnection": "AccountEndpoint=https://localhost:8081/;AccountKey=replace-me"
+}
+```
+
+Replace `replace-me` with the emulator's default account key.
+
+Create the database (`my-database`) and container (`my-container`) in the
+emulator before starting the function app.
+
+## 5) Run and Test Locally
+
+```bash
+func start
+```
+
+Insert or update a document in the `my-container` container using the
+emulator's Data Explorer or a small SDK script. Watch the terminal for log output:
+
+```text
+Processed 1 Cosmos DB change(s).
+```
+
+## 6) Customize the Change Processor
+
+Replace `describe_documents` with actual business logic. Each document in the
+batch is a dictionary:
+
+```python
+def process_documents(documents: func.DocumentList) -> None:
+    for doc in documents:
+        doc_id = doc.get("id", "unknown")
+        # Route to domain-specific processing
+        handle_update(doc_id, doc)
+```
+
+Update the trigger handler to call the new service function:
+
+```python
+def process_cosmos_changes(documents: func.DocumentList) -> None:
+    process_documents(documents)
+    logging.info("Processed %s Cosmos DB change(s).", len(documents))
+```
+
+!!! tip "Keep trigger modules thin"
+    Move document parsing and side effects into `app/services/`. The trigger
+    handler should only decode, delegate, and log.
+
+## 7) Key Configuration Parameters
+
+| Parameter | Description |
+| :--- | :--- |
+| `container_name` | Source container to watch for changes. |
+| `database_name` | Database containing the source container. |
+| `connection` | App setting name for the CosmosDB connection string. |
+| `lease_container_name` | Container used to store change feed leases. |
+| `create_lease_container_if_not_exists` | Auto-create lease container on first run. |
+| `feed_poll_delay` | Delay in milliseconds between feed polls (optional). |
+
+## 8) Testing Strategy
+
+The generated test passes a plain list to the trigger function:
+
+```python
+def test_process_cosmos_changes_runs_without_error() -> None:
+    documents = [{"id": "1", "data": "hello"}]
+    process_cosmos_changes(documents)
+```
+
+Run tests:
+
+```bash
+pytest
+```
+
+This approach works because `func.DocumentList` is compatible with a plain
+Python list in the test context. For richer tests, add assertions in the
+service layer.
+
+## Troubleshooting Notes
+
+!!! warning "No trigger fires"
+    Confirm the CosmosDB emulator is running, the connection string is valid,
+    and the database and container exist. The trigger only fires on new changes
+    after it starts monitoring.
+
+!!! warning "Lease conflicts"
+    Multiple local instances sharing the same lease container can cause
+    processing conflicts. Use a unique `lease_container_name` per instance
+    during development.
+
+!!! warning "Emulator SSL errors"
+    The CosmosDB emulator uses a self-signed certificate. If connections
+    fail, import the emulator certificate into your Python environment's
+    trust store or pass `verify=False` to the SDK client during local
+    development only.
+
+## Next Steps
+
+- See [Worker Triggers](worker_triggers.md) for queue, blob, and messaging
+  patterns.
+- See [Durable Workflow](durable_workflow.md) for orchestration workflows.
+- See [Templates](../guide/templates.md) for the full template list.
+- See [Troubleshooting](../guide/troubleshooting.md) for runtime diagnostics.

--- a/docs/examples/durable_workflow.md
+++ b/docs/examples/durable_workflow.md
@@ -1,0 +1,223 @@
+# Durable Workflow Example
+
+This walkthrough creates a Durable Functions project with an orchestrator,
+activities, and an HTTP starter endpoint, then runs everything locally.
+
+## What You Will Build
+
+You will create a durable workflow that:
+
+- starts an orchestration via an HTTP POST
+- calls multiple activity functions sequentially
+- collects results and returns them through a status endpoint
+- runs locally with Azurite and Core Tools
+
+## 1) Generate the Project
+
+```bash
+afs advanced new --template durable --preset standard my-workflow
+```
+
+Set up environment and dependencies:
+
+```bash
+cd my-workflow
+python -m venv .venv
+. .venv/bin/activate
+pip install -e .[dev]
+```
+
+Run quality checks:
+
+```bash
+make check-all
+```
+
+## 2) Understand the Durable Pattern
+
+The generated project contains three function types in a single module:
+
+**HTTP Starter** — receives a POST request and starts a new orchestration
+instance:
+
+```python
+@durable_blueprint.route(
+    route="orchestrators/{functionName}",
+    methods=["POST"],
+    auth_level=func.AuthLevel.ANONYMOUS,
+)
+@durable_blueprint.durable_client_input(client_name="client")
+async def http_start(
+    req: func.HttpRequest, client: df.DurableOrchestrationClient
+) -> func.HttpResponse:
+    instance_id = await client.start_new(req.route_params["functionName"])
+    logging.info("Started orchestration with ID '%s'.", instance_id)
+    return client.create_check_status_response(req, instance_id)
+```
+
+**Orchestrator** — coordinates activity calls using generator-style `yield`:
+
+```python
+@durable_blueprint.orchestration_trigger(context_name="context")
+def hello_orchestrator(context: df.DurableOrchestrationContext) -> list[str]:
+    results: list[str] = []
+    results.append(yield context.call_activity("say_hello", "Tokyo"))
+    results.append(yield context.call_activity("say_hello", "Seattle"))
+    results.append(yield context.call_activity("say_hello", "London"))
+    return results
+```
+
+**Activity** — performs a single unit of work:
+
+```python
+@durable_blueprint.activity_trigger(input_name="city")
+def say_hello(city: str) -> str:
+    return build_greeting(city)
+```
+
+!!! note "Durable Functions imports"
+    Durable uses `azure.functions.durable_functions` (imported as `df`)
+    alongside the standard `azure.functions` package.
+
+## 3) Generated Layout
+
+```text
+my-workflow/
+├── function_app.py
+├── app/
+│   ├── functions/durable.py
+│   └── services/durable_service.py
+├── tests/test_durable.py
+├── local.settings.json.example
+└── pyproject.toml
+```
+
+- `app/functions/durable.py` — all three function types (starter, orchestrator, activity).
+- `app/services/durable_service.py` — business logic called by activities.
+- `tests/test_durable.py` — tests service functions directly.
+
+## 4) Azurite Setup
+
+Durable Functions require `AzureWebJobsStorage` for orchestration state
+management. Start Azurite before running locally.
+
+Using npm:
+
+```bash
+npm install -g azurite
+azurite --silent --location .azurite --debug .azurite/debug.log
+```
+
+Using Docker:
+
+```bash
+docker run --rm -p 10000:10000 -p 10001:10001 -p 10002:10002 \
+  mcr.microsoft.com/azure-storage/azurite
+```
+
+Create active local settings file:
+
+```bash
+cp local.settings.json.example local.settings.json
+```
+
+## 5) Run and Test Locally
+
+```bash
+func start
+```
+
+Start the orchestration by sending a POST to the starter endpoint:
+
+```bash
+curl -X POST "http://localhost:7071/api/orchestrators/hello_orchestrator"
+```
+
+The response includes a `statusQueryGetUri` field — use that URL directly
+to poll orchestration progress:
+
+```bash
+# Copy the statusQueryGetUri value from the POST response
+curl "<statusQueryGetUri from response>"
+```
+
+Expected completed output:
+
+```json
+{
+  "runtimeStatus": "Completed",
+  "output": ["Hello, Tokyo!", "Hello, Seattle!", "Hello, London!"]
+}
+```
+
+## 6) Customize the Workflow
+
+Add a new activity and wire it into the orchestrator.
+
+Add a formatting function to `app/services/durable_service.py`:
+
+```python
+def format_greeting(greeting: str) -> str:
+    return greeting.upper()
+```
+
+Add the activity in `app/functions/durable.py`:
+
+```python
+@durable_blueprint.activity_trigger(input_name="greeting")
+def format_result(greeting: str) -> str:
+    return format_greeting(greeting)
+```
+
+Update the orchestrator to call the new activity after each greeting:
+
+```python
+results.append(yield context.call_activity("say_hello", "Tokyo"))
+results.append(yield context.call_activity("format_result", results[-1]))
+```
+
+## 7) Testing Strategy
+
+The generated test validates the service layer directly:
+
+```python
+def test_build_greeting_returns_city_greeting() -> None:
+    result = build_greeting("Tokyo")
+    assert result == "Hello, Tokyo!"
+```
+
+Run tests:
+
+```bash
+pytest
+```
+
+Durable orchestrations are best tested through their service functions rather
+than the orchestration framework. Keep activity logic in `app/services/` and
+write unit tests against those functions.
+
+!!! tip "Keep activities thin"
+    Treat activity functions as adapters: extract inputs, call a service
+    function, return the result. Test the service function.
+
+## Troubleshooting Notes
+
+!!! warning "Orchestration not starting"
+    Verify Azurite is running and `local.settings.json` has
+    `AzureWebJobsStorage` configured.
+
+!!! warning "Status URL returns 404"
+    The `{functionName}` in the route must match the decorated orchestrator
+    function name exactly (`hello_orchestrator`).
+
+!!! warning "Orchestrator yield syntax"
+    Orchestrators use Python generators with `yield`, not `async/await`.
+    Each `yield context.call_activity(...)` suspends until the activity
+    completes.
+
+## Next Steps
+
+- See [Worker Triggers](worker_triggers.md) for queue, blob, and messaging
+  patterns.
+- See [Templates](../guide/templates.md) for the full template list.
+- See [Troubleshooting](../guide/troubleshooting.md) for runtime diagnostics.

--- a/docs/examples/index.md
+++ b/docs/examples/index.md
@@ -9,6 +9,14 @@ customized function app.
   OpenAPI usage, and local verification.
 - [Timer Job](timer_job.md): scheduled workloads, NCRONTAB patterns, and Azurite
   setup for local execution.
+- [Worker Triggers](worker_triggers.md): queue, blob, Service Bus, and Event Hub
+  trigger projects with connection setup and local testing.
+- [Durable Workflow](durable_workflow.md): orchestrator, activities, and HTTP
+  starter for durable workflows.
+- [CosmosDB Change Feed](cosmosdb_change_feed.md): change feed processing with
+  lease tracking and emulator setup.
+- [AI Agents](ai_agents.md): Azure OpenAI chat endpoint and LangGraph agent
+  deployment.
 - [Full Stack](full_stack.md): end-to-end setup with strict preset, OpenAPI,
   validation, doctor checks, and CI-oriented workflow.
 
@@ -16,7 +24,10 @@ customized function app.
 
 1. Start with HTTP API if you are new to the scaffold.
 2. Continue with Timer Job if you need background/scheduled processing.
-3. Use Full Stack as your production baseline template.
+3. Try Worker Triggers for message and event-driven patterns.
+4. See Durable Workflow or CosmosDB Change Feed for specialized triggers.
+5. See AI Agents for OpenAI or LangGraph workloads.
+6. Use Full Stack as your production baseline template.
 
 ## Related Docs
 

--- a/docs/examples/worker_triggers.md
+++ b/docs/examples/worker_triggers.md
@@ -1,0 +1,234 @@
+# Worker Triggers Example
+
+This walkthrough covers the four worker trigger templates: **queue**, **blob**,
+**servicebus**, and **eventhub**. All four follow the same scaffold workflow —
+generate, configure connections, run locally, and test — with
+trigger-specific differences in connection setup and message shape.
+
+## What You Will Build
+
+By the end, you will have:
+
+- a scaffolded worker project for one of the four trigger types
+- a working local development environment with the correct emulator or connection
+- a customized message handler with service-layer separation
+- a passing test suite
+
+## 1) Choose a Worker Template
+
+| Template | CLI Command | Primary Use Case | Connection Required |
+| :--- | :--- | :--- | :--- |
+| **Queue** | `afs worker queue <name>` | Async message processing from Azure Storage Queues | `AzureWebJobsStorage` |
+| **Blob** | `afs worker blob <name>` | File processing triggered by blob uploads | `AzureWebJobsStorage` |
+| **Service Bus** | `afs worker servicebus <name>` | Enterprise messaging with queues or topics | `ServiceBusConnection` |
+| **Event Hub** | `afs worker eventhub <name>` | High-throughput event stream ingestion | `EventHubConnection` |
+
+## 2) Generate the Project
+
+This walkthrough uses the queue template as the primary example. Replace the
+command with any trigger from the table above.
+
+```bash
+afs worker queue my-queue-processor
+```
+
+Set up environment and dependencies:
+
+```bash
+cd my-queue-processor
+python -m venv .venv
+. .venv/bin/activate
+pip install -e .[dev]
+```
+
+Run quality checks:
+
+```bash
+make check-all
+```
+
+## 3) Understand Generated Layout
+
+```text
+my-queue-processor/
+├── function_app.py
+├── app/
+│   ├── functions/queue.py
+│   └── services/queue_service.py
+├── tests/test_queue.py
+├── local.settings.json.example
+└── pyproject.toml
+```
+
+- `function_app.py` — registers the queue blueprint.
+- `app/functions/queue.py` — trigger handler that decodes messages and logs output.
+- `app/services/queue_service.py` — service function for message decoding.
+- `tests/test_queue.py` — smoke test using a `SimpleNamespace` stub.
+
+The generated queue handler:
+
+```python
+@queue_blueprint.queue_trigger(
+    arg_name="message",
+    queue_name="work-items",
+    connection="AzureWebJobsStorage",
+)
+def process_queue_message(message: func.QueueMessage) -> None:
+    payload = decode_queue_message(message)
+    logging.info("Processed queue message: %s", payload)
+```
+
+## 4) Local Prerequisites
+
+### Queue and Blob (Azurite)
+
+Queue and blob triggers use `AzureWebJobsStorage` with Azurite for local
+development.
+
+Using npm:
+
+```bash
+npm install -g azurite
+azurite --silent --location .azurite --debug .azurite/debug.log
+```
+
+Using Docker:
+
+```bash
+docker run --rm -p 10000:10000 -p 10001:10001 -p 10002:10002 \
+  mcr.microsoft.com/azure-storage/azurite
+```
+
+### Service Bus
+
+Service Bus triggers require a real Azure Service Bus namespace or a local
+emulator. Set `ServiceBusConnection` in `local.settings.json` to a valid
+connection string.
+
+### Event Hub
+
+Event Hub triggers require a real Azure Event Hubs namespace or a local
+emulator. Set `EventHubConnection` in `local.settings.json` to a valid
+connection string.
+
+### Activate Local Settings
+
+```bash
+cp local.settings.json.example local.settings.json
+```
+
+!!! warning "Replace placeholder connection strings"
+    Service Bus and Event Hub templates include placeholder connection strings.
+    Replace them with real values before running locally.
+
+## 5) Run and Test Locally
+
+```bash
+func start
+```
+
+Send a test message depending on the trigger type:
+
+- **Queue**: Use Azure Storage Explorer or the Azure CLI to add a message to the
+  `work-items` queue.
+- **Blob**: Drop a file into the `samples-workitems` container via Storage
+  Explorer or Azurite.
+- **Service Bus**: Use the Azure CLI or a sender script to post a message to the
+  `work-items` queue.
+- **Event Hub**: Use the Azure CLI or a sender script to send an event to
+  `my-event-hub`.
+
+Watch the terminal for log output confirming message processing.
+
+## 6) Trigger-Specific Configuration
+
+| Trigger | Key Decorator Parameters |
+| :--- | :--- |
+| **Queue** | `queue_name`, `connection` |
+| **Blob** | `path` (container path with `{name}` pattern), `connection` |
+| **Service Bus** | `queue_name`, `connection` (use `topic_name` + `subscription_name` for topics) |
+| **Event Hub** | `event_hub_name`, `connection` |
+
+## 7) Add a Second Worker Function
+
+Add another function module to the same project:
+
+```bash
+afs add queue cleanup --project-root .
+```
+
+Preview before writing if needed:
+
+```bash
+afs add queue cleanup --project-root . --dry-run
+```
+
+After adding, verify:
+
+- `app/functions/cleanup.py` exists
+- `function_app.py` includes import and registration
+- `tests/test_cleanup.py` exists (if tests are enabled)
+
+## 8) Customization Patterns
+
+Keep trigger modules thin and route business logic to service functions:
+
+```python
+from __future__ import annotations
+
+import logging
+
+import azure.functions as func
+
+from app.services.order_service import process_order
+
+queue_blueprint = func.Blueprint()  # type: ignore[no-untyped-call]
+
+
+@queue_blueprint.queue_trigger(
+    arg_name="message",
+    queue_name="orders",
+    connection="AzureWebJobsStorage",
+)
+def process_order_message(message: func.QueueMessage) -> None:
+    payload = message.get_body().decode("utf-8")
+    process_order(payload)
+    logging.info("Order processed: %s", payload[:50])
+```
+
+!!! tip "Keep business logic separated"
+    For larger workers, move parsing, validation, and side effects into
+    `app/services/` and keep trigger modules focused on wiring.
+
+## 9) Run Tests
+
+Run the generated test suite:
+
+```bash
+pytest
+```
+
+The generated tests use `SimpleNamespace` stubs to validate message decoding
+without requiring running emulators or real Azure resources.
+
+## Troubleshooting Notes
+
+!!! warning "No messages processed"
+    Confirm Azurite is running (queue/blob) or connection strings are valid
+    (servicebus/eventhub). Check that `local.settings.json` exists.
+
+!!! warning "Queue name mismatch"
+    The queue or container must exist before the trigger can fire. Create
+    `work-items` in Azurite or match the name in the decorator to an existing
+    resource.
+
+!!! warning "Service Bus or Event Hub connection refused"
+    Placeholder connection strings in `local.settings.json.example` are not
+    functional. Replace with real Azure resource connection strings.
+
+## Next Steps
+
+- See [Timer Job](timer_job.md) for scheduled workloads.
+- See [Templates](../guide/templates.md) for the full template list.
+- See [Expanding Your Project](../guide/expanding.md) for add-command flows.
+- See [Troubleshooting](../guide/troubleshooting.md) for runtime diagnostics.

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -1,16 +1,21 @@
 # Templates
 
-The CLI supports the most common Azure Functions triggers. Each template follows the Blueprint pattern, automatically generating the trigger, a corresponding service, and a test file.
+The CLI supports the most common Azure Functions triggers. Each trigger-based template follows the Blueprint pattern, automatically generating the trigger, a corresponding service, and a test file. The LangGraph template uses a different structure based on `LangGraphApp`.
 
 ### Template Overview
 
 | Template | CLI Command | Primary Use Case |
 | :--- | :--- | :--- |
-| **HTTP** | `http` | APIs, webhooks, synchronous requests. |
-| **Timer** | `timer` | Scheduled tasks, clean-up jobs, reports. |
-| **Queue** | `queue` | Async message processing from Azure Storage. |
-| **Blob** | `blob` | File processing, image resizing, data ingestion. |
-| **Service Bus** | `servicebus` | Enterprise messaging with topics or queues. |
+| **HTTP** | `afs new <name> --template http` | APIs, webhooks, synchronous requests. |
+| **Timer** | `afs new <name> --template timer` | Scheduled tasks, clean-up jobs, reports. |
+| **Queue** | `afs worker queue <name>` | Async message processing from Azure Storage. |
+| **Blob** | `afs worker blob <name>` | File processing, image resizing, data ingestion. |
+| **Service Bus** | `afs worker servicebus <name>` | Enterprise messaging with topics or queues. |
+| **Event Hub** | `afs worker eventhub <name>` | High-throughput event stream ingestion. |
+| **CosmosDB** | `afs advanced new --template cosmosdb --preset standard <name>` | Change feed processing from Cosmos DB containers. |
+| **Durable** | `afs advanced new --template durable --preset standard <name>` | Orchestrated workflows with activities and fan-out. |
+| **AI** | `afs advanced new --template ai --preset standard <name>` | Azure OpenAI chat completion endpoints. |
+| **LangGraph** | `afs ai agent <name>` | LangGraph agent deployment on Azure Functions. |
 
 ### HTTP Template
 
@@ -39,7 +44,7 @@ afs new nightly-job --template timer
 Reacts to messages added to an Azure Storage Queue.
 
 ```bash
-afs new queue-processor --template queue
+afs worker queue my-queue-processor
 ```
 
 *   **Generates**: `app/functions/queue.py`, `app/services/queue_service.py`, `tests/test_queue.py`.
@@ -53,7 +58,7 @@ afs new queue-processor --template queue
 Triggers when a blob is uploaded or updated in a storage container.
 
 ```bash
-afs new image-resizer --template blob
+afs worker blob my-image-resizer
 ```
 
 *   **Generates**: `app/functions/blob.py`, `app/services/blob_service.py`, `tests/test_blob.py`.
@@ -64,11 +69,69 @@ afs new image-resizer --template blob
 Handles high-throughput enterprise messages from Service Bus queues or topics.
 
 ```bash
-afs new bus-listener --template servicebus
+afs worker servicebus my-bus-listener
 ```
 
 *   **Generates**: `app/functions/servicebus.py`, `app/services/servicebus_service.py`, `tests/test_servicebus.py`.
-*   **Key points**: Uses a `SERVICEBUS_CONNECTION` placeholder in your settings.
+*   **Key points**: Uses a `ServiceBusConnection` placeholder in your settings.
+
+### Event Hub Template
+
+Ingests high-throughput event streams from Azure Event Hubs.
+
+```bash
+afs worker eventhub my-event-processor
+```
+
+*   **Generates**: `app/functions/eventhub.py`, `app/services/eventhub_service.py`, `tests/test_eventhub.py`.
+*   **Key points**: Uses an `EventHubConnection` placeholder. Default event hub name is `my-event-hub`.
+
+### CosmosDB Template
+
+Reacts to document changes via the Cosmos DB change feed.
+
+```bash
+afs advanced new --template cosmosdb --preset standard my-processor
+```
+
+*   **Generates**: `app/functions/cosmosdb.py`, `app/services/cosmosdb_service.py`, `tests/test_cosmosdb.py`.
+*   **Key points**: Uses `cosmos_db_trigger_v3` binding. Requires `CosmosDBConnection` and a lease container for tracking.
+
+!!! tip "Local Development"
+    Use the [CosmosDB Emulator](https://learn.microsoft.com/en-us/azure/cosmos-db/emulator) for local change feed testing.
+
+### Durable Template
+
+Builds orchestrated workflows with an HTTP starter, orchestrator, and activity functions.
+
+```bash
+afs advanced new --template durable --preset standard my-workflow
+```
+
+*   **Generates**: `app/functions/durable.py`, `app/services/durable_service.py`, `tests/test_durable.py`.
+*   **Key points**: Uses `azure.functions.durable_functions`. Requires Azurite for state management.
+
+### AI Template
+
+Creates an HTTP endpoint backed by Azure OpenAI for chat completions.
+
+```bash
+afs advanced new --template ai --preset standard my-ai-api
+```
+
+*   **Generates**: `app/functions/ai.py`, `app/services/ai_service.py`, `tests/test_ai.py`.
+*   **Key points**: Requires `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_API_KEY`, and `AZURE_OPENAI_DEPLOYMENT` settings.
+
+### LangGraph Template
+
+Deploys a LangGraph agent as an Azure Functions app using `azure-functions-langgraph`.
+
+```bash
+afs ai agent my-agent
+```
+
+*   **Generates**: `app/graphs/echo_agent.py`, `function_app.py`, `tests/test_echo_agent.py`.
+*   **Key points**: Uses `LangGraphApp` to register graphs. Default scaffold includes an echo agent.
 
 ### What's Next?
 


### PR DESCRIPTION
## Summary

- Add 4 new example walkthrough docs covering all previously undocumented templates: worker triggers (queue/blob/servicebus/eventhub), durable workflows, CosmosDB change feed, and AI agents (Azure OpenAI + LangGraph)
- Update `docs/guide/templates.md` to cover all 10 templates with correct CLI commands including `--preset standard <name>` for advanced templates
- Update `docs/examples/index.md` to reference all new docs with recommended reading order

## New Files

| File | Lines | Templates Covered |
|------|-------|-------------------|
| `docs/examples/worker_triggers.md` | 234 | queue, blob, servicebus, eventhub |
| `docs/examples/durable_workflow.md` | 223 | durable |
| `docs/examples/cosmosdb_change_feed.md` | 203 | cosmosdb |
| `docs/examples/ai_agents.md` | 291 | ai, langgraph |

## Updated Files

- `docs/guide/templates.md` — expanded from 3 templates to all 10 with accurate CLI commands
- `docs/examples/index.md` — added references to all 4 new walkthrough docs

## Quality

- Oracle-reviewed: 14 issues identified, 8 valid issues fixed, 4 rejected as invalid (verified against source), 2 deemed inapplicable to page type
- All CLI commands verified against `template_registry.py` intent specs
- All code snippets verified against template `.j2` source files
- Style consistent with existing `http_api.md` and `timer_job.md` reference docs
- Each doc covers: generate → understand → run → customize → test → troubleshoot