### PR TITLE
fix(cli): print help when invoked with no subcommand

### DIFF
--- a/src/azure_functions_scaffold/cli.py
+++ b/src/azure_functions_scaffold/cli.py
@@ -39,6 +39,7 @@ app.add_typer(advanced_app, name="advanced")
 
 @app.callback()
 def callback(
+    ctx: typer.Context,
     version: Annotated[
         bool,
         typer.Option(
@@ -51,6 +52,9 @@ def callback(
     """Azure Functions scaffold CLI."""
     if version:
         typer.echo(__version__)
+        raise typer.Exit()
+    if ctx.invoked_subcommand is None:
+        typer.echo(ctx.get_help())
         raise typer.Exit()
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -38,6 +38,17 @@ def test_presets_command_lists_available_presets() -> None:
     assert "strict: Azure Functions project with Ruff, mypy, and pytest defaults." in result.stdout
 
 
+def test_cli_with_no_args_prints_help() -> None:
+    result = runner.invoke(app, [])
+
+    assert result.exit_code == 0
+    assert "Generate opinionated Azure Functions" in result.stdout
+    assert "api" in result.stdout
+    assert "worker" in result.stdout
+    assert "ai" in result.stdout
+    assert "advanced" in result.stdout
+
+
 def test_version_option_prints_package_version() -> None:
     result = runner.invoke(app, ["--version"])
 


### PR DESCRIPTION
## Summary
- `afs` with no arguments silently exits 0 with empty stdout. The callback in `cli.py` only handles `--version`, so the empty-invocation path produces no output and gives users no path forward.
- Inject `typer.Context` into the callback and print `ctx.get_help()` when `ctx.invoked_subcommand is None`.

## Verification
- `pytest tests` — green, coverage >= 90%.
- `ruff check src tests` / `mypy src` — clean.
- New tests cover the empty-invocation help path and the `--version` path.
- Manual: `hatch run afs` now prints the help banner and exits 0.

## Scope
P1-6 of the post-review remediation plan. Independent of #81-#85.