### PR TITLE
fix(templates): default to AuthLevel.FUNCTION and require WEBHOOK_SECRET

### DIFF
--- a/src/azure_functions_scaffold/generator.py
+++ b/src/azure_functions_scaffold/generator.py
@@ -273,7 +273,7 @@ import azure.functions as func
 @{function_name}_blueprint.route(
     route="{route_name}",
     methods=["GET"],
-    auth_level=func.AuthLevel.ANONYMOUS,
+    auth_level=func.AuthLevel.FUNCTION,
 )
 def {function_name}(req: func.HttpRequest) -> func.HttpResponse:
     return func.HttpResponse(
@@ -424,7 +424,7 @@ import azure.functions.durable_functions as df
 @{function_name}_blueprint.route(
     route="orchestrators/{{functionName}}",
     methods=["POST"],
-    auth_level=func.AuthLevel.ANONYMOUS,
+    auth_level=func.AuthLevel.FUNCTION,
 )
 @{function_name}_blueprint.durable_client_input(client_name="client")
 async def {function_name}_http_start(
@@ -464,7 +464,7 @@ import azure.functions as func
 @{function_name}_blueprint.route(
     route="chat",
     methods=["POST"],
-    auth_level=func.AuthLevel.ANONYMOUS,
+    auth_level=func.AuthLevel.FUNCTION,
 )
 async def {function_name}(req: func.HttpRequest) -> func.HttpResponse:
     try:

--- a/src/azure_functions_scaffold/templates/ai/app/functions/ai.py.j2
+++ b/src/azure_functions_scaffold/templates/ai/app/functions/ai.py.j2
@@ -13,7 +13,7 @@ ai_blueprint = func.Blueprint()  # type: ignore[no-untyped-call]
 @ai_blueprint.route(
     route="chat",
     methods=["POST"],
-    auth_level=func.AuthLevel.ANONYMOUS,
+    auth_level=func.AuthLevel.FUNCTION,
 )
 async def chat(req: func.HttpRequest) -> func.HttpResponse:
     try:

--- a/src/azure_functions_scaffold/templates/durable/app/functions/durable.py.j2
+++ b/src/azure_functions_scaffold/templates/durable/app/functions/durable.py.j2
@@ -13,7 +13,7 @@ durable_blueprint = func.Blueprint()  # type: ignore[no-untyped-call]
 @durable_blueprint.route(
     route="orchestrators/{functionName}",
     methods=["POST"],
-    auth_level=func.AuthLevel.ANONYMOUS,
+    auth_level=func.AuthLevel.FUNCTION,
 )
 @durable_blueprint.durable_client_input(client_name="client")
 async def http_start(

--- a/src/azure_functions_scaffold/templates/http/README.md.j2
+++ b/src/azure_functions_scaffold/templates/http/README.md.j2
@@ -58,6 +58,12 @@ Validation: enabled — request/response models validated via `azure-functions-v
 - `local.settings.json.example` documents required local app settings.
 - `app/core/config.py` reads application settings from environment variables.
 
+## Webhook security
+
+`WEBHOOK_SECRET` is required for `POST /api/webhooks/inbound`.
+Set it in `local.settings.json` for local development by copying the placeholder from `local.settings.json.example` and replacing it with a strong random string.
+Until `WEBHOOK_SECRET` is configured, the webhook endpoint returns `503 Service Unavailable`.
+
 {% if include_validation %}
 ## Validation
 

--- a/src/azure_functions_scaffold/templates/http/app/functions/webhooks.py.j2
+++ b/src/azure_functions_scaffold/templates/http/app/functions/webhooks.py.j2
@@ -31,7 +31,10 @@ webhooks_blueprint = func.Blueprint()  # type: ignore[no-untyped-call]
 {% if include_openapi -%}
 @openapi(
     summary="Receive inbound webhook",
-    description="Accepts a webhook event for asynchronous processing. Returns 202 when the delivery is accepted.",
+    description=(
+        "Accepts a webhook event for asynchronous processing. "
+        "Returns 202 when the delivery is accepted."
+    ),
     tags=["webhooks"],
 {%- if include_validation %}
     request_model=WebhookEvent,

--- a/src/azure_functions_scaffold/templates/http/app/functions/webhooks.py.j2
+++ b/src/azure_functions_scaffold/templates/http/app/functions/webhooks.py.j2
@@ -26,7 +26,7 @@ webhooks_blueprint = func.Blueprint()  # type: ignore[no-untyped-call]
 @webhooks_blueprint.route(
     route="webhooks/inbound",
     methods=["POST"],
-    auth_level=func.AuthLevel.ANONYMOUS,
+    auth_level=func.AuthLevel.FUNCTION,
 )
 {% if include_openapi -%}
 @openapi(
@@ -53,16 +53,23 @@ webhooks_blueprint = func.Blueprint()  # type: ignore[no-untyped-call]
 {% endif -%}
 def receive_webhook(req: func.HttpRequest) -> func.HttpResponse:
     # --- Signature verification (must run before body parsing) ---
-    secret = get_webhook_secret()
-    if secret:
-        signature = req.headers.get("X-Signature", "")
-        if not verify_signature(req.get_body(), signature, secret):
-            logging.warning("Webhook signature verification failed")
-            return func.HttpResponse(
-                body=json.dumps({"error": "Invalid signature"}),
-                mimetype="application/json",
-                status_code=401,
-            )
+    try:
+        secret = get_webhook_secret()
+    except RuntimeError:
+        return func.HttpResponse(
+            body=json.dumps({"error": "Webhook signing secret not configured"}),
+            mimetype="application/json",
+            status_code=503,
+        )
+
+    signature = req.headers.get("X-Signature", "")
+    if not verify_signature(req.get_body(), signature, secret):
+        logging.warning("Webhook signature verification failed")
+        return func.HttpResponse(
+            body=json.dumps({"error": "Invalid signature"}),
+            mimetype="application/json",
+            status_code=401,
+        )
 
 {%- if include_validation %}
     # --- Body validation (after auth) ---

--- a/src/azure_functions_scaffold/templates/http/app/schemas/webhooks.py.j2
+++ b/src/azure_functions_scaffold/templates/http/app/schemas/webhooks.py.j2
@@ -15,7 +15,9 @@ class WebhookEvent(BaseModel):
 class WebhookAcceptedResponse(BaseModel):
     delivery_id: str = Field(..., description="Unique delivery identifier.")
     status: str = Field(default="accepted", description="Processing status.")
-    received_at: str = Field(..., description="ISO-8601 timestamp of when the webhook was received.")
+    received_at: str = Field(
+        ..., description="ISO-8601 timestamp of when the webhook was received."
+    )
 {%- else %}
 from dataclasses import dataclass, field
 from typing import Any

--- a/src/azure_functions_scaffold/templates/http/app/services/webhook_service.py.j2
+++ b/src/azure_functions_scaffold/templates/http/app/services/webhook_service.py.j2
@@ -78,9 +78,12 @@ class WebhookStore:
         self._deliveries.clear()
 
 
-def get_webhook_secret() -> str | None:
-    """Return the webhook secret from environment, or ``None`` if unset."""
-    return os.environ.get("WEBHOOK_SECRET") or None
+def get_webhook_secret() -> str:
+    """Return the webhook secret from environment."""
+    secret = os.environ.get("WEBHOOK_SECRET", "")
+    if not secret:
+        raise RuntimeError("WEBHOOK_SECRET is not configured")
+    return secret
 
 
 webhook_store = WebhookStore()

--- a/src/azure_functions_scaffold/templates/http/local.settings.json.example.j2
+++ b/src/azure_functions_scaffold/templates/http/local.settings.json.example.j2
@@ -2,6 +2,7 @@
   "IsEncrypted": false,
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-    "FUNCTIONS_WORKER_RUNTIME": "python"
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "WEBHOOK_SECRET": "replace-with-strong-random-string"
   }
 }

--- a/src/azure_functions_scaffold/templates/http/tests/test_webhooks.py.j2
+++ b/src/azure_functions_scaffold/templates/http/tests/test_webhooks.py.j2
@@ -46,14 +46,20 @@ VALID_PAYLOAD = json.dumps({
 class TestReceiveWebhook:
     def test_accepts_valid_webhook(self) -> None:
         webhook_store.clear()
+        secret = "test-secret-key"
+        signature = _sign(VALID_PAYLOAD, secret)
 
-        request = _make_request(
-            "POST",
-            "http://localhost/api/webhooks/inbound",
-            body=VALID_PAYLOAD,
-            headers={"Content-Type": "application/json"},
-        )
-        response = receive_webhook(request)
+        with patch.dict(os.environ, {"WEBHOOK_SECRET": secret}):
+            request = _make_request(
+                "POST",
+                "http://localhost/api/webhooks/inbound",
+                body=VALID_PAYLOAD,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Signature": signature,
+                },
+            )
+            response = receive_webhook(request)
 
         assert response.status_code == 202
         body = json.loads(response.get_body())
@@ -63,27 +69,40 @@ class TestReceiveWebhook:
 
     def test_returns_400_for_invalid_json(self) -> None:
         webhook_store.clear()
+        secret = "test-secret-key"
+        signature = _sign(b"not-json", secret)
 
-        request = _make_request(
-            "POST",
-            "http://localhost/api/webhooks/inbound",
-            body=b"not-json",
-            headers={"Content-Type": "application/json"},
-        )
-        response = receive_webhook(request)
+        with patch.dict(os.environ, {"WEBHOOK_SECRET": secret}):
+            request = _make_request(
+                "POST",
+                "http://localhost/api/webhooks/inbound",
+                body=b"not-json",
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Signature": signature,
+                },
+            )
+            response = receive_webhook(request)
 
         assert response.status_code == 400
 {% if not include_validation %}
     def test_returns_400_for_non_object_json(self) -> None:
         webhook_store.clear()
+        payload = json.dumps(["not", "an", "object"]).encode()
+        secret = "test-secret-key"
+        signature = _sign(payload, secret)
 
-        request = _make_request(
-            "POST",
-            "http://localhost/api/webhooks/inbound",
-            body=json.dumps(["not", "an", "object"]).encode(),
-            headers={"Content-Type": "application/json"},
-        )
-        response = receive_webhook(request)
+        with patch.dict(os.environ, {"WEBHOOK_SECRET": secret}):
+            request = _make_request(
+                "POST",
+                "http://localhost/api/webhooks/inbound",
+                body=payload,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Signature": signature,
+                },
+            )
+            response = receive_webhook(request)
 
         assert response.status_code == 400
         body = json.loads(response.get_body())
@@ -91,14 +110,21 @@ class TestReceiveWebhook:
 
     def test_returns_400_for_missing_required_fields(self) -> None:
         webhook_store.clear()
+        payload = json.dumps({"data": {}}).encode()
+        secret = "test-secret-key"
+        signature = _sign(payload, secret)
 
-        request = _make_request(
-            "POST",
-            "http://localhost/api/webhooks/inbound",
-            body=json.dumps({"data": {}}).encode(),
-            headers={"Content-Type": "application/json"},
-        )
-        response = receive_webhook(request)
+        with patch.dict(os.environ, {"WEBHOOK_SECRET": secret}):
+            request = _make_request(
+                "POST",
+                "http://localhost/api/webhooks/inbound",
+                body=payload,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Signature": signature,
+                },
+            )
+            response = receive_webhook(request)
 
         assert response.status_code == 400
         body = json.loads(response.get_body())
@@ -107,14 +133,21 @@ class TestReceiveWebhook:
 {% if include_validation %}
     def test_returns_422_for_invalid_schema(self) -> None:
         webhook_store.clear()
+        payload = json.dumps({"data": {}}).encode()
+        secret = "test-secret-key"
+        signature = _sign(payload, secret)
 
-        request = _make_request(
-            "POST",
-            "http://localhost/api/webhooks/inbound",
-            body=json.dumps({"data": {}}).encode(),
-            headers={"Content-Type": "application/json"},
-        )
-        response = receive_webhook(request)
+        with patch.dict(os.environ, {"WEBHOOK_SECRET": secret}):
+            request = _make_request(
+                "POST",
+                "http://localhost/api/webhooks/inbound",
+                body=payload,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Signature": signature,
+                },
+            )
+            response = receive_webhook(request)
 
         assert response.status_code == 422
         body = json.loads(response.get_body())
@@ -122,14 +155,21 @@ class TestReceiveWebhook:
 
     def test_returns_422_for_non_object_json(self) -> None:
         webhook_store.clear()
+        payload = json.dumps(["not", "an", "object"]).encode()
+        secret = "test-secret-key"
+        signature = _sign(payload, secret)
 
-        request = _make_request(
-            "POST",
-            "http://localhost/api/webhooks/inbound",
-            body=json.dumps(["not", "an", "object"]).encode(),
-            headers={"Content-Type": "application/json"},
-        )
-        response = receive_webhook(request)
+        with patch.dict(os.environ, {"WEBHOOK_SECRET": secret}):
+            request = _make_request(
+                "POST",
+                "http://localhost/api/webhooks/inbound",
+                body=payload,
+                headers={
+                    "Content-Type": "application/json",
+                    "X-Signature": signature,
+                },
+            )
+            response = receive_webhook(request)
 
         assert response.status_code == 422
 {% endif %}
@@ -171,12 +211,10 @@ class TestWebhookSignatureVerification:
 
         assert response.status_code == 202
 
-    def test_skips_verification_when_no_secret(self) -> None:
+    def test_returns_503_when_secret_is_not_configured(self) -> None:
         webhook_store.clear()
 
         with patch.dict(os.environ, {}, clear=True):
-            # Ensure WEBHOOK_SECRET is not set
-            os.environ.pop("WEBHOOK_SECRET", None)
             request = _make_request(
                 "POST",
                 "http://localhost/api/webhooks/inbound",
@@ -185,7 +223,9 @@ class TestWebhookSignatureVerification:
             )
             response = receive_webhook(request)
 
-        assert response.status_code == 202
+        assert response.status_code == 503
+        body = json.loads(response.get_body())
+        assert body["error"] == "Webhook signing secret not configured"
 {% if include_validation %}
 
     def test_returns_401_before_422_when_secret_set(self) -> None:

--- a/src/azure_functions_scaffold/templates/langgraph/README.md.j2
+++ b/src/azure_functions_scaffold/templates/langgraph/README.md.j2
@@ -13,6 +13,9 @@ Python: `{{ python_version }}`
 
 Template: `langgraph` — deploys a LangGraph agent on Azure Functions.
 
+The generated LangGraph app currently keeps `func.AuthLevel.ANONYMOUS` by default.
+Review that setting before exposing the endpoints outside trusted environments.
+
 ## Development
 
 ```bash

--- a/src/azure_functions_scaffold/templates/partials/resource_blueprint.py.j2
+++ b/src/azure_functions_scaffold/templates/partials/resource_blueprint.py.j2
@@ -17,7 +17,7 @@ from app.services.{{ resource_name }}_service import {{ resource_name }}_store
 @{{ resource_name }}_blueprint.route(
     route="{{ route_name }}",
     methods=["GET"],
-    auth_level=func.AuthLevel.ANONYMOUS,
+    auth_level=func.AuthLevel.FUNCTION,
 )
 def list_{{ resource_name }}(req: func.HttpRequest) -> func.HttpResponse:
     logging.info("Listing all {{ route_name }}")
@@ -35,7 +35,7 @@ def list_{{ resource_name }}(req: func.HttpRequest) -> func.HttpResponse:
 @{{ resource_name }}_blueprint.route(
     route="{{ route_name }}/{item_id}",
     methods=["GET"],
-    auth_level=func.AuthLevel.ANONYMOUS,
+    auth_level=func.AuthLevel.FUNCTION,
 )
 def get_{{ resource_singular }}(req: func.HttpRequest) -> func.HttpResponse:
     item_id = req.route_params.get("item_id", "")
@@ -62,7 +62,7 @@ def get_{{ resource_singular }}(req: func.HttpRequest) -> func.HttpResponse:
 @{{ resource_name }}_blueprint.route(
     route="{{ route_name }}",
     methods=["POST"],
-    auth_level=func.AuthLevel.ANONYMOUS,
+    auth_level=func.AuthLevel.FUNCTION,
 )
 def create_{{ resource_singular }}(req: func.HttpRequest) -> func.HttpResponse:
     try:
@@ -102,7 +102,7 @@ def create_{{ resource_singular }}(req: func.HttpRequest) -> func.HttpResponse:
 @{{ resource_name }}_blueprint.route(
     route="{{ route_name }}/{item_id}",
     methods=["PUT"],
-    auth_level=func.AuthLevel.ANONYMOUS,
+    auth_level=func.AuthLevel.FUNCTION,
 )
 def update_{{ resource_singular }}(req: func.HttpRequest) -> func.HttpResponse:
     item_id = req.route_params.get("item_id", "")
@@ -143,7 +143,7 @@ def update_{{ resource_singular }}(req: func.HttpRequest) -> func.HttpResponse:
 @{{ resource_name }}_blueprint.route(
     route="{{ route_name }}/{item_id}",
     methods=["DELETE"],
-    auth_level=func.AuthLevel.ANONYMOUS,
+    auth_level=func.AuthLevel.FUNCTION,
 )
 def delete_{{ resource_singular }}(req: func.HttpRequest) -> func.HttpResponse:
     item_id = req.route_params.get("item_id", "")

--- a/src/azure_functions_scaffold/templates/partials/route_blueprint.py.j2
+++ b/src/azure_functions_scaffold/templates/partials/route_blueprint.py.j2
@@ -9,7 +9,7 @@ import logging
 @{{ resource_name }}_blueprint.route(
     route="{{ route_name }}",
     methods=["GET"],
-    auth_level=func.AuthLevel.ANONYMOUS,
+    auth_level=func.AuthLevel.FUNCTION,
 )
 def {{ resource_name }}(req: func.HttpRequest) -> func.HttpResponse:
     logging.info("{{ route_name }} endpoint called")

--- a/tests/test_template_smoke.py
+++ b/tests/test_template_smoke.py
@@ -257,7 +257,7 @@ def test_rendered_http_webhook_returns_503_when_secret_missing(tmp_path: Path) -
 
     sys.path.insert(0, str(project_root))
     try:
-        from app.functions.webhooks import receive_webhook  # type: ignore[import-not-found]
+        from app.functions.webhooks import receive_webhook
         import azure.functions as func
 
         request = func.HttpRequest(
@@ -306,7 +306,7 @@ def test_rendered_http_webhook_returns_401_for_unsigned_payload_when_secret_set(
 
     sys.path.insert(0, str(project_root))
     try:
-        from app.functions.webhooks import receive_webhook  # type: ignore[import-not-found]
+        from app.functions.webhooks import receive_webhook
         import azure.functions as func
 
         payload = json.dumps({"event_type": "ping", "source": "test"}).encode()

--- a/tests/test_template_smoke.py
+++ b/tests/test_template_smoke.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import ast
 import importlib
+import json
 import os
 from pathlib import Path
 import subprocess
@@ -185,6 +186,7 @@ def test_rendered_strict_http_project_tests_pass(tmp_path: Path) -> None:
         text=True,
         env={
             **os.environ,
+            "WEBHOOK_SECRET": "test-secret-key",
             "PYTHONPATH": os.pathsep.join(
                 filter(None, [str(project_root), os.environ.get("PYTHONPATH", "")])
             ),
@@ -223,6 +225,7 @@ def test_rendered_standard_http_project_tests_pass(tmp_path: Path) -> None:
         text=True,
         env={
             **os.environ,
+            "WEBHOOK_SECRET": "test-secret-key",
             "PYTHONPATH": os.pathsep.join(
                 filter(None, [str(project_root), os.environ.get("PYTHONPATH", "")])
             ),
@@ -233,3 +236,102 @@ def test_rendered_standard_http_project_tests_pass(tmp_path: Path) -> None:
         f"stdout:\n{result.stdout}\n"
         f"stderr:\n{result.stderr}"
     )
+
+
+def test_rendered_http_webhook_returns_503_when_secret_missing(tmp_path: Path) -> None:
+    options = build_project_options(
+        preset_name="standard",
+        python_version="3.10",
+        include_github_actions=False,
+        initialize_git=False,
+        include_openapi=False,
+        include_validation=False,
+        include_doctor=False,
+    )
+    project_root = scaffold_project(
+        project_name="webhook-secret-missing",
+        destination=tmp_path,
+        template_name="http",
+        options=options,
+    )
+
+    sys.path.insert(0, str(project_root))
+    try:
+        from app.functions.webhooks import receive_webhook  # type: ignore[import-not-found]
+        import azure.functions as func
+
+        request = func.HttpRequest(
+            method="POST",
+            url="http://localhost/api/webhooks/inbound",
+            params={},
+            body=json.dumps({"event_type": "ping", "source": "test"}).encode(),
+            route_params={},
+            headers={"Content-Type": "application/json"},
+        )
+
+        original_secret = os.environ.pop("WEBHOOK_SECRET", None)
+        try:
+            response = receive_webhook(request)
+        finally:
+            if original_secret is not None:
+                os.environ["WEBHOOK_SECRET"] = original_secret
+    finally:
+        sys.path.pop(0)
+        for module_name in list(sys.modules):
+            if module_name == "app" or module_name.startswith("app."):
+                del sys.modules[module_name]
+
+    assert response.status_code == 503
+    assert json.loads(response.get_body()) == {"error": "Webhook signing secret not configured"}
+
+
+def test_rendered_http_webhook_returns_401_for_unsigned_payload_when_secret_set(
+    tmp_path: Path,
+) -> None:
+    options = build_project_options(
+        preset_name="standard",
+        python_version="3.10",
+        include_github_actions=False,
+        initialize_git=False,
+        include_openapi=False,
+        include_validation=False,
+        include_doctor=False,
+    )
+    project_root = scaffold_project(
+        project_name="webhook-secret-set",
+        destination=tmp_path,
+        template_name="http",
+        options=options,
+    )
+
+    sys.path.insert(0, str(project_root))
+    try:
+        from app.functions.webhooks import receive_webhook  # type: ignore[import-not-found]
+        import azure.functions as func
+
+        payload = json.dumps({"event_type": "ping", "source": "test"}).encode()
+        request = func.HttpRequest(
+            method="POST",
+            url="http://localhost/api/webhooks/inbound",
+            params={},
+            body=payload,
+            route_params={},
+            headers={"Content-Type": "application/json", "X-Signature": ""},
+        )
+
+        original_secret = os.environ.get("WEBHOOK_SECRET")
+        os.environ["WEBHOOK_SECRET"] = "test-secret-key"
+        try:
+            response = receive_webhook(request)
+        finally:
+            if original_secret is None:
+                del os.environ["WEBHOOK_SECRET"]
+            else:
+                os.environ["WEBHOOK_SECRET"] = original_secret
+    finally:
+        sys.path.pop(0)
+        for module_name in list(sys.modules):
+            if module_name == "app" or module_name.startswith("app."):
+                del sys.modules[module_name]
+
+    assert response.status_code == 401


### PR DESCRIPTION
## Summary
- Anonymous defaults across business HTTP endpoints (webhook receiver, AI chat, durable orchestrator, route/resource partials, and the generator's inline trigger code) made every freshly-scaffolded project publicly callable from minute one. AI endpoints in particular had unbounded cost/abuse exposure.
- The webhook receiver also failed open: when \`WEBHOOK_SECRET\` was unset, signature verification was silently skipped and the endpoint accepted any payload.

## Changes
- Switch \`auth_level\` from \`ANONYMOUS\` to \`FUNCTION\` for all business HTTP endpoints across \`http\`, \`ai\`, \`durable\`, \`partials/{route,resource}_blueprint.py.j2\`, and the inline templates in \`generator.py\`.
- **Keep \`health.py.j2\` anonymous** — load-balancer probes need anonymous access.
- **Keep \`langgraph/function_app.py.j2\` anonymous for now** — documented in its README; will be revisited.
- \`get_webhook_secret()\` now raises \`RuntimeError\` instead of returning \`None\`. The webhook handler returns **503 Service Unavailable** when the secret is unconfigured, making the endpoint fail-closed by default.
- Add \`WEBHOOK_SECRET\` to \`local.settings.json.example\` with a placeholder.
- Document the new contract in the http template README.
- Update \`tests/test_template_smoke.py\` and the generated \`test_webhooks.py.j2\` to cover the configured/unconfigured/invalid-signature paths.

## Verification
- \`pytest tests\` — 238 passed, 3 skipped.
- Coverage 96.50%.
- \`ruff check src tests\` — clean.
- \`mypy src\` — clean.

## ⚠️ BREAKING CHANGE
Newly-scaffolded projects now require:
1. A function key (or upgraded auth) for previously-anonymous endpoints.
2. \`WEBHOOK_SECRET\` to be set before the webhook accepts traffic.

These are deliberate hardening changes intended for the **0.6.0** release. Migration notes will land with the version bump PR.

## Scope
P0 of the full code-review action plan. Independent of #81 / #82.