### PR TITLE
fix: align hatch wheel packages and toolkit dependency names

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,10 +45,10 @@ dev = [
     # Smoke-test deps: generated project runtime packages needed by
     # test_template_smoke.py to run the scaffolded project's own test suite.
     "azure-functions>=1.23.0",
-    "azure-functions-logging-python>=0.5.0",
-    "azure-functions-openapi-python>=0.17.0",
-    "azure-functions-validation-python>=0.7.0",
-    "azure-functions-doctor-python>=0.16.0",
+    "azure-functions-logging>=0.5.0",
+    "azure-functions-openapi>=0.17.0",
+    "azure-functions-validation>=0.7.0",
+    "azure-functions-doctor>=0.16.0",
     "pydantic>=2.0.0",
 ]
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,7 @@ build-backend = "hatchling.build"
 sources = ["src"]
 
 [tool.hatch.build.targets.wheel]
+packages = ["src/azure_functions_scaffold"]
 
 [tool.hatch.build.targets.sdist]
 include = [

--- a/src/azure_functions_scaffold/templates/http/app/services/webhook_service.py.j2
+++ b/src/azure_functions_scaffold/templates/http/app/services/webhook_service.py.j2
@@ -49,7 +49,7 @@ class WebhookStore:
     def record(self, event_type: str, source: str) -> dict[str, str]:
         """Record an accepted webhook delivery and return its metadata."""
         delivery_id = _generate_delivery_id()
-        received_at = datetime.now(timezone.utc).isoformat()
+        received_at = datetime.now(timezone.utc).isoformat()  # noqa: UP017
         entry = {
             "delivery_id": delivery_id,
             "status": "accepted",

--- a/tests/test_cli_intents.py
+++ b/tests/test_cli_intents.py
@@ -31,9 +31,9 @@ class TestApiNew:
         webhooks_text = (project_dir / "app/functions/webhooks.py").read_text(encoding="utf-8")
         makefile_text = (project_dir / "Makefile").read_text(encoding="utf-8")
         # api intent: strict preset + openapi + validation + doctor
-        assert "azure-functions-openapi-python>=0.17.0" in pyproject_text
-        assert "azure-functions-validation-python>=0.7.0" in pyproject_text
-        assert "azure-functions-doctor-python>=0.16.0" in pyproject_text
+        assert "azure-functions-openapi>=0.17.0" in pyproject_text
+        assert "azure-functions-validation>=0.7.0" in pyproject_text
+        assert "azure-functions-doctor>=0.16.0" in pyproject_text
         assert "mypy>=1.17.1" in pyproject_text  # strict preset
         assert "@openapi(" in webhooks_text
         assert "ValidationError" in webhooks_text  # manual Pydantic validation
@@ -46,7 +46,7 @@ class TestApiNew:
         # no azd by default
         assert not (project_dir / "azure.yaml").exists()
         # no db by default
-        assert "azure-functions-db-python" not in pyproject_text
+        assert "azure-functions-db" not in pyproject_text
 
     def test_with_azd_flag(self, tmp_path: Path) -> None:
         result = runner.invoke(
@@ -111,9 +111,9 @@ class TestNew:
         pyproject_text = (project_dir / "pyproject.toml").read_text(encoding="utf-8")
         function_app_text = (project_dir / "function_app.py").read_text(encoding="utf-8")
         # Same defaults as afs api new: strict + openapi + validation + doctor
-        assert "azure-functions-openapi-python>=0.17.0" in pyproject_text
-        assert "azure-functions-validation-python>=0.7.0" in pyproject_text
-        assert "azure-functions-doctor-python>=0.16.0" in pyproject_text
+        assert "azure-functions-openapi>=0.17.0" in pyproject_text
+        assert "azure-functions-validation>=0.7.0" in pyproject_text
+        assert "azure-functions-doctor>=0.16.0" in pyproject_text
         assert "mypy>=1.17.1" in pyproject_text  # strict preset
         assert (project_dir / "app/functions/health.py").exists()
         assert (project_dir / "app/functions/webhooks.py").exists()
@@ -121,9 +121,7 @@ class TestNew:
         assert "webhooks_blueprint" in function_app_text
 
     def test_dry_run(self, tmp_path: Path) -> None:
-        result = runner.invoke(
-            app, ["new", "dry-api", "--destination", str(tmp_path), "--dry-run"]
-        )
+        result = runner.invoke(app, ["new", "dry-api", "--destination", str(tmp_path), "--dry-run"])
         assert result.exit_code == 0
         assert "Dry run: create project at" in result.stdout
         assert not (tmp_path / "dry-api").exists()
@@ -141,9 +139,7 @@ class TestNew:
         assert (project_dir / "function_app.py").exists()
 
     def test_with_azd_flag(self, tmp_path: Path) -> None:
-        result = runner.invoke(
-            app, ["new", "azd-api", "--destination", str(tmp_path), "--azd"]
-        )
+        result = runner.invoke(app, ["new", "azd-api", "--destination", str(tmp_path), "--azd"])
         assert result.exit_code == 0
         assert (tmp_path / "azd-api" / "azure.yaml").exists()
 
@@ -187,6 +183,7 @@ class TestNew:
             if p.is_file()
         )
         assert api_files == new_files
+
 
 # ---------------------------------------------------------------------------
 # afs api add
@@ -376,7 +373,7 @@ class TestAiAgent:
         pyproject_text = (project_dir / "pyproject.toml").read_text(encoding="utf-8")
         assert (project_dir / "app/graphs/echo_agent.py").exists()
         assert "LangGraphApp" in function_app_text
-        assert "azure-functions-langgraph-python>=0.5.1" in pyproject_text
+        assert "azure-functions-langgraph>=0.5.1" in pyproject_text
 
     def test_dry_run(self, tmp_path: Path) -> None:
         result = runner.invoke(
@@ -429,9 +426,9 @@ class TestAdvanced:
         assert result.exit_code == 0
         project_dir = tmp_path / "full-api"
         pyproject_text = (project_dir / "pyproject.toml").read_text(encoding="utf-8")
-        assert "azure-functions-openapi-python>=0.17.0" in pyproject_text
-        assert "azure-functions-validation-python>=0.7.0" in pyproject_text
-        assert "azure-functions-doctor-python>=0.16.0" in pyproject_text
+        assert "azure-functions-openapi>=0.17.0" in pyproject_text
+        assert "azure-functions-validation>=0.7.0" in pyproject_text
+        assert "azure-functions-doctor>=0.16.0" in pyproject_text
         assert (project_dir / "azure.yaml").exists()
 
     def test_new_dry_run(self, tmp_path: Path) -> None:

--- a/tests/test_scaffolder.py
+++ b/tests/test_scaffolder.py
@@ -266,7 +266,7 @@ def test_scaffold_project_generates_expected_project_contract(
     assert "mypy>=1.17.1" in pyproject_text
     assert "pytest>=8.3.5" in pyproject_text
     assert "Preset: `strict`" in readme_text
-    assert "azure-functions-logging-python>=0.5.0" in pyproject_text
+    assert "azure-functions-logging>=0.5.0" in pyproject_text
 
 
 @pytest.mark.parametrize("template_name", ["queue", "blob", "servicebus", "eventhub", "cosmosdb"])
@@ -580,5 +580,5 @@ def test_scaffold_project_renders_langgraph_template(tmp_path: Path) -> None:
     assert "LangGraphApp" in function_app_text
     assert "lg_app.register" in function_app_text
     pyproject_text = (project_path / "pyproject.toml").read_text(encoding="utf-8")
-    assert "azure-functions-langgraph-python>=0.5.1" in pyproject_text
+    assert "azure-functions-langgraph>=0.5.1" in pyproject_text
     assert "langgraph>=0.2.0" in pyproject_text


### PR DESCRIPTION
## Summary

Two related packaging fixes that were blocking install and tests on \`main\`:

1. **Hatch wheel auto-detect failure** — distribution name (\`azure-functions-scaffold-python\` → normalized \`azure_functions_scaffold_python\`) did not match the source layout (\`src/azure_functions_scaffold/\`), so hatchling's auto-discovery produced an empty wheel target and \`pip install\` failed. Declare \`packages = [\"src/azure_functions_scaffold\"]\` explicitly.

2. **Dev/test deps referenced non-existent PyPI names** — the dev extras and \`test_cli_intents\` / \`test_scaffolder\` assertions used \`azure-functions-{logging,openapi,validation,doctor,langgraph,db}-python\`, but those distributions are published unsuffixed on PyPI (\`azure-functions-logging\`, \`azure-functions-openapi\`, \`azure-functions-validation\`, \`azure-functions-doctor\`). The Jinja templates already emit the correct unsuffixed names, so the test fixtures diverged from generator output and the CLI-intent suite failed on every run. Aligns sources with PyPI ground truth.

3. **Ruff UP017 in http template** — \`webhook_service.py.j2\` used \`datetime.timezone.utc\`, which ruff wants to rewrite to \`datetime.UTC\`. The generated project targets Python 3.10+, where \`datetime.UTC\` does not exist, so the rewrite would break runtime. Add \`# noqa: UP017\` to keep \`timezone.utc\` and unblock the strict-preset smoke check.

## Verification

- \`pip install -e '.[dev]' --dry-run\` resolves cleanly against PyPI.
- \`pytest\` (excluding the pre-existing \`test_template_smoke\` PyPI-install flake): **229 passed, 3 skipped**.
- \`pytest tests/test_scaffolder.py::test_simple_trigger_templates_pass_generated_checks[http-strict]\`: **1 passed** (was failing on \`main\`).

## Evidence

PyPI lookups (HTTP 200 = published, 404 = does not exist):

| Name | Status |
|---|---|
| \`azure-functions-logging\` | 200 (0.5.0) |
| \`azure-functions-logging-python\` | 404 |
| \`azure-functions-openapi\` | 200 (0.17.1) |
| \`azure-functions-openapi-python\` | 404 |
| \`azure-functions-validation\` | 200 (0.7.1) |
| \`azure-functions-validation-python\` | 404 |
| \`azure-functions-doctor\` | 200 (0.16.3) |
| \`azure-functions-doctor-python\` | 404 |

Refs: #71