### PR TITLE
fix(generator): split ADDABLE_TRIGGERS from SUPPORTED_TRIGGERS

### DIFF
--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -131,6 +131,7 @@ Use for adding triggers to existing projects:
 - `add_function(...)`
 - `describe_add_function(...)`
 - `SUPPORTED_TRIGGERS`
+- `ADDABLE_TRIGGERS` - Tuple of trigger names that can be added to an existing project via 'afs advanced add'. Excludes templates (e.g. langgraph) that only support full project creation.
 
 ### `azure_functions_scaffold.template_registry`
 

--- a/src/azure_functions_scaffold/cli_advanced.py
+++ b/src/azure_functions_scaffold/cli_advanced.py
@@ -18,7 +18,7 @@ from azure_functions_scaffold.cli_common import (
 )
 from azure_functions_scaffold.errors import ScaffoldError
 from azure_functions_scaffold.generator import (
-    SUPPORTED_TRIGGERS,
+    ADDABLE_TRIGGERS,
     add_function,
     add_resource,
     add_route,
@@ -193,7 +193,7 @@ def advanced_add(
         str,
         typer.Argument(
             ...,
-            help=f"Trigger type to add. Supported: {', '.join(SUPPORTED_TRIGGERS)}",
+            help=f"Trigger type to add. Supported: {', '.join(ADDABLE_TRIGGERS)}",
         ),
     ],
     function_name: Annotated[

--- a/src/azure_functions_scaffold/generator.py
+++ b/src/azure_functions_scaffold/generator.py
@@ -17,6 +17,17 @@ FUNCTION_REGISTRATION_MARKER = "# azure-functions-scaffold: function registratio
 LEGACY_FUNCTION_IMPORT_MARKER = "# azure-functions-scaffold-python: function imports"
 LEGACY_FUNCTION_REGISTRATION_MARKER = "# azure-functions-scaffold-python: function registrations"
 SUPPORTED_TRIGGERS = tuple(template.name for template in list_templates())
+ADDABLE_TRIGGERS: tuple[str, ...] = (
+    "http",
+    "timer",
+    "queue",
+    "blob",
+    "servicebus",
+    "eventhub",
+    "cosmosdb",
+    "durable",
+    "ai",
+)
 PARTIALS_ROOT = Path(__file__).parent / "templates" / "partials"
 HOST_JSON_TRIGGERS = frozenset({"queue", "blob", "servicebus", "eventhub", "cosmosdb"})
 logger = logging.getLogger(__name__)
@@ -336,8 +347,8 @@ def describe_add_function(
 
 def _normalize_trigger(trigger: str) -> str:
     normalized = trigger.strip().lower()
-    if normalized not in SUPPORTED_TRIGGERS:
-        supported = ", ".join(SUPPORTED_TRIGGERS)
+    if normalized not in ADDABLE_TRIGGERS:
+        supported = ", ".join(ADDABLE_TRIGGERS)
         raise ScaffoldError(f"Unsupported trigger '{trigger}'. Supported triggers: {supported}")
     return normalized
 

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -9,10 +9,12 @@ import pytest
 
 from azure_functions_scaffold.errors import ScaffoldError
 from azure_functions_scaffold.generator import (
+    ADDABLE_TRIGGERS,
     FUNCTION_IMPORT_MARKER,
     FUNCTION_REGISTRATION_MARKER,
     _derive_resource_names,
     _insert_near_marker,
+    _normalize_trigger,
     _render_function_module,
     _render_function_test,
     _update_function_app,
@@ -205,6 +207,7 @@ def test_add_function_succeeds_atomically_for_queue_trigger(tmp_path: Path) -> N
     function_app_text = function_app_path.read_text(encoding="utf-8")
     assert "from app.functions.foo import foo_blueprint" in function_app_text
     assert "app.register_functions(foo_blueprint)" in function_app_text
+
 
 def test_add_function_can_skip_test_generation_for_minimal_preset(tmp_path: Path) -> None:
     project_root = scaffold_project(
@@ -547,6 +550,20 @@ def test_render_function_test_raises_for_unknown_trigger() -> None:
     """Test that _render_function_test raises error for unknown trigger."""
     with pytest.raises(ScaffoldError, match="No function test template for trigger"):
         _render_function_test(trigger="unknown", function_name="test_func")
+
+
+def test_normalize_trigger_rejects_langgraph(tmp_path: Path) -> None:
+    """Test that add_function rejects langgraph before filesystem writes."""
+    with pytest.raises(ScaffoldError, match="langgraph|Unsupported trigger"):
+        add_function(project_root=tmp_path, trigger="langgraph", function_name="foo")
+
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.parametrize("trigger", ADDABLE_TRIGGERS)
+def test_normalize_trigger_accepts_all_addable(trigger: str) -> None:
+    """Test that _normalize_trigger accepts every addable trigger unchanged."""
+    assert _normalize_trigger(trigger) == trigger
 
 
 def test_add_function_with_http_trigger_skips_host_extensions(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary
- `afs advanced add langgraph <name>` advertised `langgraph` as a valid `--trigger` and only failed deep in code generation with a generic error. langgraph is a full-project template (`afs ai agent`), not an addable trigger.
- Introduce `ADDABLE_TRIGGERS` as the authoritative list for `_normalize_trigger` and the `afs advanced add` CLI help.
- Keep `SUPPORTED_TRIGGERS` for backward compatibility (still derived from `list_templates()` and re-exported).

## Verification
- `pytest tests` — green, coverage >= 90%.
- `ruff check src tests` — clean.
- `mypy src` — clean.
- New tests cover the langgraph rejection path and the full ADDABLE_TRIGGERS positive path.

## Scope
P1-4 of the post-review remediation plan. Independent of #81 / #82 / #83.