### PR TITLE
fix(scaffold): guard --overwrite with TTY confirmation and .git check

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -32,6 +32,9 @@ Generates a new Azure Functions Python v2 project from scratch.
 | `--interactive`, `-i` | False | Boolean | Force interactive wizard. |
 | `--dry-run` | False | Boolean | Show planned files without writing to disk. |
 | `--overwrite` | False | Boolean | Overwrite files if the destination directory exists. |
+| `--yes`, `-y` | False | Boolean | Skip overwrite confirmation prompts when deletion is intentional. |
+
+When `--overwrite` is used in an interactive TTY, the CLI prompts before deleting the target directory and defaults to No. In non-interactive sessions, `--overwrite` is refused unless `--yes` is also passed. As an extra safety guard, any target directory containing `.git/` also requires `--yes` before it can be deleted.
 
 ### `add`
 

--- a/src/azure_functions_scaffold/cli.py
+++ b/src/azure_functions_scaffold/cli.py
@@ -17,6 +17,7 @@ from azure_functions_scaffold.cli_common import (
     GitOption,
     OverwriteOption,
     PythonVersionOption,
+    YesOption,
     run_intent,
 )
 from azure_functions_scaffold.cli_worker import worker_app
@@ -79,6 +80,7 @@ def new(
     include_azd: AzdOption = False,
     dry_run: DryRunOption = False,
     overwrite: OverwriteOption = False,
+    yes: YesOption = False,
 ) -> None:
     """Create a new API project (shortcut for 'afs api new')."""
     run_intent(
@@ -91,6 +93,7 @@ def new(
         include_azd=include_azd,
         dry_run=dry_run,
         overwrite=overwrite,
+        yes=yes,
     )
 
 

--- a/src/azure_functions_scaffold/cli_advanced.py
+++ b/src/azure_functions_scaffold/cli_advanced.py
@@ -12,6 +12,7 @@ from azure_functions_scaffold.cli_common import (
     DestinationOption,
     DryRunOption,
     OverwriteOption,
+    YesOption,
     run_scaffold,
 )
 from azure_functions_scaffold.errors import ScaffoldError
@@ -104,6 +105,7 @@ def advanced_new(
     with_azd: AzdOption = False,
     dry_run: DryRunOption = False,
     overwrite: OverwriteOption = False,
+    yes: YesOption = False,
 ) -> None:
     """Create a new project with full option control (power-user mode)."""
     try:
@@ -128,6 +130,7 @@ def advanced_new(
         destination=destination,
         dry_run=dry_run,
         overwrite=overwrite,
+        yes=yes,
     )
 
 

--- a/src/azure_functions_scaffold/cli_ai.py
+++ b/src/azure_functions_scaffold/cli_ai.py
@@ -14,6 +14,7 @@ from azure_functions_scaffold.cli_common import (
     GitOption,
     OverwriteOption,
     PythonVersionOption,
+    YesOption,
     run_intent,
 )
 
@@ -33,6 +34,7 @@ def ai_agent(
     include_azd: AzdOption = False,
     dry_run: DryRunOption = False,
     overwrite: OverwriteOption = False,
+    yes: YesOption = False,
 ) -> None:
     """Create a LangGraph agent project."""
     run_intent(
@@ -45,4 +47,5 @@ def ai_agent(
         include_azd=include_azd,
         dry_run=dry_run,
         overwrite=overwrite,
+        yes=yes,
     )

--- a/src/azure_functions_scaffold/cli_api.py
+++ b/src/azure_functions_scaffold/cli_api.py
@@ -14,6 +14,7 @@ from azure_functions_scaffold.cli_common import (
     GitOption,
     OverwriteOption,
     PythonVersionOption,
+    YesOption,
     run_intent,
 )
 from azure_functions_scaffold.errors import ScaffoldError
@@ -42,6 +43,7 @@ def api_new(
     include_azd: AzdOption = False,
     dry_run: DryRunOption = False,
     overwrite: OverwriteOption = False,
+    yes: YesOption = False,
 ) -> None:
     """Create a REST API project with OpenAPI, validation, and doctor."""
     run_intent(
@@ -54,6 +56,7 @@ def api_new(
         include_azd=include_azd,
         dry_run=dry_run,
         overwrite=overwrite,
+        yes=yes,
     )
 
 

--- a/src/azure_functions_scaffold/cli_common.py
+++ b/src/azure_functions_scaffold/cli_common.py
@@ -77,6 +77,18 @@ OverwriteOption = Annotated[
     ),
 ]
 
+YesOption = Annotated[
+    bool,
+    typer.Option(
+        "--yes",
+        "-y",
+        help=(
+            "Skip confirmation prompts (required when --overwrite runs in a "
+            "non-TTY session or against a directory containing .git)."
+        ),
+    ),
+]
+
 
 # ---------------------------------------------------------------------------
 # Intent-based scaffold execution
@@ -94,6 +106,7 @@ def run_intent(
     include_azd: bool = False,
     dry_run: bool = False,
     overwrite: bool = False,
+    yes: bool = False,
 ) -> None:
     """Look up *intent_key* in ``INTENT_SPECS`` and scaffold accordingly."""
     try:
@@ -128,6 +141,7 @@ def run_intent(
         destination=destination,
         dry_run=dry_run,
         overwrite=overwrite,
+        yes=yes,
     )
 
 
@@ -139,6 +153,7 @@ def run_scaffold(
     destination: Path = Path("."),
     dry_run: bool = False,
     overwrite: bool = False,
+    yes: bool = False,
 ) -> None:
     """Execute scaffold_project (or describe if dry_run) with unified error handling."""
     logger.debug(
@@ -156,6 +171,7 @@ def run_scaffold(
                 template_name=template_name,
                 options=options,
                 overwrite=overwrite,
+                yes=yes,
             ):
                 typer.echo(line)
             return
@@ -165,6 +181,7 @@ def run_scaffold(
             template_name=template_name,
             options=options,
             overwrite=overwrite,
+            yes=yes,
         )
     except ScaffoldError as exc:
         typer.secho(str(exc), fg=typer.colors.RED)

--- a/src/azure_functions_scaffold/cli_worker.py
+++ b/src/azure_functions_scaffold/cli_worker.py
@@ -14,6 +14,7 @@ from azure_functions_scaffold.cli_common import (
     GitOption,
     OverwriteOption,
     PythonVersionOption,
+    YesOption,
     run_intent,
 )
 
@@ -33,6 +34,7 @@ def worker_timer(
     include_azd: AzdOption = False,
     dry_run: DryRunOption = False,
     overwrite: OverwriteOption = False,
+    yes: YesOption = False,
 ) -> None:
     """Create a timer-trigger worker project."""
     run_intent(
@@ -45,6 +47,7 @@ def worker_timer(
         include_azd=include_azd,
         dry_run=dry_run,
         overwrite=overwrite,
+        yes=yes,
     )
 
 
@@ -58,6 +61,7 @@ def worker_queue(
     include_azd: AzdOption = False,
     dry_run: DryRunOption = False,
     overwrite: OverwriteOption = False,
+    yes: YesOption = False,
 ) -> None:
     """Create a queue-trigger worker project."""
     run_intent(
@@ -70,6 +74,7 @@ def worker_queue(
         include_azd=include_azd,
         dry_run=dry_run,
         overwrite=overwrite,
+        yes=yes,
     )
 
 
@@ -83,6 +88,7 @@ def worker_blob(
     include_azd: AzdOption = False,
     dry_run: DryRunOption = False,
     overwrite: OverwriteOption = False,
+    yes: YesOption = False,
 ) -> None:
     """Create a blob-trigger worker project."""
     run_intent(
@@ -95,6 +101,7 @@ def worker_blob(
         include_azd=include_azd,
         dry_run=dry_run,
         overwrite=overwrite,
+        yes=yes,
     )
 
 
@@ -108,6 +115,7 @@ def worker_servicebus(
     include_azd: AzdOption = False,
     dry_run: DryRunOption = False,
     overwrite: OverwriteOption = False,
+    yes: YesOption = False,
 ) -> None:
     """Create a Service Bus-trigger worker project."""
     run_intent(
@@ -120,6 +128,7 @@ def worker_servicebus(
         include_azd=include_azd,
         dry_run=dry_run,
         overwrite=overwrite,
+        yes=yes,
     )
 
 
@@ -133,6 +142,7 @@ def worker_eventhub(
     include_azd: AzdOption = False,
     dry_run: DryRunOption = False,
     overwrite: OverwriteOption = False,
+    yes: YesOption = False,
 ) -> None:
     """Create an EventHub-trigger worker project."""
     run_intent(
@@ -145,4 +155,5 @@ def worker_eventhub(
         include_azd=include_azd,
         dry_run=dry_run,
         overwrite=overwrite,
+        yes=yes,
     )

--- a/src/azure_functions_scaffold/scaffolder.py
+++ b/src/azure_functions_scaffold/scaffolder.py
@@ -5,8 +5,10 @@ from pathlib import Path
 import re
 import shutil
 import subprocess  # nosec B404
+import sys
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
+import typer
 
 from azure_functions_scaffold.errors import ScaffoldError
 from azure_functions_scaffold.models import ProjectOptions, TemplateContext, TemplateSpec
@@ -21,6 +23,7 @@ def scaffold_project(
     template_name: str = "http",
     options: ProjectOptions | None = None,
     overwrite: bool = False,
+    yes: bool = False,
 ) -> Path:
     context, target_dir, template = _resolve_scaffold_inputs(
         project_name=project_name,
@@ -40,6 +43,7 @@ def scaffold_project(
             raise ScaffoldError(
                 f"Target directory already exists: {target_dir}. Use --overwrite to replace it."
             )
+        _confirm_overwrite_or_raise(target_dir, yes=yes)
         logger.warning("Overwriting existing directory: %s", target_dir)
         shutil.rmtree(target_dir)
 
@@ -101,6 +105,7 @@ def describe_scaffold_project(
     template_name: str = "http",
     options: ProjectOptions | None = None,
     overwrite: bool = False,
+    yes: bool = False,
 ) -> list[str]:
     context, target_dir, template = _resolve_scaffold_inputs(
         project_name=project_name,
@@ -142,6 +147,33 @@ def describe_scaffold_project(
         lines.append(f"  - {rendered_path.as_posix()}")
 
     return lines
+
+
+def _confirm_overwrite_or_raise(target_dir: Path, *, yes: bool) -> None:
+    has_git = (target_dir / ".git").is_dir()
+    file_count = sum(1 for path in target_dir.rglob("*") if path.is_file())
+
+    if has_git and not yes:
+        raise ScaffoldError(
+            f"Refusing to overwrite {target_dir} because it contains a .git directory. "
+            f"Pass --yes if you really want to delete this repository."
+        )
+
+    if yes:
+        return
+
+    if not sys.stdin.isatty():
+        raise ScaffoldError(
+            f"--overwrite refused: not running in a TTY. "
+            f"Pass --yes to confirm deletion of {target_dir} ({file_count} files)."
+        )
+
+    git_note = " (contains .git)" if has_git else ""
+    if not typer.confirm(
+        f"Delete and overwrite {target_dir}{git_note} ({file_count} files)?",
+        default=False,
+    ):
+        raise ScaffoldError("Overwrite cancelled by user.")
 
 
 def build_template_context(project_name: str, options: ProjectOptions) -> TemplateContext:

--- a/tests/test_cli_intents.py
+++ b/tests/test_cli_intents.py
@@ -69,7 +69,8 @@ class TestApiNew:
         (project_dir / "stale.txt").write_text("stale", encoding="utf-8")
 
         result = runner.invoke(
-            app, ["api", "new", "my-api", "--destination", str(tmp_path), "--overwrite"]
+            app,
+            ["api", "new", "my-api", "--destination", str(tmp_path), "--overwrite", "--yes"],
         )
         assert result.exit_code == 0
         assert not (project_dir / "stale.txt").exists()
@@ -132,8 +133,23 @@ class TestNew:
         (project_dir / "stale.txt").write_text("stale", encoding="utf-8")
 
         result = runner.invoke(
-            app, ["new", "my-api", "--destination", str(tmp_path), "--overwrite"]
+            app,
+            ["new", "my-api", "--destination", str(tmp_path), "--overwrite", "--yes"],
         )
+        assert result.exit_code == 0
+        assert not (project_dir / "stale.txt").exists()
+        assert (project_dir / "function_app.py").exists()
+
+    def test_overwrite_with_yes_flag(self, tmp_path: Path) -> None:
+        project_dir = tmp_path / "my-api"
+        project_dir.mkdir()
+        (project_dir / "stale.txt").write_text("stale", encoding="utf-8")
+
+        result = runner.invoke(
+            app,
+            ["new", "my-api", "--destination", str(tmp_path), "--overwrite", "--yes"],
+        )
+
         assert result.exit_code == 0
         assert not (project_dir / "stale.txt").exists()
         assert (project_dir / "function_app.py").exists()

--- a/tests/test_scaffolder.py
+++ b/tests/test_scaffolder.py
@@ -9,6 +9,7 @@ import pytest
 
 from azure_functions_scaffold.errors import ScaffoldError
 from azure_functions_scaffold.models import TemplateContext
+import azure_functions_scaffold.scaffolder as scaffolder_module
 from azure_functions_scaffold.scaffolder import (
     _initialize_git_repository,
     _iter_template_files,
@@ -171,10 +172,106 @@ def test_scaffold_project_can_overwrite_existing_target(tmp_path: Path) -> None:
     stale_file = target_dir / "stale.txt"
     stale_file.write_text("stale", encoding="utf-8")
 
+    project_path = scaffold_project("sample", tmp_path, overwrite=True, yes=True)
+
+    assert project_path == target_dir
+    assert not stale_file.exists()
+    assert (project_path / "function_app.py").exists()
+
+
+def test_overwrite_in_tty_with_yes_proceeds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target_dir = tmp_path / "sample"
+    target_dir.mkdir()
+    stale_file = target_dir / "stale.txt"
+    stale_file.write_text("stale", encoding="utf-8")
+
+    monkeypatch.setattr(scaffolder_module.sys.stdin, "isatty", lambda: True)
+
+    project_path = scaffold_project("sample", tmp_path, overwrite=True, yes=True)
+
+    assert project_path == target_dir
+    assert not stale_file.exists()
+    assert (project_path / "function_app.py").exists()
+
+
+def test_overwrite_in_tty_without_yes_prompts_and_proceeds_on_y(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target_dir = tmp_path / "sample"
+    target_dir.mkdir()
+    stale_file = target_dir / "stale.txt"
+    stale_file.write_text("stale", encoding="utf-8")
+
+    monkeypatch.setattr(scaffolder_module.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(scaffolder_module.typer, "confirm", lambda *args, **kwargs: True)
+
     project_path = scaffold_project("sample", tmp_path, overwrite=True)
 
     assert project_path == target_dir
     assert not stale_file.exists()
+    assert (project_path / "function_app.py").exists()
+
+
+def test_overwrite_in_tty_without_yes_aborts_on_n(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target_dir = tmp_path / "sample"
+    target_dir.mkdir()
+    stale_file = target_dir / "stale.txt"
+    stale_file.write_text("stale", encoding="utf-8")
+
+    monkeypatch.setattr(scaffolder_module.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr(scaffolder_module.typer, "confirm", lambda *args, **kwargs: False)
+
+    with pytest.raises(ScaffoldError, match="cancelled by user"):
+        scaffold_project("sample", tmp_path, overwrite=True)
+
+    assert stale_file.exists()
+
+
+def test_overwrite_in_non_tty_without_yes_raises(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target_dir = tmp_path / "sample"
+    target_dir.mkdir()
+    (target_dir / "stale.txt").write_text("stale", encoding="utf-8")
+
+    monkeypatch.setattr(scaffolder_module.sys.stdin, "isatty", lambda: False)
+
+    with pytest.raises(ScaffoldError, match="TTY|--yes"):
+        scaffold_project("sample", tmp_path, overwrite=True)
+
+
+def test_overwrite_with_git_dir_requires_yes(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target_dir = tmp_path / "sample"
+    (target_dir / ".git").mkdir(parents=True)
+    (target_dir / "tracked.txt").write_text("stale", encoding="utf-8")
+
+    monkeypatch.setattr(scaffolder_module.sys.stdin, "isatty", lambda: True)
+
+    with pytest.raises(ScaffoldError, match=r"\.git.*--yes"):
+        scaffold_project("sample", tmp_path, overwrite=True)
+
+
+def test_overwrite_with_git_dir_and_yes_proceeds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    target_dir = tmp_path / "sample"
+    (target_dir / ".git").mkdir(parents=True)
+    stale_file = target_dir / "tracked.txt"
+    stale_file.write_text("stale", encoding="utf-8")
+
+    monkeypatch.setattr(scaffolder_module.sys.stdin, "isatty", lambda: True)
+
+    project_path = scaffold_project("sample", tmp_path, overwrite=True, yes=True)
+
+    assert project_path == target_dir
+    assert not stale_file.exists()
+    assert not (project_path / ".git").exists()
     assert (project_path / "function_app.py").exists()
 
 

--- a/tests/test_scaffolder.py
+++ b/tests/test_scaffolder.py
@@ -9,7 +9,6 @@ import pytest
 
 from azure_functions_scaffold.errors import ScaffoldError
 from azure_functions_scaffold.models import TemplateContext
-import azure_functions_scaffold.scaffolder as scaffolder_module
 from azure_functions_scaffold.scaffolder import (
     _initialize_git_repository,
     _iter_template_files,
@@ -187,7 +186,7 @@ def test_overwrite_in_tty_with_yes_proceeds(
     stale_file = target_dir / "stale.txt"
     stale_file.write_text("stale", encoding="utf-8")
 
-    monkeypatch.setattr(scaffolder_module.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
 
     project_path = scaffold_project("sample", tmp_path, overwrite=True, yes=True)
 
@@ -204,8 +203,10 @@ def test_overwrite_in_tty_without_yes_prompts_and_proceeds_on_y(
     stale_file = target_dir / "stale.txt"
     stale_file.write_text("stale", encoding="utf-8")
 
-    monkeypatch.setattr(scaffolder_module.sys.stdin, "isatty", lambda: True)
-    monkeypatch.setattr(scaffolder_module.typer, "confirm", lambda *args, **kwargs: True)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr(
+        "azure_functions_scaffold.scaffolder.typer.confirm", lambda *args, **kwargs: True
+    )
 
     project_path = scaffold_project("sample", tmp_path, overwrite=True)
 
@@ -222,8 +223,10 @@ def test_overwrite_in_tty_without_yes_aborts_on_n(
     stale_file = target_dir / "stale.txt"
     stale_file.write_text("stale", encoding="utf-8")
 
-    monkeypatch.setattr(scaffolder_module.sys.stdin, "isatty", lambda: True)
-    monkeypatch.setattr(scaffolder_module.typer, "confirm", lambda *args, **kwargs: False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+    monkeypatch.setattr(
+        "azure_functions_scaffold.scaffolder.typer.confirm", lambda *args, **kwargs: False
+    )
 
     with pytest.raises(ScaffoldError, match="cancelled by user"):
         scaffold_project("sample", tmp_path, overwrite=True)
@@ -238,7 +241,7 @@ def test_overwrite_in_non_tty_without_yes_raises(
     target_dir.mkdir()
     (target_dir / "stale.txt").write_text("stale", encoding="utf-8")
 
-    monkeypatch.setattr(scaffolder_module.sys.stdin, "isatty", lambda: False)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: False)
 
     with pytest.raises(ScaffoldError, match="TTY|--yes"):
         scaffold_project("sample", tmp_path, overwrite=True)
@@ -251,7 +254,7 @@ def test_overwrite_with_git_dir_requires_yes(
     (target_dir / ".git").mkdir(parents=True)
     (target_dir / "tracked.txt").write_text("stale", encoding="utf-8")
 
-    monkeypatch.setattr(scaffolder_module.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
 
     with pytest.raises(ScaffoldError, match=r"\.git.*--yes"):
         scaffold_project("sample", tmp_path, overwrite=True)
@@ -265,7 +268,7 @@ def test_overwrite_with_git_dir_and_yes_proceeds(
     stale_file = target_dir / "tracked.txt"
     stale_file.write_text("stale", encoding="utf-8")
 
-    monkeypatch.setattr(scaffolder_module.sys.stdin, "isatty", lambda: True)
+    monkeypatch.setattr("sys.stdin.isatty", lambda: True)
 
     project_path = scaffold_project("sample", tmp_path, overwrite=True, yes=True)
 


### PR DESCRIPTION
## Summary
- `--overwrite` previously ran `shutil.rmtree` with no warning. A typo in `--destination` or `project_name` could destroy a real project, including its git history.
- Add a layered safety model: interactive prompt in a TTY, `--yes` required in non-TTY environments, and an extra `--yes` requirement when the target directory contains `.git/`.
- Add `--yes` / `-y` flag wired through every `*new*` command.

## Behavior
| Scenario | Behavior |
|---|---|
| `--overwrite` only, TTY | Prompts; default No. |
| `--overwrite --yes` | Proceeds. |
| `--overwrite` only, non-TTY | Refuses with "pass --yes" hint. |
| `--overwrite` against dir with `.git/`, no `--yes` | Refuses regardless of TTY. |
| `--overwrite --yes` against dir with `.git/` | Proceeds. |

## Verification
- `pytest tests` - green, coverage >= 90%.
- `ruff check src tests` / `mypy src` - clean.
- New tests cover all five scenarios above plus a CLI integration test for `--yes` plumbing.
- Manual: non-TTY refuses; `--yes` proceeds; `.git` guard fires.

## Scope
P1-9 of the post-review remediation plan. Independent of #81-#88.