### PR TITLE
feat: add orjson as default dependency for faster JSON serialization

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -138,3 +138,16 @@ afs add queue process_orders --project-root ./my-api --dry-run
 - [Configuration](guide/configuration.md)
 - [HTTP API Example](examples/http_api.md)
 - [Troubleshooting](guide/troubleshooting.md)
+
+## Why is `orjson` included in generated projects?
+
+All scaffolded projects include [`orjson`](https://github.com/ijl/orjson) as a
+default dependency. The Azure Functions Python worker
+[automatically detects orjson](https://techcommunity.microsoft.com/blog/appsonazureblog/scaling-azure-functions-python-with-orjson/4445780)
+when it is installed and uses it for JSON serialization and deserialization —
+no code changes required.
+
+Benchmarks from Microsoft show up to **40% lower HTTP response times** and
+significantly higher throughput for Service Bus and Event Hub triggers. Since
+`orjson` provides pre-built wheels for all platforms Azure Functions supports,
+it adds negligible install overhead for a meaningful performance gain.

--- a/src/azure_functions_scaffold/templates/ai/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/ai/pyproject.toml.j2
@@ -27,6 +27,7 @@ dependencies = [
   "azure-functions>=1.23.0",
   "azure-functions-logging>=0.5.0",
   "openai>=1.0.0",
+  "orjson>=3.10.0",
 {% if include_doctor -%}
   "azure-functions-doctor>=0.16.0",
 {% endif -%}

--- a/src/azure_functions_scaffold/templates/blob/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/blob/pyproject.toml.j2
@@ -26,6 +26,7 @@ requires-python = ">={{ python_version }},<{{ python_upper_bound }}"
 dependencies = [
   "azure-functions>=1.23.0",
   "azure-functions-logging>=0.5.0",
+  "orjson>=3.10.0",
 {% if include_doctor -%}
   "azure-functions-doctor>=0.16.0",
 {% endif -%}

--- a/src/azure_functions_scaffold/templates/cosmosdb/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/cosmosdb/pyproject.toml.j2
@@ -26,6 +26,7 @@ requires-python = ">={{ python_version }},<{{ python_upper_bound }}"
 dependencies = [
   "azure-functions>=1.23.0",
   "azure-functions-logging>=0.5.0",
+  "orjson>=3.10.0",
 {% if include_doctor -%}
   "azure-functions-doctor>=0.16.0",
 {% endif -%}

--- a/src/azure_functions_scaffold/templates/durable/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/durable/pyproject.toml.j2
@@ -27,6 +27,7 @@ dependencies = [
   "azure-functions>=1.23.0",
   "azure-functions-logging>=0.5.0",
   "azure-functions-durable>=1.2.9",
+  "orjson>=3.10.0",
 {% if include_doctor -%}
   "azure-functions-doctor>=0.16.0",
 {% endif -%}

--- a/src/azure_functions_scaffold/templates/eventhub/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/eventhub/pyproject.toml.j2
@@ -26,6 +26,7 @@ requires-python = ">={{ python_version }},<{{ python_upper_bound }}"
 dependencies = [
   "azure-functions>=1.23.0",
   "azure-functions-logging>=0.5.0",
+  "orjson>=3.10.0",
 {% if include_doctor -%}
   "azure-functions-doctor>=0.16.0",
 {% endif -%}

--- a/src/azure_functions_scaffold/templates/http/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/http/pyproject.toml.j2
@@ -26,6 +26,7 @@ requires-python = ">={{ python_version }},<{{ python_upper_bound }}"
 dependencies = [
   "azure-functions>=1.23.0",
   "azure-functions-logging>=0.5.0",
+  "orjson>=3.10.0",
 {% if include_openapi -%}
   "azure-functions-openapi>=0.17.0",
 {% endif -%}

--- a/src/azure_functions_scaffold/templates/langgraph/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/langgraph/pyproject.toml.j2
@@ -27,6 +27,7 @@ dependencies = [
   "azure-functions>=1.23.0",
   "azure-functions-langgraph>=0.5.1",
   "langgraph>=0.2.0",
+  "orjson>=3.10.0",
 ]
 
 [project.optional-dependencies]

--- a/src/azure_functions_scaffold/templates/queue/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/queue/pyproject.toml.j2
@@ -26,6 +26,7 @@ requires-python = ">={{ python_version }},<{{ python_upper_bound }}"
 dependencies = [
   "azure-functions>=1.23.0",
   "azure-functions-logging>=0.5.0",
+  "orjson>=3.10.0",
 {% if include_doctor -%}
   "azure-functions-doctor>=0.16.0",
 {% endif -%}

--- a/src/azure_functions_scaffold/templates/servicebus/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/servicebus/pyproject.toml.j2
@@ -26,6 +26,7 @@ requires-python = ">={{ python_version }},<{{ python_upper_bound }}"
 dependencies = [
   "azure-functions>=1.23.0",
   "azure-functions-logging>=0.5.0",
+  "orjson>=3.10.0",
 {% if include_doctor -%}
   "azure-functions-doctor>=0.16.0",
 {% endif -%}

--- a/src/azure_functions_scaffold/templates/timer/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/timer/pyproject.toml.j2
@@ -26,6 +26,7 @@ requires-python = ">={{ python_version }},<{{ python_upper_bound }}"
 dependencies = [
   "azure-functions>=1.23.0",
   "azure-functions-logging>=0.5.0",
+  "orjson>=3.10.0",
 {% if include_doctor -%}
   "azure-functions-doctor>=0.16.0",
 {% endif -%}


### PR DESCRIPTION
## Summary

- Add `orjson>=3.10.0` to all 10 scaffold template `pyproject.toml.j2` files
- Add FAQ entry explaining why orjson is included in generated projects

## Motivation

The Azure Functions Python worker [automatically detects orjson](https://techcommunity.microsoft.com/blog/appsonazureblog/scaling-azure-functions-python-with-orjson/4445780) when installed and uses it for JSON serialization/deserialization — zero code changes required.

Microsoft benchmarks show:
- **HTTP**: up to 40% lower response times, dropped requests 289→0
- **Service Bus**: +38% throughput (1K messages)
- **Event Hub**: ~50% higher message processing rate

Since `orjson` provides pre-built wheels for all platforms Azure Functions supports, it adds negligible install overhead for a meaningful performance gain.

## Changes

### Templates (10 files)
All template `pyproject.toml.j2` files now include `"orjson>=3.10.0"` in the dependencies list:
- `http`, `timer`, `queue`, `blob`, `servicebus`, `eventhub`, `cosmosdb` — after `azure-functions-logging`
- `durable` — after `azure-functions-durable`
- `ai` — after `openai`
- `langgraph` — after `langgraph`

### Docs
- `docs/faq.md` — new "Why is `orjson` included in generated projects?" section

## Verification

- `make check-all` passes (236 tests, 97.2% coverage, lint clean, type check clean, security scan clean)

Closes #65