### PR TITLE
fix(cli): add deprecation shims for legacy 'add' and 'profiles'

### DIFF
--- a/docs/examples/full_stack.md
+++ b/docs/examples/full_stack.md
@@ -93,19 +93,19 @@ curl "http://localhost:7071/api/openapi.json"
 Add a product list endpoint:
 
 ```bash
-afs add http list_products --project-root .
+afs api add list_products --project-root .
 ```
 
 Add an order status endpoint:
 
 ```bash
-afs add http get_order_status --project-root .
+afs api add get_order_status --project-root .
 ```
 
 Use dry-run before either change if needed:
 
 ```bash
-afs add http get_order_status --project-root . --dry-run
+afs api add get_order_status --project-root . --dry-run
 ```
 
 ## 6) Add Service Layer and Contracts

--- a/docs/examples/http_api.md
+++ b/docs/examples/http_api.md
@@ -84,10 +84,10 @@ http://localhost:7071/api/docs
 
 ## 4) Add a New HTTP Endpoint Module
 
-Use `afs add` to add a second endpoint scaffold:
+Use `afs api add` to add a second endpoint scaffold:
 
 ```bash
-afs add http users --project-root .
+afs api add users --project-root .
 ```
 
 This command:
@@ -99,7 +99,7 @@ This command:
 Preview before writing if needed:
 
 ```bash
-afs add http users --project-root . --dry-run
+afs api add users --project-root . --dry-run
 ```
 
 ## 5) Customize the New Endpoint

--- a/docs/examples/timer_job.md
+++ b/docs/examples/timer_job.md
@@ -115,13 +115,13 @@ then restore production cadence.
 Add another timer function module:
 
 ```bash
-afs add timer cleanup_cache --project-root .
+afs advanced add timer cleanup_cache --project-root .
 ```
 
 Preview first if preferred:
 
 ```bash
-afs add timer cleanup_cache --project-root . --dry-run
+afs advanced add timer cleanup_cache --project-root . --dry-run
 ```
 
 After adding, verify:

--- a/docs/examples/worker_triggers.md
+++ b/docs/examples/worker_triggers.md
@@ -154,13 +154,13 @@ Watch the terminal for log output confirming message processing.
 Add another function module to the same project:
 
 ```bash
-afs add queue cleanup --project-root .
+afs advanced add queue cleanup --project-root .
 ```
 
 Preview before writing if needed:
 
 ```bash
-afs add queue cleanup --project-root . --dry-run
+afs advanced add queue cleanup --project-root . --dry-run
 ```
 
 After adding, verify:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -31,7 +31,7 @@ If you need custom templates today:
 1. Fork or clone the project source.
 2. Add a new folder under `src/azure_functions_scaffold/templates/`.
 3. Register it in `src/azure_functions_scaffold/template_registry.py`.
-4. Add tests for generation and `afs add` behavior.
+4. Add tests for generation and function-add behavior.
 
 See [Template Specification](reference/template-spec.md) for format rules.
 
@@ -59,7 +59,7 @@ afs presets
 
 Yes for scaffolding, no for local runtime and deployment.
 
-- You can generate files with `afs new` and `afs add` without Core Tools.
+- You can generate files with `afs new`, `afs api add`, and `afs advanced add` without Core Tools.
 - You need Core Tools (`func`) to run `func start` locally.
 - You typically need Core Tools for `func azure functionapp publish ...`.
 
@@ -109,7 +109,7 @@ Yes when pytest tooling is enabled.
 - `standard` and `strict` presets include pytest and generate tests.
 - `minimal` preset does not include pytest by default.
 
-When adding functions with `afs add`, test files are created if a `tests/`
+When adding functions with `afs api add` or `afs advanced add`, test files are created if a `tests/`
 directory exists in the project.
 
 ## Does `afs` differ from `azure-functions-scaffold-python`?
@@ -129,7 +129,7 @@ Yes. Use `--dry-run` on both project creation and add flows.
 
 ```bash
 afs new my-api --preset strict --dry-run
-afs add queue process_orders --project-root ./my-api --dry-run
+afs advanced add queue process_orders --project-root ./my-api --dry-run
 ```
 
 ## Where should I start next?

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -23,7 +23,8 @@ The scaffold follows three principles:
 You will primarily configure projects through:
 
 - `afs new <name>` for project creation.
-- `afs add <trigger> <name>` for adding new function modules.
+- `afs api add <name>` for adding HTTP function modules.
+- `afs advanced add <trigger> <name>` for adding non-HTTP function modules.
 
 `afs` is a short alias for `azure-functions-scaffold-python` and behaves exactly the
 same.
@@ -175,7 +176,7 @@ afs new my-api --preset strict --with-openapi --dry-run
 For project expansion:
 
 ```bash
-afs add timer cleanup --project-root ./my-api --dry-run
+afs advanced add timer cleanup --project-root ./my-api --dry-run
 ```
 
 Dry-run output includes:
@@ -188,7 +189,8 @@ Dry-run output includes:
 ## `add` Command Configuration
 
 ```bash
-afs add <trigger> <function-name> --project-root <path>
+afs api add <function-name> --project-root <path>
+afs advanced add <trigger> <function-name> --project-root <path>
 ```
 
 Supported triggers:
@@ -206,7 +208,7 @@ Options:
 | `--project-root` | `.` | Existing scaffolded project directory. |
 | `--dry-run` | `False` | Preview files and updates without writing. |
 
-When successful, `add` updates `function_app.py` markers and may update
+When successful, these commands update `function_app.py` markers and may update
 `host.json` or `local.settings.json.example` depending on trigger type.
 
 ## Naming and Validation Rules
@@ -222,7 +224,7 @@ Examples:
 - valid: `my-api`, `worker_v2`, `orders2026`
 - invalid: `my api`, `-api`, `api!`
 
-Function names added through `afs add` are normalized to Python module names.
+Function names added through `afs api add` or `afs advanced add` are normalized to Python module names.
 For example, `Process Orders` becomes `process_orders`.
 
 ## Related Guides

--- a/docs/guide/expanding.md
+++ b/docs/guide/expanding.md
@@ -1,13 +1,14 @@
 # Expanding Your Project
 
-The `add` command allows you to add new triggers to an existing project while maintaining the Blueprint structure. It automatically handles trigger registration in `function_app.py`.
+The `afs api add` and `afs advanced add` commands let you add new triggers to an existing project while maintaining the Blueprint structure. They automatically handle trigger registration in `function_app.py`.
 
-### The `add` Command
+### Add Commands
 
-Use the `add` command to append new function modules to your project root.
+Use `afs api add` for HTTP functions and `afs advanced add` for non-HTTP triggers.
 
 ```bash
-afs add <trigger-type> <function-name> --project-root <path>
+afs api add <function-name> --project-root <path>
+afs advanced add <trigger-type> <function-name> --project-root <path>
 ```
 
 When you run this command, the CLI:
@@ -19,17 +20,17 @@ When you run this command, the CLI:
 
 Add a secondary HTTP endpoint to your API:
 ```bash
-afs add http user-profile
+afs api add user-profile
 ```
 
 Add a timer trigger to an existing project:
 ```bash
-afs add timer cleanup-job
+afs advanced add timer cleanup-job
 ```
 
 Add a queue listener to handle background tasks:
 ```bash
-afs add queue task-processor
+afs advanced add queue task-processor
 ```
 
 ### Dry Run
@@ -37,12 +38,12 @@ afs add queue task-processor
 Use the `--dry-run` flag to preview which files will be created and how `function_app.py` will be modified before making any changes.
 
 ```bash
-afs add http reports --dry-run
+afs api add reports --dry-run
 ```
 
 ### Development Workflow
 
-1.  **Add Trigger**: Run the `add` command to generate the boilerplate.
+1.  **Add Trigger**: Run `afs api add` or `afs advanced add` to generate the boilerplate.
 2.  **Implement Logic**: Create a corresponding service file in `app/services/` and write your core business rules there.
 3.  **Update Schemas**: If needed, define new request/response models in `app/schemas/`.
 4.  **Add Tests**: Update the generated test file in `tests/` to verify your new function.

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -19,7 +19,7 @@ It generates the wiring you would otherwise repeat manually:
 ## Core Workflow
 
 1. Generate a project with `afs new`.
-2. Add triggers over time with `afs add`.
+2. Add HTTP endpoints with `afs api add` and non-HTTP triggers with `afs advanced add`.
 3. Keep business logic in services, trigger code thin.
 4. Use preset-driven quality checks in CI.
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -132,7 +132,7 @@ With `--with-validation`, generated hello endpoint uses POST body validation.
 - ensure project was generated with `--with-doctor`
 - reinstall dependencies in active environment
 
-## `afs add` Problems
+## `afs api add` / `afs advanced add` Problems
 
 ### `add` cannot find scaffold project root
 
@@ -148,7 +148,7 @@ With `--with-validation`, generated hello endpoint uses POST body validation.
 **Fix**
 
 ```bash
-afs add http users --project-root ./my-api
+afs api add users --project-root ./my-api
 ```
 
 Use `--project-root` explicitly in scripts and CI.
@@ -162,7 +162,7 @@ Use `--project-root` explicitly in scripts and CI.
 **Fix**
 
 - choose a different function name, or
-- remove/rename the existing module before running `afs add` again
+- remove/rename the existing module before running `afs api add` or `afs advanced add` again
 
 ## Core Tools Runtime Issues
 
@@ -204,7 +204,7 @@ For timer/queue/blob/servicebus local workflows, ensure Azurite is running and
 
 ### Missing tests after adding a function
 
-`afs add` creates test files only when `tests/` directory exists. If your
+`afs api add` and `afs advanced add` create test files only when `tests/` directory exists. If your
 project removed tests, recreate the folder or add tests manually.
 
 ## Diagnostic Workflow

--- a/docs/guide/tutorial.md
+++ b/docs/guide/tutorial.md
@@ -177,10 +177,10 @@ Hello, Azure!
 
 ### Expand with `add`
 
-Use the `add` command to append new functions to an existing project. The CLI generates the function file, a test, and registers the blueprint in `function_app.py` automatically.
+Use `afs api add` to append HTTP functions to an existing project. The CLI generates the function file, a test, and registers the blueprint in `function_app.py` automatically.
 
 ```bash
-afs add http users --project-root .
+afs api add users --project-root .
 ```
 
 The CLI generates a skeleton for the new endpoint:

--- a/docs/index.md
+++ b/docs/index.md
@@ -32,7 +32,8 @@ That creates a working HTTP project scaffold with a practical default preset.
 ### Commands
 
 - `afs new <name>` creates a new project.
-- `afs add <trigger> <name>` adds a function module to an existing project.
+- `afs api add <name>` adds an HTTP function module to an existing project.
+- `afs advanced add <trigger> <name>` adds a non-HTTP function module to an existing project.
 - `afs templates` lists built-in templates.
 - `afs presets` lists quality/tooling presets.
 
@@ -111,7 +112,7 @@ afs new orders-api --preset strict --with-openapi --with-validation
 afs new nightly-job --template timer --preset standard
 
 # Add another endpoint to an existing project
-afs add http get_user --project-root ./orders-api
+afs api add get_user --project-root ./orders-api
 
 # Preview generation without writing files
 afs new sandbox-api --dry-run
@@ -137,7 +138,7 @@ afs new sandbox-api --dry-run
 
 - Project names must start with an alphanumeric character and can include
   alphanumerics, `_`, and `-`.
-- `afs add` must point to a valid scaffold project root.
+- `afs api add` and `afs advanced add` must point to a valid scaffold project root.
 - Local execution and publish flows use Azure Functions Core Tools (`func`).
 
 ## Keep Reading

--- a/src/azure_functions_scaffold/cli.py
+++ b/src/azure_functions_scaffold/cli.py
@@ -94,6 +94,66 @@ def new(
     )
 
 
+@app.command(
+    "add",
+    deprecated=True,
+    help="DEPRECATED: use 'afs api add' (http) or 'afs advanced add <trigger>' instead.",
+    hidden=False,
+)
+def legacy_add(
+    ctx: typer.Context,
+    trigger: str = typer.Argument(..., help="Trigger type (e.g. http, timer, queue)."),
+    function_name: str = typer.Argument(..., help="Function name."),
+    project_root: Path = typer.Option(Path("."), "--project-root", "-p", help="Project root."),
+    dry_run: bool = typer.Option(False, "--dry-run", help="Preview without writing files."),
+) -> None:
+    """DEPRECATED shim. Forwards to the modern command."""
+    del ctx
+    normalized = trigger.strip().lower()
+    if normalized == "http":
+        replacement = f"afs api add {function_name} --project-root {project_root}"
+    else:
+        replacement = f"afs advanced add {normalized} {function_name} --project-root {project_root}"
+    typer.echo(
+        f"warning: 'afs add' is deprecated and will be removed in a future release. "
+        f"Use: {replacement}",
+        err=True,
+    )
+    from azure_functions_scaffold.errors import ScaffoldError
+    from azure_functions_scaffold.generator import add_function, describe_add_function
+
+    try:
+        if dry_run:
+            for line in describe_add_function(
+                project_root=project_root, trigger=normalized, function_name=function_name
+            ):
+                typer.echo(line)
+        else:
+            path = add_function(
+                project_root=project_root, trigger=normalized, function_name=function_name
+            )
+            typer.echo(f"Created: {path}")
+    except ScaffoldError as exc:
+        typer.echo(f"Error: {exc}", err=True)
+        raise typer.Exit(code=1) from exc
+
+
+@app.command(
+    "profiles",
+    deprecated=True,
+    help="DEPRECATED: use 'afs presets' instead.",
+    hidden=False,
+)
+def legacy_profiles() -> None:
+    """DEPRECATED shim. Forwards to 'afs presets'."""
+    typer.echo(
+        "warning: 'afs profiles' is deprecated and will be removed in a future release. "
+        "Use: afs presets",
+        err=True,
+    )
+    show_presets()
+
+
 def main() -> None:
     app()
 

--- a/tests/test_cli_intents.py
+++ b/tests/test_cli_intents.py
@@ -1,3 +1,4 @@
+# pyright: reportMissingImports=false
 """Tests for intent-centric CLI subcommand groups (api, worker, ai, advanced)."""
 
 from __future__ import annotations
@@ -555,20 +556,30 @@ class TestAdvancedAddResource:
 
 
 # ---------------------------------------------------------------------------
-# Legacy commands are removed
+# Legacy commands are deprecated shims
 # ---------------------------------------------------------------------------
 
 
-class TestLegacyRemoved:
-    def test_legacy_add_command_not_available(self) -> None:
-        result = runner.invoke(app, ["add", "http", "get-user"])
-        assert result.exit_code != 0
-        assert "No such command" in result.stdout or "No such command" in (result.stderr or "")
+class TestLegacyDeprecated:
+    """Legacy commands now print a deprecation warning and forward to the new command."""
 
-    def test_legacy_profiles_command_not_available(self) -> None:
+    def test_legacy_add_warns_and_forwards_for_http(self, tmp_path: Path) -> None:
+        result = runner.invoke(app, ["add", "http", "get-user", "--project-root", str(tmp_path)])
+        assert "deprecated" in result.stderr.lower()
+        assert "afs api add" in result.stderr
+
+    def test_legacy_add_suggests_advanced_for_non_http(self, tmp_path: Path) -> None:
+        result = runner.invoke(app, ["add", "queue", "sync", "--project-root", str(tmp_path)])
+        assert "deprecated" in result.stderr.lower()
+        assert "afs advanced add queue" in result.stderr
+
+    def test_legacy_profiles_warns_and_lists_presets(self) -> None:
         result = runner.invoke(app, ["profiles"])
-        assert result.exit_code != 0
-        assert "No such command" in result.stdout or "No such command" in (result.stderr or "")
+        assert result.exit_code == 0
+        assert "deprecated" in result.stderr.lower()
+        assert (
+            "minimal" in result.stdout or "standard" in result.stdout or "strict" in result.stdout
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `afs add` and `afs profiles` were removed without a migration shim, but the public docs (guides, examples, index) still tell users to run them. The generic \"No such command\" error gives no migration path.
- Restore both commands as **deprecation shims** that print a clear warning to stderr and forward to the modern command.
- Update all stale `afs add` / `afs profiles` references across the docs.

## Behavior
- `afs add http get-user` -> warns \"use 'afs api add get-user'\" then runs.
- `afs add timer cleanup` -> warns \"use 'afs advanced add timer cleanup'\" then runs.
- `afs profiles` -> warns \"use 'afs presets'\" then lists presets.
- Both commands appear in `afs --help` marked as deprecated.

## Verification
- `pytest tests` — green, coverage >= 90%.
- `ruff check src tests` / `mypy src` — clean.
- `TestLegacyRemoved` replaced by `TestLegacyDeprecated`.
- Manual: deprecation warnings verified end-to-end via `hatch run afs ...`.

## Scope
P1-7 of the post-review remediation plan. Independent of #81-#86.