### PR TITLE
fix(cli): validate advanced new flag/template compatibility

### DIFF
--- a/src/azure_functions_scaffold/cli_advanced.py
+++ b/src/azure_functions_scaffold/cli_advanced.py
@@ -35,6 +35,51 @@ advanced_app = typer.Typer(
     help="Power-user project scaffolding with full option control.",
 )
 
+_TEMPLATE_ALLOWED_FEATURES: dict[str, frozenset[str]] = {
+    "http": frozenset({"openapi", "validation", "doctor", "azd"}),
+    "timer": frozenset({"doctor", "azd"}),
+    "queue": frozenset({"doctor", "azd"}),
+    "blob": frozenset({"doctor", "azd"}),
+    "servicebus": frozenset({"doctor", "azd"}),
+    "eventhub": frozenset({"doctor", "azd"}),
+    "cosmosdb": frozenset({"doctor", "azd"}),
+    "durable": frozenset({"doctor", "azd"}),
+    "ai": frozenset({"doctor", "azd"}),
+    "langgraph": frozenset({"azd"}),
+}
+
+
+def _validate_feature_flags_for_template(
+    template: str,
+    *,
+    with_openapi: bool,
+    with_validation: bool,
+    with_doctor: bool,
+    with_azd: bool,
+) -> None:
+    requested = {
+        "openapi": with_openapi,
+        "validation": with_validation,
+        "doctor": with_doctor,
+        "azd": with_azd,
+    }
+    enabled = {name for name, is_enabled in requested.items() if is_enabled}
+    allowed = _TEMPLATE_ALLOWED_FEATURES.get(template)
+    if allowed is None:
+        return
+    invalid = sorted(enabled - allowed)
+    if not invalid:
+        return
+    flag_names = {
+        "openapi": "--with-openapi",
+        "validation": "--with-validation",
+        "doctor": "--with-doctor",
+        "azd": "--azd",
+    }
+    rejected = ", ".join(flag_names[name] for name in invalid)
+    raise ScaffoldError(f"Template '{template}' does not support {rejected}.")
+
+
 TemplateOption = Annotated[
     str,
     typer.Option(
@@ -107,6 +152,13 @@ def advanced_new(
 ) -> None:
     """Create a new project with full option control (power-user mode)."""
     try:
+        _validate_feature_flags_for_template(
+            template,
+            with_openapi=with_openapi,
+            with_validation=with_validation,
+            with_doctor=with_doctor,
+            with_azd=with_azd,
+        )
         options = build_project_options(
             preset_name=preset,
             python_version=python_version,

--- a/tests/test_cli_intents.py
+++ b/tests/test_cli_intents.py
@@ -493,6 +493,148 @@ class TestAdvanced:
         assert "strict:" in result.stdout
 
 
+class TestAdvancedNewFlagValidation:
+    def test_with_openapi_rejected_for_timer_template(self, tmp_path: Path) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "advanced",
+                "new",
+                "myproj",
+                "--destination",
+                str(tmp_path),
+                "--template",
+                "timer",
+                "--with-openapi",
+            ],
+        )
+
+        assert result.exit_code != 0
+        out = (result.stdout or "") + (result.stderr or "")
+        assert "timer" in out
+        assert "--with-openapi" in out
+        assert not (tmp_path / "myproj").exists()
+
+    def test_with_validation_rejected_for_queue_template(self, tmp_path: Path) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "advanced",
+                "new",
+                "myproj",
+                "--destination",
+                str(tmp_path),
+                "--template",
+                "queue",
+                "--with-validation",
+            ],
+        )
+
+        assert result.exit_code != 0
+        out = (result.stdout or "") + (result.stderr or "")
+        assert "--with-validation" in out
+
+    def test_with_doctor_rejected_for_langgraph_template(self, tmp_path: Path) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "advanced",
+                "new",
+                "myproj",
+                "--destination",
+                str(tmp_path),
+                "--template",
+                "langgraph",
+                "--with-doctor",
+            ],
+        )
+
+        assert result.exit_code != 0
+        out = (result.stdout or "") + (result.stderr or "")
+        assert "--with-doctor" in out
+
+    def test_http_template_accepts_all_features(self, tmp_path: Path) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "advanced",
+                "new",
+                "myproj",
+                "--destination",
+                str(tmp_path),
+                "--template",
+                "http",
+                "--with-openapi",
+                "--with-validation",
+                "--with-doctor",
+                "--azd",
+            ],
+        )
+
+        assert result.exit_code == 0, (
+            f"Expected success, got: {result.stdout}\n{result.stderr or ''}"
+        )
+
+    def test_azd_allowed_for_non_http_templates(self, tmp_path: Path) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "advanced",
+                "new",
+                "myproj",
+                "--destination",
+                str(tmp_path),
+                "--template",
+                "timer",
+                "--azd",
+            ],
+        )
+
+        assert result.exit_code == 0, (
+            f"Expected success, got: {result.stdout}\n{result.stderr or ''}"
+        )
+
+    def test_doctor_allowed_for_timer_template(self, tmp_path: Path) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "advanced",
+                "new",
+                "myproj",
+                "--destination",
+                str(tmp_path),
+                "--template",
+                "timer",
+                "--with-doctor",
+            ],
+        )
+
+        assert result.exit_code == 0, (
+            f"Expected success, got: {result.stdout}\n{result.stderr or ''}"
+        )
+
+    def test_multiple_invalid_flags_listed_together(self, tmp_path: Path) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "advanced",
+                "new",
+                "myproj",
+                "--destination",
+                str(tmp_path),
+                "--template",
+                "blob",
+                "--with-openapi",
+                "--with-validation",
+            ],
+        )
+
+        assert result.exit_code != 0
+        out = (result.stdout or "") + (result.stderr or "")
+        assert "--with-openapi" in out
+        assert "--with-validation" in out
+
+
 class TestAdvancedAddRoute:
     def test_adds_route(self, tmp_path: Path) -> None:
         runner.invoke(app, ["api", "new", "my-api", "--destination", str(tmp_path)])


### PR DESCRIPTION
## Summary
- `afs advanced new --template <non-http> --with-openapi/--with-validation/--with-doctor` was silently accepted even though the help text said "(HTTP template only)". The generator dropped the flag and the user got a project with no scaffolding for the requested feature.
- Add a static template -> allowed-features policy and reject invalid combinations up front with a clear error message.
- Template inspection found one policy deviation from the initial proposal: `--with-doctor` is legitimately consumed by the timer, queue, blob, servicebus, eventhub, cosmosdb, durable, and ai templates, while langgraph remains azd-only.

## Behavior
- `afs advanced new myproj --template timer --with-openapi` -> error, exit 1, no files created.
- `afs advanced new myproj --template http --with-openapi --with-validation --with-doctor` -> succeeds (all four allowed for http).
- `afs advanced new myproj --template <any> --azd` -> always succeeds (azd is template-independent).

## Verification
- `pytest tests` - green, coverage >= 90%.
- `ruff check src tests` / `mypy src` - clean.
- New `TestAdvancedNewFlagValidation` covers reject paths, valid http path, valid non-http+azd path, valid non-http+doctor path where supported, and combined-flag error message.
- Manual: invalid combinations produce a clear error and no filesystem writes.

## Scope
P1-8 of the post-review remediation plan. Independent of #81-#87.