### PR TITLE
fix(packaging): align PyPI name with publish reality (drop -python suffix)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
 ## Purpose
-`azure-functions-scaffold-python` is a CLI and library for scaffolding production-ready Azure Functions Python v2 projects.
+`azure-functions-scaffold` is a CLI and library for scaffolding production-ready Azure Functions Python v2 projects.
 
 ## Read First
 - `README.md`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Changed (BREAKING - packaging)
+
+- Renamed PyPI package from `azure-functions-scaffold-python` to `azure-functions-scaffold` to align with the existing PyPI registration (the suffixed name was never published). Install command: `pip install azure-functions-scaffold`. The CLI binary `afs` and the long-form `azure-functions-scaffold` are unchanged behaviorally; the long-form name no longer carries the `-python` suffix.
+- Generated project templates now depend on unsuffixed sibling packages: `azure-functions-logging`, `azure-functions-openapi`, `azure-functions-validation`, `azure-functions-doctor`, `azure-functions-db`. Existing `-python`-suffixed deps were unresolvable on PyPI.
+- Function-app marker comments are now `# azure-functions-scaffold: function imports` / `# azure-functions-scaffold: function registrations` (was `azure-functions-scaffold-python: ...`). Existing scaffolded projects will continue to work because the generator still recognizes both legacy and new markers - see migration notes.
+
+### Migration
+
+- Users with previously-scaffolded projects do not need to take action; the marker constants only matter when running `afs api add` / `afs advanced add` / `afs api add-route` / `afs api add-resource` against an existing project. If those commands fail with "marker not found" against an old scaffold, replace the comment in `function_app.py` from `# azure-functions-scaffold-python:` to `# azure-functions-scaffold:`.
+- Users following the previous suffixed install instructions will hit a 404. The README and docs are updated; PyPI package name is now `azure-functions-scaffold`.
+
 ## [0.5.0] - 2025-04-09
 
 ### Features

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing Guide
 
-We welcome contributions to the `azure-functions-scaffold-python` project.
+We welcome contributions to the `azure-functions-scaffold` project.
 
 ## Branch Strategy
 

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,6 +1,6 @@
 # DESIGN.md
 
-Design Principles for `azure-functions-scaffold-python`
+Design Principles for `azure-functions-scaffold`
 
 ## Purpose
 

--- a/PRD.md
+++ b/PRD.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-`azure-functions-scaffold-python` is a scaffolding CLI for creating production-leaning Azure Functions
+`azure-functions-scaffold` is a scaffolding CLI for creating production-leaning Azure Functions
 Python v2 projects.
 
 It generates a clean project structure with testing, linting, and packaging defaults that are
@@ -64,7 +64,7 @@ Without a scaffold, each team reinvents these decisions and quality drifts acros
 
 ### Philosophy
 
-A scaffolding CLI is only as good as the projects it generates. `azure-functions-scaffold-python`
+A scaffolding CLI is only as good as the projects it generates. `azure-functions-scaffold`
 treats every generated project as a runnable example — if a developer cannot go from
 `pip install` to `func start` with a working endpoint in under two minutes, the scaffold
 has failed its purpose.
@@ -74,8 +74,8 @@ has failed its purpose.
 The shortest path from zero to a running Azure Function:
 
 ```bash
-pip install azure-functions-scaffold-python
-azure-functions-scaffold-python new my-api
+pip install azure-functions-scaffold
+azure-functions-scaffold new my-api
 cd my-api
 pip install -e .
 func start
@@ -96,7 +96,7 @@ out of the box with zero manual configuration.
    scaffold by running the output, not by reading documentation.
 2. **AI agent discoverability.** Tools like GitHub Copilot, Cursor, and Claude Code recommend
    libraries based on README, PRD, and example content. Clear CLI usage patterns and
-   generated output help AI agents suggest `azure-functions-scaffold-python` for project setup prompts.
+generated output help AI agents suggest `azure-functions-scaffold` for project setup prompts.
 3. **Cookbook role.** For niche ecosystems, generated project templates serve as the primary
    reference architecture. Each template teaches real project structure, not toy examples.
 4. **Proven approach.** FastAPI, LangChain, SQLAlchemy, and Pandas all achieved early adoption

--- a/README.ja.md
+++ b/README.ja.md
@@ -1,7 +1,7 @@
 # Azure Functions Scaffold
 
-[![PyPI](https://img.shields.io/pypi/v/azure-functions-scaffold-python.svg)](https://pypi.org/project/azure-functions-scaffold-python/)
-[![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-scaffold-python/)
+[![PyPI](https://img.shields.io/pypi/v/azure-functions-scaffold.svg)](https://pypi.org/project/azure-functions-scaffold/)
+[![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-scaffold/)
 [![CI](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/release.yml/badge.svg)](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/release.yml)
 [![Security Scans](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/security.yml)
@@ -16,7 +16,7 @@
 
 ## なぜこのツールを使うのか
 
-新しい Azure Functions プロジェクトを始めるには、ボイラープレートの設定が必要です: `host.json`、`function_app.py`、ディレクトリ構造、ツール設定、テスト。`azure-functions-scaffold-python` は一つのコマンドでプロダクションレベルのプロジェクトレイアウトを生成し、最初からビジネスロジックに集中できるようにします。
+新しい Azure Functions プロジェクトを始めるには、ボイラープレートの設定が必要です: `host.json`、`function_app.py`、ディレクトリ構造、ツール設定、テスト。`azure-functions-scaffold` は一つのコマンドでプロダクションレベルのプロジェクトレイアウトを生成し、最初からビジネスロジックに集中できるようにします。
 
 ## スコープ
 
@@ -34,12 +34,12 @@
 - オプション統合: `--with-openapi`、`--with-validation`、`--with-doctor`
 - プリセットツーリングレベル: `--preset minimal|standard|strict`
 - パワーユーザー向けの詳細フラグ制御: `afs advanced new`
-- ショートエイリアス: `afs` を `azure-functions-scaffold-python` の代わりに使用可能
+- ショートエイリアス: `afs` を `azure-functions-scaffold` の代わりに使用可能
 
 ## インストール
 
 ```bash
-pip install azure-functions-scaffold-python
+pip install azure-functions-scaffold
 ```
 
 ## クイックスタート
@@ -118,7 +118,7 @@ my-api/
 | blob | `afs worker blob my-blob` | ファイル処理 (Azurite) |
 | servicebus | `afs worker servicebus my-bus` | エンタープライズメッセージング |
 
-注: `afs` は `azure-functions-scaffold-python` の短縮形です。どちらも利用できます。
+注: `afs` は `azure-functions-scaffold` の短縮形です。どちらも利用できます。
 
 テンプレートの既定値:
 
@@ -211,14 +211,14 @@ make build
 
 | パッケージ | 役割 |
 |---------|------|
-| **azure-functions-scaffold-python** | プロジェクトスキャフォールディング CLI |
-| [azure-functions-validation-python](https://github.com/yeongseon/azure-functions-validation-python) | リクエスト/レスポンスバリデーションとシリアライゼーション |
-| [azure-functions-openapi-python](https://github.com/yeongseon/azure-functions-openapi-python) | OpenAPI 仕様生成と Swagger UI |
-| [azure-functions-langgraph-python](https://github.com/yeongseon/azure-functions-langgraph-python) | Azure Functions 向け LangGraph デプロイアダプター |
-| [azure-functions-logging-python](https://github.com/yeongseon/azure-functions-logging-python) | 構造化ロギングとオブザーバビリティ |
-| [azure-functions-doctor-python](https://github.com/yeongseon/azure-functions-doctor-python) | デプロイ前診断 CLI |
-| [azure-functions-durable-graph-python](https://github.com/yeongseon/azure-functions-durable-graph-python) | Durable Functions ベースのグラフランタイム *(計画中)* |
-| [azure-functions-cookbook-python](https://github.com/yeongseon/azure-functions-cookbook-python) | レシピとサンプル |
+| **azure-functions-scaffold** | プロジェクトスキャフォールディング CLI |
+| [azure-functions-validation](https://github.com/yeongseon/azure-functions-validation-python) | リクエスト/レスポンスバリデーションとシリアライゼーション |
+| [azure-functions-openapi](https://github.com/yeongseon/azure-functions-openapi-python) | OpenAPI 仕様生成と Swagger UI |
+| [azure-functions-langgraph](https://github.com/yeongseon/azure-functions-langgraph-python) | Azure Functions 向け LangGraph デプロイアダプター |
+| [azure-functions-logging](https://github.com/yeongseon/azure-functions-logging-python) | 構造化ロギングとオブザーバビリティ |
+| [azure-functions-doctor](https://github.com/yeongseon/azure-functions-doctor-python) | デプロイ前診断 CLI |
+| [azure-functions-durable-graph](https://github.com/yeongseon/azure-functions-durable-graph-python) | Durable Functions ベースのグラフランタイム *(計画中)* |
+| [azure-functions-cookbook](https://github.com/yeongseon/azure-functions-cookbook-python) | レシピとサンプル |
 
 ## 免責事項
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,7 +1,7 @@
 # Azure Functions Scaffold
 
-[![PyPI](https://img.shields.io/pypi/v/azure-functions-scaffold-python.svg)](https://pypi.org/project/azure-functions-scaffold-python/)
-[![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-scaffold-python/)
+[![PyPI](https://img.shields.io/pypi/v/azure-functions-scaffold.svg)](https://pypi.org/project/azure-functions-scaffold/)
+[![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-scaffold/)
 [![CI](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/release.yml/badge.svg)](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/release.yml)
 [![Security Scans](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/security.yml)
@@ -16,7 +16,7 @@
 
 ## 왜 사용해야 할까
 
-새로운 Azure Functions 프로젝트를 시작하려면 보일러플레이트 설정이 필요합니다: `host.json`, `function_app.py`, 디렉터리 구조, 도구 설정, 테스트. `azure-functions-scaffold-python`는 한 번의 명령으로 프로덕션 수준의 프로젝트 레이아웃을 생성하여, 처음부터 비즈니스 로직에 집중할 수 있게 합니다.
+새로운 Azure Functions 프로젝트를 시작하려면 보일러플레이트 설정이 필요합니다: `host.json`, `function_app.py`, 디렉터리 구조, 도구 설정, 테스트. `azure-functions-scaffold`는 한 번의 명령으로 프로덕션 수준의 프로젝트 레이아웃을 생성하여, 처음부터 비즈니스 로직에 집중할 수 있게 합니다.
 
 ## 범위
 
@@ -34,12 +34,12 @@
 - 선택적 통합: `--with-openapi`, `--with-validation`, `--with-doctor`
 - 사전 설정 도구 수준: `--preset minimal|standard|strict`
 - 파워 유저를 위한 고급 플래그 제어: `afs advanced new`
-- 단축 별칭: `afs`를 `azure-functions-scaffold-python` 대신 사용 가능
+- 단축 별칭: `afs`를 `azure-functions-scaffold` 대신 사용 가능
 
 ## 설치
 
 ```bash
-pip install azure-functions-scaffold-python
+pip install azure-functions-scaffold
 ```
 
 ## 빠른 시작
@@ -118,7 +118,7 @@ my-api/
 | blob | `afs worker blob my-blob` | 파일 처리 (Azurite) |
 | servicebus | `afs worker servicebus my-bus` | 엔터프라이즈 메시징 |
 
-참고: `afs`는 `azure-functions-scaffold-python`의 줄임말입니다. 둘 다 동작합니다.
+참고: `afs`는 `azure-functions-scaffold`의 줄임말입니다. 둘 다 동작합니다.
 
 템플릿 기본값:
 
@@ -211,14 +211,14 @@ make build
 
 | 패키지 | 역할 |
 |---------|------|
-| **azure-functions-scaffold-python** | 프로젝트 스캐폴딩 CLI |
-| [azure-functions-validation-python](https://github.com/yeongseon/azure-functions-validation-python) | 요청/응답 검증 및 직렬화 |
-| [azure-functions-openapi-python](https://github.com/yeongseon/azure-functions-openapi-python) | OpenAPI 사양 생성 및 Swagger UI |
-| [azure-functions-langgraph-python](https://github.com/yeongseon/azure-functions-langgraph-python) | Azure Functions용 LangGraph 배포 어댑터 |
-| [azure-functions-logging-python](https://github.com/yeongseon/azure-functions-logging-python) | 구조화된 로깅 및 관측성 |
-| [azure-functions-doctor-python](https://github.com/yeongseon/azure-functions-doctor-python) | 배포 전 진단 CLI |
-| [azure-functions-durable-graph-python](https://github.com/yeongseon/azure-functions-durable-graph-python) | Durable Functions 기반 그래프 런타임 *(계획)* |
-| [azure-functions-cookbook-python](https://github.com/yeongseon/azure-functions-cookbook-python) | 레시피 및 예제 |
+| **azure-functions-scaffold** | 프로젝트 스캐폴딩 CLI |
+| [azure-functions-validation](https://github.com/yeongseon/azure-functions-validation-python) | 요청/응답 검증 및 직렬화 |
+| [azure-functions-openapi](https://github.com/yeongseon/azure-functions-openapi-python) | OpenAPI 사양 생성 및 Swagger UI |
+| [azure-functions-langgraph](https://github.com/yeongseon/azure-functions-langgraph-python) | Azure Functions용 LangGraph 배포 어댑터 |
+| [azure-functions-logging](https://github.com/yeongseon/azure-functions-logging-python) | 구조화된 로깅 및 관측성 |
+| [azure-functions-doctor](https://github.com/yeongseon/azure-functions-doctor-python) | 배포 전 진단 CLI |
+| [azure-functions-durable-graph](https://github.com/yeongseon/azure-functions-durable-graph-python) | Durable Functions 기반 그래프 런타임 *(계획)* |
+| [azure-functions-cookbook](https://github.com/yeongseon/azure-functions-cookbook-python) | 레시피 및 예제 |
 
 ## 면책 조항
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Azure Functions Scaffold
 
-[![PyPI](https://img.shields.io/pypi/v/azure-functions-scaffold-python.svg)](https://pypi.org/project/azure-functions-scaffold-python/)
-[![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-scaffold-python/)
+[![PyPI](https://img.shields.io/pypi/v/azure-functions-scaffold.svg)](https://pypi.org/project/azure-functions-scaffold/)
+[![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-scaffold/)
 [![CI](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/release.yml/badge.svg)](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/release.yml)
 [![Security Scans](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/security.yml)
@@ -16,7 +16,7 @@ Scaffolding CLI for production-ready Azure Functions Python v2 projects.
 
 ## Why Use It
 
-Starting a new Azure Functions project means setting up boilerplate: `host.json`, `function_app.py`, directory structure, tooling config, and tests. `azure-functions-scaffold-python` generates a production-ready project layout in one command, so you can focus on business logic from the start.
+Starting a new Azure Functions project means setting up boilerplate: `host.json`, `function_app.py`, directory structure, tooling config, and tests. `azure-functions-scaffold` generates a production-ready project layout in one command, so you can focus on business logic from the start.
 
 ```mermaid
 flowchart LR
@@ -24,7 +24,7 @@ flowchart LR
     CLI["afs new my-api"]
     T["Templates"]
     P["Generated Project"]
-    VAL["azure-functions-validation-python"]
+    VAL["azure-functions-validation"]
 
     Dev --> CLI
     CLI --> T
@@ -46,9 +46,9 @@ This tool generates project scaffolds. It does **not** provide runtime libraries
 This package does not own:
 
 - **Runtime behavior** — intent commands choose optional package wiring during generation, but runtime logic belongs to those packages
-- **API documentation** — use [`azure-functions-openapi-python`](https://github.com/yeongseon/azure-functions-openapi-python) for API documentation and spec generation
-- **Request validation** — use [`azure-functions-validation-python`](https://github.com/yeongseon/azure-functions-validation-python) for request/response validation and serialization
-- **Database bindings** — use [`azure-functions-db-python`](https://github.com/yeongseon/azure-functions-db-python) for database input/output bindings
+- **API documentation** — use [`azure-functions-openapi`](https://github.com/yeongseon/azure-functions-openapi-python) for API documentation and spec generation
+- **Request validation** — use [`azure-functions-validation`](https://github.com/yeongseon/azure-functions-validation-python) for request/response validation and serialization
+- **Database bindings** — use [`azure-functions-db`](https://github.com/yeongseon/azure-functions-db-python) for database input/output bindings
 
 ## Features
 
@@ -60,12 +60,12 @@ This package does not own:
 - Advanced power-user commands: `afs advanced new`, `afs advanced add`, `afs advanced add-route`, and `afs advanced add-resource`
 - Optional feature flags (`--with-openapi`, `--with-validation`, `--with-doctor`) and `--preset minimal|standard|strict` available via `afs advanced new`
 - Discovery commands: `afs templates` and `afs presets`
-- Short alias: `afs` is the primary CLI entry point for `azure-functions-scaffold-python`
+- Short alias: `afs` is the primary CLI entry point for `azure-functions-scaffold`
 
 ## Installation
 
 ```bash
-pip install azure-functions-scaffold-python
+pip install azure-functions-scaffold
 ```
 
 ## Quick Start
@@ -145,7 +145,7 @@ Why this layout works:
 | servicebus | `afs worker servicebus my-bus` | Enterprise messaging |
 | langgraph | `afs ai agent my-agent` | LangGraph AI agent deployment |
 
-Note: `afs` is short for `azure-functions-scaffold-python`. Both work.
+Note: `afs` is short for `azure-functions-scaffold`. Both work.
 
 Template defaults:
 
@@ -256,19 +256,19 @@ make build
 
 This package is part of the **Azure Functions Python DX Toolkit**.
 
-**Design principle:** `azure-functions-scaffold-python` owns project generation and template expansion. It does not provide runtime libraries — runtime behavior belongs to [`azure-functions-openapi-python`](https://github.com/yeongseon/azure-functions-openapi-python) (API documentation and spec generation), [`azure-functions-validation-python`](https://github.com/yeongseon/azure-functions-validation-python) (request/response validation), and [`azure-functions-langgraph-python`](https://github.com/yeongseon/azure-functions-langgraph-python) (LangGraph runtime exposure).
+**Design principle:** `azure-functions-scaffold` owns project generation and template expansion. It does not provide runtime libraries — runtime behavior belongs to [`azure-functions-openapi`](https://github.com/yeongseon/azure-functions-openapi-python) (API documentation and spec generation), [`azure-functions-validation`](https://github.com/yeongseon/azure-functions-validation-python) (request/response validation), and [`azure-functions-langgraph`](https://github.com/yeongseon/azure-functions-langgraph-python) (LangGraph runtime exposure).
 
 | Package | Role |
 |---------|------|
-| [azure-functions-openapi-python](https://github.com/yeongseon/azure-functions-openapi-python) | OpenAPI spec generation and Swagger UI |
-| [azure-functions-validation-python](https://github.com/yeongseon/azure-functions-validation-python) | Request/response validation and serialization |
-| [azure-functions-db-python](https://github.com/yeongseon/azure-functions-db-python) | Database bindings for SQL, PostgreSQL, MySQL, SQLite, and Cosmos DB |
-| [azure-functions-langgraph-python](https://github.com/yeongseon/azure-functions-langgraph-python) | LangGraph deployment adapter for Azure Functions |
-| **azure-functions-scaffold-python** | Project scaffolding CLI |
-| [azure-functions-logging-python](https://github.com/yeongseon/azure-functions-logging-python) | Structured logging and observability |
-| [azure-functions-doctor-python](https://github.com/yeongseon/azure-functions-doctor-python) | Pre-deploy diagnostic CLI |
-| [azure-functions-durable-graph-python](https://github.com/yeongseon/azure-functions-durable-graph-python) | Manifest-first graph runtime with Durable Functions *(experimental)* |
-| [azure-functions-cookbook-python](https://github.com/yeongseon/azure-functions-cookbook-python) | Recipes and examples |
+| [azure-functions-openapi](https://github.com/yeongseon/azure-functions-openapi-python) | OpenAPI spec generation and Swagger UI |
+| [azure-functions-validation](https://github.com/yeongseon/azure-functions-validation-python) | Request/response validation and serialization |
+| [azure-functions-db](https://github.com/yeongseon/azure-functions-db-python) | Database bindings for SQL, PostgreSQL, MySQL, SQLite, and Cosmos DB |
+| [azure-functions-langgraph](https://github.com/yeongseon/azure-functions-langgraph-python) | LangGraph deployment adapter for Azure Functions |
+| **azure-functions-scaffold** | Project scaffolding CLI |
+| [azure-functions-logging](https://github.com/yeongseon/azure-functions-logging-python) | Structured logging and observability |
+| [azure-functions-doctor](https://github.com/yeongseon/azure-functions-doctor-python) | Pre-deploy diagnostic CLI |
+| [azure-functions-durable-graph](https://github.com/yeongseon/azure-functions-durable-graph-python) | Manifest-first graph runtime with Durable Functions *(experimental)* |
+| [azure-functions-cookbook](https://github.com/yeongseon/azure-functions-cookbook-python) | Recipes and examples |
 
 ## For AI Coding Assistants
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,7 +1,7 @@
 # Azure Functions Scaffold
 
-[![PyPI](https://img.shields.io/pypi/v/azure-functions-scaffold-python.svg)](https://pypi.org/project/azure-functions-scaffold-python/)
-[![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-scaffold-python/)
+[![PyPI](https://img.shields.io/pypi/v/azure-functions-scaffold.svg)](https://pypi.org/project/azure-functions-scaffold/)
+[![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-scaffold/)
 [![CI](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/release.yml/badge.svg)](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/release.yml)
 [![Security Scans](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/security.yml)
@@ -16,7 +16,7 @@
 
 ## 为什么使用它
 
-启动新的 Azure Functions 项目意味着设置样板文件：`host.json`、`function_app.py`、目录结构、工具配置和测试。`azure-functions-scaffold-python` 通过一个命令生成生产级项目布局，让你从一开始就专注于业务逻辑。
+启动新的 Azure Functions 项目意味着设置样板文件：`host.json`、`function_app.py`、目录结构、工具配置和测试。`azure-functions-scaffold` 通过一个命令生成生产级项目布局，让你从一开始就专注于业务逻辑。
 
 ## 范围
 
@@ -34,12 +34,12 @@
 - 可选集成: `--with-openapi`、`--with-validation`、`--with-doctor`
 - 预设工具级别: `--preset minimal|standard|strict`
 - 面向高级用户的细粒度参数控制: `afs advanced new`
-- 短别名: `afs` 可替代 `azure-functions-scaffold-python`
+- 短别名: `afs` 可替代 `azure-functions-scaffold`
 
 ## 安装
 
 ```bash
-pip install azure-functions-scaffold-python
+pip install azure-functions-scaffold
 ```
 
 ## 快速开始
@@ -118,7 +118,7 @@ my-api/
 | blob | `afs worker blob my-blob` | 文件处理 (Azurite) |
 | servicebus | `afs worker servicebus my-bus` | 企业消息传递 |
 
-注意: `afs` 是 `azure-functions-scaffold-python` 的简称。两者都可用。
+注意: `afs` 是 `azure-functions-scaffold` 的简称。两者都可用。
 
 模板默认值:
 
@@ -211,14 +211,14 @@ make build
 
 | 包 | 角色 |
 |---------|------|
-| **azure-functions-scaffold-python** | 项目脚手架 CLI |
-| [azure-functions-validation-python](https://github.com/yeongseon/azure-functions-validation-python) | 请求/响应校验与序列化 |
-| [azure-functions-openapi-python](https://github.com/yeongseon/azure-functions-openapi-python) | OpenAPI 规范生成与 Swagger UI |
-| [azure-functions-langgraph-python](https://github.com/yeongseon/azure-functions-langgraph-python) | Azure Functions 的 LangGraph 部署适配器 |
-| [azure-functions-logging-python](https://github.com/yeongseon/azure-functions-logging-python) | 结构化日志与可观测性 |
-| [azure-functions-doctor-python](https://github.com/yeongseon/azure-functions-doctor-python) | 部署前诊断 CLI |
-| [azure-functions-durable-graph-python](https://github.com/yeongseon/azure-functions-durable-graph-python) | 基于 Durable Functions 的图运行时 *(计划中)* |
-| [azure-functions-cookbook-python](https://github.com/yeongseon/azure-functions-cookbook-python) | 食谱与示例 |
+| **azure-functions-scaffold** | 项目脚手架 CLI |
+| [azure-functions-validation](https://github.com/yeongseon/azure-functions-validation-python) | 请求/响应校验与序列化 |
+| [azure-functions-openapi](https://github.com/yeongseon/azure-functions-openapi-python) | OpenAPI 规范生成与 Swagger UI |
+| [azure-functions-langgraph](https://github.com/yeongseon/azure-functions-langgraph-python) | Azure Functions 的 LangGraph 部署适配器 |
+| [azure-functions-logging](https://github.com/yeongseon/azure-functions-logging-python) | 结构化日志与可观测性 |
+| [azure-functions-doctor](https://github.com/yeongseon/azure-functions-doctor-python) | 部署前诊断 CLI |
+| [azure-functions-durable-graph](https://github.com/yeongseon/azure-functions-durable-graph-python) | 基于 Durable Functions 的图运行时 *(计划中)* |
+| [azure-functions-cookbook](https://github.com/yeongseon/azure-functions-cookbook-python) | 食谱与示例 |
 
 ## 免责声明
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to the `azure-functions-scaffold-python` project are documented on this page. This project adheres to Semantic Versioning and maintains a structured history of updates, features, and bug fixes.
+All notable changes to the `azure-functions-scaffold` project are documented on this page. This project adheres to Semantic Versioning and maintains a structured history of updates, features, and bug fixes.
 
 ## Versioning Scheme
 
@@ -29,17 +29,17 @@ This release captures the tooling unification and documentation overhaul applied
 This release introduces health check integration and enhanced structured logging capabilities across all project templates.
 
 #### Added
-- Introduced `--with-doctor` and `--no-doctor` flags for the `new` command to include `azure-functions-doctor-python` health checks in scaffolded projects.
+- Introduced `--with-doctor` and `--no-doctor` flags for the `new` command to include `azure-functions-doctor` health checks in scaffolded projects.
 - Added an interactive prompt to choose whether to include the doctor health check tool during project setup.
 - Implemented a conditional `make doctor` target in the generated `Makefile` when the doctor flag is enabled.
-- Set `azure-functions-logging-python>=0.2.0` as a default dependency for all generated project templates.
+- Set `azure-functions-logging>=0.2.0` as a default dependency for all generated project templates.
 - Added structured JSON logging support via `setup_logging(format="json")` and `get_logger()` in the generated `logging.py` file.
 - Updated non-HTTP function templates to use `logging.info()` instead of `print()` for better production readiness.
 - Added a dry-run report status for the doctor tool, showing "Doctor: enabled" when requested.
 - Expanded test coverage to include the doctor flag, dry-run output verification, and logging dependency management.
 
 #### Changed
-- Refactored the generated `logging.py` to replace the basic `basicConfig` stub with full `azure-functions-logging-python` integration.
+- Refactored the generated `logging.py` to replace the basic `basicConfig` stub with full `azure-functions-logging` integration.
 - Updated Queue, Blob, and Service Bus function templates to use lazy `%s` format strings for more efficient logging.
 
 ### v0.2.0 (2026-03-12)
@@ -56,7 +56,7 @@ This update focuses on the HTTP template, adding optional support for OpenAPI do
 
 ### v0.1.0 (2026-03-08)
 
-The initial release of the `azure-functions-scaffold-python` CLI, providing a robust foundation for building Azure Functions Python v2 projects.
+The initial release of the `azure-functions-scaffold` CLI, providing a robust foundation for building Azure Functions Python v2 projects.
 
 #### Added
 - Launched the interactive `new` command for bootstrapping Azure Functions Python v2 projects with ease.

--- a/docs/choose-a-plan.md
+++ b/docs/choose-a-plan.md
@@ -94,7 +94,7 @@ Start here:
 
 **For most users**: Start with **Flex Consumption**. It costs nothing when idle, handles most workloads well, and you can switch plans later without changing your code.
 
-**For LLM/AI workloads** (like `azure-functions-langgraph-python`): Start with **Premium EP1**. LLM calls can take 30+ seconds, and cold starts frustrate users. Premium gives you always-warm instances and no hard timeout ceiling.
+**For LLM/AI workloads** (like `azure-functions-langgraph`): Start with **Premium EP1**. LLM calls can take 30+ seconds, and cold starts frustrate users. Premium gives you always-warm instances and no hard timeout ceiling.
 
 ## Cost at a glance
 
@@ -245,7 +245,7 @@ Most `azure-functions-*` repos default to **Flex Consumption** because:
 - Simple provisioning (no plan creation step)
 - Sufficient timeout (30 min) for most HTTP workloads
 
-**Exception**: `azure-functions-langgraph-python` defaults to **Premium** because:
+**Exception**: `azure-functions-langgraph` defaults to **Premium** because:
 - LLM/agent invocations can take 30+ seconds
 - Cold starts degrade the AI agent user experience
 - Dependency footprint is larger (LangGraph + LLM SDKs)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -10,7 +10,7 @@ Now you want to deploy it to Azure so it runs in the cloud. This guide assumes y
 
 ## What you are deploying
 
-`azure-functions-scaffold-python` generates ready-to-deploy Azure Functions projects from templates.
+`azure-functions-scaffold` generates ready-to-deploy Azure Functions projects from templates.
 This guide deploys two templates:
 
 - **`http` template** — An HTTP API with a `/api/hello` endpoint
@@ -45,7 +45,7 @@ After following this guide, your scaffolded project will be running on Azure and
 | Azure CLI | `az --version` | [Install Azure CLI](https://learn.microsoft.com/cli/azure/install-azure-cli) |
 | Azure Functions Core Tools v4 | `func --version` | [Install Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local#install-the-azure-functions-core-tools) |
 | Python 3.10–3.13 | `python --version` | [python.org](https://www.python.org/downloads/) |
-| `afs` CLI installed | `afs --version` | `pip install azure-functions-scaffold-python` |
+| `afs` CLI installed | `afs --version` | `pip install azure-functions-scaffold` |
 | Local project working | `func start` → responds to `curl` | See [README Quick Start](https://github.com/yeongseon/azure-functions-scaffold-python/blob/main/README.md) |
 
 > ⚠️ **Verify locally first.** If your project doesn't work locally, it won't work on Azure either.
@@ -110,7 +110,7 @@ Azure Functions expects a `requirements.txt` file in the project root:
 ```bash
 cat > requirements.txt << 'EOF'
 azure-functions>=1.23.0
-azure-functions-logging-python>=0.2.0
+azure-functions-logging>=0.2.0
 EOF
 ```
 
@@ -301,7 +301,7 @@ cd my-timer-job
 ```bash
 cat > requirements.txt << 'EOF'
 azure-functions>=1.23.0
-azure-functions-logging-python>=0.2.0
+azure-functions-logging>=0.2.0
 EOF
 ```
 
@@ -533,8 +533,8 @@ az group list --query "[?starts_with(name, 'rg-scaffold')]" -o table
 
 - [Choose an Azure Functions Hosting Plan](choose-a-plan.md) — Plan selection guide with decision tree
 - [Deploying guide](./guide/deploying.md) — Additional deployment topics
-- [`azure-functions-openapi-python`](https://github.com/yeongseon/azure-functions-openapi-python)
-- [`azure-functions-validation-python`](https://github.com/yeongseon/azure-functions-validation-python)
-- [`azure-functions-doctor-python`](https://github.com/yeongseon/azure-functions-doctor-python)
-- [`azure-functions-logging-python`](https://github.com/yeongseon/azure-functions-logging-python)
-- [`azure-functions-langgraph-python`](https://github.com/yeongseon/azure-functions-langgraph-python)
+- [`azure-functions-openapi`](https://github.com/yeongseon/azure-functions-openapi-python)
+- [`azure-functions-validation`](https://github.com/yeongseon/azure-functions-validation-python)
+- [`azure-functions-doctor`](https://github.com/yeongseon/azure-functions-doctor-python)
+- [`azure-functions-logging`](https://github.com/yeongseon/azure-functions-logging-python)
+- [`azure-functions-langgraph`](https://github.com/yeongseon/azure-functions-langgraph-python)

--- a/docs/examples/ai_agents.md
+++ b/docs/examples/ai_agents.md
@@ -245,7 +245,7 @@ pytest
 !!! note "LangGraph documentation"
     For deeper LangGraph configuration — tools, multi-step graphs, LLM
     integration — see the
-    [azure-functions-langgraph-python](https://github.com/yeongseon/azure-functions-langgraph-python)
+    [azure-functions-langgraph](https://github.com/yeongseon/azure-functions-langgraph-python)
     documentation.
 
 ## 9) Customization Patterns
@@ -277,7 +277,7 @@ pytest
 !!! warning "Module not found errors"
     Confirm all dependencies are installed. The AI template requires the
     `openai` package. The LangGraph template requires `langgraph` and
-    `azure-functions-langgraph-python`.
+    `azure-functions-langgraph`.
 
 !!! warning "Empty response from chat endpoint"
     Check that `AZURE_OPENAI_DEPLOYMENT` matches an existing deployment in

--- a/docs/examples/full_stack.md
+++ b/docs/examples/full_stack.md
@@ -47,7 +47,7 @@ make doctor
 ```
 
 !!! note "What doctor adds"
-    `--with-doctor` adds `azure-functions-doctor-python` dependency and Makefile target.
+    `--with-doctor` adds `azure-functions-doctor` dependency and Makefile target.
     It does not auto-create an HTTP endpoint.
 
 ## 3) Verify Generated Feature Set

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,6 +1,6 @@
 # FAQ
 
-Answers to common questions about `azure-functions-scaffold-python` and generated
+Answers to common questions about `azure-functions-scaffold` and generated
 projects.
 
 ## What templates are available?
@@ -76,7 +76,7 @@ Practical options:
 Examples:
 
 - OpenAPI requires route handlers in `function_app.py` and OpenAPI decorators.
-- Validation requires `azure-functions-validation-python`, request/response models, and
+- Validation requires `azure-functions-validation`, request/response models, and
   validated endpoint signatures.
 - Doctor requires dependency plus command invocation (for example `make doctor`).
 
@@ -112,7 +112,7 @@ Yes when pytest tooling is enabled.
 When adding functions with `afs add`, test files are created if a `tests/`
 directory exists in the project.
 
-## Does `afs` differ from `azure-functions-scaffold-python`?
+## Does `afs` differ from `azure-functions-scaffold`?
 
 No. `afs` is a short alias and a drop-in replacement.
 
@@ -120,7 +120,7 @@ These are equivalent:
 
 ```bash
 afs new my-api
-azure-functions-scaffold-python new my-api
+azure-functions-scaffold new my-api
 ```
 
 ## Can I preview changes before writing files?

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-This guide explains how `azure-functions-scaffold-python` maps CLI options to generated
+This guide explains how `azure-functions-scaffold` maps CLI options to generated
 project behavior. Use it when you need predictable output across environments,
 teams, and CI pipelines.
 
@@ -25,7 +25,7 @@ You will primarily configure projects through:
 - `afs new <name>` for project creation.
 - `afs add <trigger> <name>` for adding new function modules.
 
-`afs` is a short alias for `azure-functions-scaffold-python` and behaves exactly the
+`afs` is a short alias for `azure-functions-scaffold` and behaves exactly the
 same.
 
 ## `new` Command Options
@@ -57,7 +57,7 @@ The following are included in every generated project regardless of flags.
 
 | Feature | Dependency | Location |
 | :--- | :--- | :--- |
-| Structured logging | `azure-functions-logging-python` | `app/core/logging.py` |
+| Structured logging | `azure-functions-logging` | `app/core/logging.py` |
 
 Structured JSON logging is pre-configured via `configure_logging()` in `app/core/logging.py`
 and called at startup in `function_app.py`. No additional flag is required.
@@ -79,8 +79,8 @@ logger = get_logger("my-api")
 | Flag | Default | Effect |
 | :--- | :--- | :--- |
 | `--with-openapi` / `--no-openapi` | `--no-openapi` | Adds OpenAPI routes (`/api/docs`, `/api/openapi.json`, `/api/openapi.yaml`) for HTTP projects. |
-| `--with-validation` / `--no-validation` | `--no-validation` | Adds `azure-functions-validation-python` and Pydantic request/response model validation for HTTP projects. |
-| `--with-doctor` / `--no-doctor` | `--no-doctor` | Adds `azure-functions-doctor-python` dependency and a `make doctor` target. |
+| `--with-validation` / `--no-validation` | `--no-validation` | Adds `azure-functions-validation` and Pydantic request/response model validation for HTTP projects. |
+| `--with-doctor` / `--no-doctor` | `--no-doctor` | Adds `azure-functions-doctor` dependency and a `make doctor` target. |
 
 !!! warning "HTTP-only behavior"
     `--with-openapi` and `--with-validation` are intended for the HTTP template.

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -26,7 +26,7 @@ Combine flags to add specialized capabilities to your project.
 
 #### Structured Logging (Built-in)
 
-Every scaffold template includes `azure-functions-logging-python` as a default dependency.
+Every scaffold template includes `azure-functions-logging` as a default dependency.
 Structured JSON logging is configured in `app/core/logging.py` and activated at startup
 in `function_app.py` — no flag required.
 
@@ -50,11 +50,11 @@ from app.core.logging import logger
 logger.info("request received", route="/api/hello")
 ```
 
-See [azure-functions-logging-python](https://github.com/yeongseon/azure-functions-logging-python) for the full API.
+See [azure-functions-logging](https://github.com/yeongseon/azure-functions-logging-python) for the full API.
 
 #### --with-openapi
 
-Adds `azure-functions-openapi-python` to the dependencies and configures HTTP triggers with the necessary decorators for Swagger/OpenAPI documentation.
+Adds `azure-functions-openapi` to the dependencies and configures HTTP triggers with the necessary decorators for Swagger/OpenAPI documentation.
 
 ```bash
 afs new swagger-api --with-openapi

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -16,10 +16,10 @@ Install the CLI globally or in a virtual environment. Use `pipx` if you want to 
 
 ```bash
 # Global install
-pip install azure-functions-scaffold-python
+pip install azure-functions-scaffold
 
 # Recommended (Isolated install)
-pipx install azure-functions-scaffold-python
+pipx install azure-functions-scaffold
 ```
 
 Verify the installation by running the command or its alias:

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -1,6 +1,6 @@
 # Introduction
 
-`azure-functions-scaffold-python` is a CLI for creating and evolving Azure Functions
+`azure-functions-scaffold` is a CLI for creating and evolving Azure Functions
 Python v2 projects with consistent architecture and practical defaults.
 
 It generates the wiring you would otherwise repeat manually:
@@ -24,7 +24,7 @@ It generates the wiring you would otherwise repeat manually:
 4. Use preset-driven quality checks in CI.
 
 ```bash
-pip install azure-functions-scaffold-python
+pip install azure-functions-scaffold
 afs new my-api --preset standard
 cd my-api
 pip install -e .[dev]
@@ -54,7 +54,7 @@ func start
 - `--with-doctor` for diagnostics integration (`make doctor`)
 
 !!! note "Command alias"
-    `afs` and `azure-functions-scaffold-python` are equivalent. Use whichever fits your
+    `afs` and `azure-functions-scaffold` are equivalent. Use whichever fits your
     shell scripts and team conventions.
 
 ## Recommended Reading Order

--- a/docs/guide/stacks.md
+++ b/docs/guide/stacks.md
@@ -11,9 +11,9 @@ and the scaffold command to generate a matching project.
 
 | Package | Role |
 |---------|------|
-| `azure-functions-openapi-python` | Swagger UI + OpenAPI 3.1 spec |
-| `azure-functions-validation-python` | Pydantic request/response validation |
-| `azure-functions-logging-python` | Structured JSON logging |
+| `azure-functions-openapi` | Swagger UI + OpenAPI 3.1 spec |
+| `azure-functions-validation` | Pydantic request/response validation |
+| `azure-functions-logging` | Structured JSON logging |
 
 ```bash
 afs new my-api --profile api
@@ -22,9 +22,9 @@ afs new my-api --profile api
 ```text
 # requirements.txt
 azure-functions
-azure-functions-openapi-python
-azure-functions-validation-python
-azure-functions-logging-python
+azure-functions-openapi
+azure-functions-validation
+azure-functions-logging
 ```
 
 **What you get:** validated HTTP endpoints with auto-generated API docs,
@@ -38,10 +38,10 @@ structured logs, and request correlation IDs.
 
 | Package | Role |
 |---------|------|
-| `azure-functions-openapi-python` | Swagger UI + OpenAPI 3.1 spec |
-| `azure-functions-validation-python` | Pydantic request/response validation |
-| `azure-functions-db-python` | Declarative database input/output bindings |
-| `azure-functions-logging-python` | Structured JSON logging |
+| `azure-functions-openapi` | Swagger UI + OpenAPI 3.1 spec |
+| `azure-functions-validation` | Pydantic request/response validation |
+| `azure-functions-db` | Declarative database input/output bindings |
+| `azure-functions-logging` | Structured JSON logging |
 
 ```bash
 afs new my-api --profile db-api
@@ -50,10 +50,10 @@ afs new my-api --profile db-api
 ```text
 # requirements.txt
 azure-functions
-azure-functions-openapi-python
-azure-functions-validation-python
-azure-functions-db-python[postgres]
-azure-functions-logging-python
+azure-functions-openapi
+azure-functions-validation
+azure-functions-db[postgres]
+azure-functions-logging
 ```
 
 **What you get:** everything in the API Stack plus declarative database
@@ -67,9 +67,9 @@ read/write bindings via `@db.input()` and `@db.output()`.
 
 | Package | Role |
 |---------|------|
-| `azure-functions-langgraph-python` | LangGraph HTTP deployment adapter |
-| `azure-functions-openapi-python` | Swagger UI for agent endpoints |
-| `azure-functions-logging-python` | Structured JSON logging |
+| `azure-functions-langgraph` | LangGraph HTTP deployment adapter |
+| `azure-functions-openapi` | Swagger UI for agent endpoints |
+| `azure-functions-logging` | Structured JSON logging |
 
 ```bash
 afs new my-agent --template langgraph
@@ -79,9 +79,9 @@ afs new my-agent --template langgraph
 # requirements.txt
 azure-functions
 langgraph
-azure-functions-langgraph-python
-azure-functions-openapi-python
-azure-functions-logging-python
+azure-functions-langgraph
+azure-functions-openapi
+azure-functions-logging
 ```
 
 **What you get:** invoke, stream, and health endpoints for LangGraph graphs,
@@ -96,11 +96,11 @@ database access, health diagnostics, and observability.
 
 | Package | Role |
 |---------|------|
-| `azure-functions-openapi-python` | Swagger UI + OpenAPI 3.1 spec |
-| `azure-functions-validation-python` | Pydantic request/response validation |
-| `azure-functions-db-python` | Declarative database bindings |
-| `azure-functions-logging-python` | Structured JSON logging |
-| `azure-functions-doctor-python` | Pre-deploy diagnostic checks |
+| `azure-functions-openapi` | Swagger UI + OpenAPI 3.1 spec |
+| `azure-functions-validation` | Pydantic request/response validation |
+| `azure-functions-db` | Declarative database bindings |
+| `azure-functions-logging` | Structured JSON logging |
+| `azure-functions-doctor` | Pre-deploy diagnostic checks |
 
 ```bash
 afs new my-api --profile db-api --with-doctor
@@ -109,11 +109,11 @@ afs new my-api --profile db-api --with-doctor
 ```text
 # requirements.txt
 azure-functions
-azure-functions-openapi-python
-azure-functions-validation-python
-azure-functions-db-python[postgres]
-azure-functions-logging-python
-azure-functions-doctor-python
+azure-functions-openapi
+azure-functions-validation
+azure-functions-db[postgres]
+azure-functions-logging
+azure-functions-doctor
 ```
 
 **What you get:** a fully instrumented API with validation, database access,

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -124,7 +124,7 @@ afs advanced new --template ai --preset standard my-ai-api
 
 ### LangGraph Template
 
-Deploys a LangGraph agent as an Azure Functions app using `azure-functions-langgraph-python`.
+Deploys a LangGraph agent as an Azure Functions app using `azure-functions-langgraph`.
 
 ```bash
 afs ai agent my-agent

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -1,7 +1,7 @@
 # Troubleshooting
 
 Use this page to diagnose common CLI and runtime issues for
-`azure-functions-scaffold-python` projects.
+`azure-functions-scaffold` projects.
 
 ## CLI Installation and Execution
 
@@ -20,7 +20,7 @@ Use this page to diagnose common CLI and runtime issues for
 **Fix**
 
 ```bash
-pipx install azure-functions-scaffold-python
+pipx install azure-functions-scaffold
 afs --version
 ```
 

--- a/docs/guide/tutorial.md
+++ b/docs/guide/tutorial.md
@@ -8,7 +8,7 @@ The default template generates a RESTful API endpoint with a clean separation be
 
 ### Generate the Project
 
-Run the following command to create a new project using the `azure-functions-scaffold-python` CLI (aliased as `afs`):
+Run the following command to create a new project using the `azure-functions-scaffold` CLI (aliased as `afs`):
 
 ```bash
 afs new my-api
@@ -65,12 +65,12 @@ import azure.functions as func
 from app.core.logging import configure_logging
 from app.functions.http import http_blueprint
 
-# azure-functions-scaffold-python: function imports
+# azure-functions-scaffold: function imports
 
 configure_logging()
 
 app = func.FunctionApp()
-# azure-functions-scaffold-python: function registrations
+# azure-functions-scaffold: function registrations
 app.register_functions(http_blueprint)
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,7 +2,7 @@
 
 Scaffold production-ready Azure Functions Python v2 projects in one command.
 
-`azure-functions-scaffold-python` gives you a clean, modular starting point with
+`azure-functions-scaffold` gives you a clean, modular starting point with
 opinionated defaults, optional feature integrations, and predictable structure.
 Use the short alias `afs` or the full command name interchangeably.
 
@@ -54,7 +54,7 @@ That creates a working HTTP project scaffold with a practical default preset.
 
 - `--with-openapi`: OpenAPI routes and Swagger UI for HTTP projects
 - `--with-validation`: request/response model validation for HTTP projects
-- `--with-doctor`: adds `azure-functions-doctor-python` integration and command target
+- `--with-doctor`: adds `azure-functions-doctor` integration and command target
 
 ## What You Get in a New Project
 
@@ -86,7 +86,7 @@ Design goals of this layout:
 ## Quick Start Flow
 
 ```bash
-pip install azure-functions-scaffold-python
+pip install azure-functions-scaffold
 afs new my-api --preset standard
 cd my-api
 python -m venv .venv

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,12 +1,12 @@
 # API Reference
 
-This page documents the Python API surface for `azure-functions-scaffold-python`.
+This page documents the Python API surface for `azure-functions-scaffold`.
 Use it when embedding scaffold behavior in tests, custom automation, or other
 developer tooling.
 
 !!! note "CLI-first project"
     The primary public interface is the command line (`afs` /
-    `azure-functions-scaffold-python`). Python imports are useful for advanced flows,
+    `azure-functions-scaffold`). Python imports are useful for advanced flows,
     but CLI compatibility is the main stability target.
 
 ## Module Overview

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -1,6 +1,6 @@
 # Architecture
 
-Internal structure and design principles for `azure-functions-scaffold-python`.
+Internal structure and design principles for `azure-functions-scaffold`.
 
 ## Design Objectives
 
@@ -46,9 +46,9 @@ A CLI tool built with Typer and Jinja2. It provides offline-capable, determinist
 
 ## Public API Boundary
 
-`azure-functions-scaffold-python` is primarily a CLI tool. The package root exports only `__version__` via `__all__`.
+`azure-functions-scaffold` is primarily a CLI tool. The package root exports only `__version__` via `__all__`.
 
-### CLI entry point (`afs` / `azure-functions-scaffold-python`)
+### CLI entry point (`afs` / `azure-functions-scaffold`)
 
 | Command | Description |
 | :--- | :--- |
@@ -227,7 +227,7 @@ The project uses a single domain exception, `ScaffoldError(RuntimeError)`. The C
 
 ### 6. Marker-based function_app.py updates
 
-The `add` command inserts imports and registrations using marker comments (`# azure-functions-scaffold-python: function imports` / `# azure-functions-scaffold-python: function registrations`). This avoids AST manipulation while keeping updates predictable.
+The `add` command inserts imports and registrations using marker comments (`# azure-functions-scaffold: function imports` / `# azure-functions-scaffold: function registrations`). Legacy `azure-functions-scaffold-python` markers are still recognized for backwards compatibility. This avoids AST manipulation while keeping updates predictable.
 
 ## Related Documents
 
@@ -246,8 +246,8 @@ The `add` command inserts imports and registrations using marker comments (`# az
 
 ## See Also
 
-- [azure-functions-validation-python — Architecture](https://github.com/yeongseon/azure-functions-validation-python) — Request/response validation and serialization
-- [azure-functions-openapi-python — Architecture](https://github.com/yeongseon/azure-functions-openapi-python) — API documentation and spec generation
-- [azure-functions-logging-python — Architecture](https://github.com/yeongseon/azure-functions-logging-python) — Structured logging with contextvars
-- [azure-functions-doctor-python — Architecture](https://github.com/yeongseon/azure-functions-doctor-python) — Pre-deploy diagnostic CLI
-- [azure-functions-langgraph-python — Architecture](https://github.com/yeongseon/azure-functions-langgraph-python) — LangGraph runtime exposure for Azure Functions
+- [azure-functions-validation — Architecture](https://github.com/yeongseon/azure-functions-validation-python) — Request/response validation and serialization
+- [azure-functions-openapi — Architecture](https://github.com/yeongseon/azure-functions-openapi-python) — API documentation and spec generation
+- [azure-functions-logging — Architecture](https://github.com/yeongseon/azure-functions-logging-python) — Structured logging with contextvars
+- [azure-functions-doctor — Architecture](https://github.com/yeongseon/azure-functions-doctor-python) — Pre-deploy diagnostic CLI
+- [azure-functions-langgraph — Architecture](https://github.com/yeongseon/azure-functions-langgraph-python) — LangGraph runtime exposure for Azure Functions

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,6 +1,6 @@
 # CLI Reference
 
-Technical specification for the `azure-functions-scaffold-python` (alias: `afs`) command-line interface.
+Technical specification for the `azure-functions-scaffold` (alias: `afs`) command-line interface.
 
 ## Commands
 
@@ -8,7 +8,7 @@ Technical specification for the `azure-functions-scaffold-python` (alias: `afs`)
 
 Generates a new Azure Functions Python v2 project from scratch.
 
-- **Synopsis**: `azure-functions-scaffold-python new [PROJECT_NAME] [OPTIONS]`
+- **Synopsis**: `azure-functions-scaffold new [PROJECT_NAME] [OPTIONS]`
 
 #### Arguments
 
@@ -37,7 +37,7 @@ Generates a new Azure Functions Python v2 project from scratch.
 
 Adds a new function to an existing project.
 
-- **Synopsis**: `azure-functions-scaffold-python add TRIGGER FUNCTION_NAME [OPTIONS]`
+- **Synopsis**: `azure-functions-scaffold add TRIGGER FUNCTION_NAME [OPTIONS]`
 
 #### Arguments
 
@@ -57,19 +57,19 @@ Adds a new function to an existing project.
 
 Lists all available function templates.
 
-- **Synopsis**: `azure-functions-scaffold-python templates`
+- **Synopsis**: `azure-functions-scaffold templates`
 
 ### `presets`
 
 Lists all available project presets and their included tools.
 
-- **Synopsis**: `azure-functions-scaffold-python presets`
+- **Synopsis**: `azure-functions-scaffold presets`
 
 ### `--version`
 
 Shows the current version of the CLI tool.
 
-- **Synopsis**: `azure-functions-scaffold-python --version`
+- **Synopsis**: `azure-functions-scaffold --version`
 
 ## Exit Codes
 

--- a/docs/reference/template-spec.md
+++ b/docs/reference/template-spec.md
@@ -1,6 +1,6 @@
 # Template Specification
 
-Standard for developing and maintaining templates for `azure-functions-scaffold-python`.
+Standard for developing and maintaining templates for `azure-functions-scaffold`.
 
 ## Template Locations
 

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -1,6 +1,6 @@
 # Release Process
 
-This document outlines the steps to release a new version of **azure-functions-scaffold-python** to PyPI and update the changelog using the existing Makefile and Hatch-based workflows.
+This document outlines the steps to release a new version of **azure-functions-scaffold** to PyPI and update the changelog using the existing Makefile and Hatch-based workflows.
 
 ---
 
@@ -95,7 +95,7 @@ make publish-test
 To install from TestPyPI:
 
 ```bash
-pip install --index-url https://test.pypi.org/simple/ azure-functions-scaffold-python
+pip install --index-url https://test.pypi.org/simple/ azure-functions-scaffold
 ```
 
 ---

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,6 +1,6 @@
 # Testing
 
-This guide describes the test suite for `azure-functions-scaffold-python`, including how to run tests, the structure of the test suite, and guidelines for contributing new tests.
+This guide describes the test suite for `azure-functions-scaffold`, including how to run tests, the structure of the test suite, and guidelines for contributing new tests.
 
 ## Running Tests
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -1,10 +1,10 @@
-# azure-functions-scaffold-python — Full LLM Reference
+# azure-functions-scaffold — Full LLM Reference
 
 > Scaffolding CLI for production-ready Azure Functions Python v2 projects.
 
 ## Package Info
 
-- PyPI: `pip install azure-functions-scaffold-python`
+- PyPI: `pip install azure-functions-scaffold`
 - Version: 0.5.0
 - Python: >=3.10, <3.15
 - License: MIT
@@ -15,12 +15,12 @@
 ## Installation
 
 ```bash
-pip install azure-functions-scaffold-python
+pip install azure-functions-scaffold
 ```
 
 ## Entry Points
 
-- CLI: `azure-functions-scaffold-python` or `afs` (short alias)
+- CLI: `azure-functions-scaffold` or `afs` (short alias)
 - Python import: `from azure_functions_scaffold.scaffolder import scaffold_project`
 
 ## Complete CLI Reference
@@ -28,7 +28,7 @@ pip install azure-functions-scaffold-python
 ### Root Command
 
 ```bash
-azure-functions-scaffold-python [GROUP] [COMMAND] [OPTIONS]
+azure-functions-scaffold [GROUP] [COMMAND] [OPTIONS]
 afs [GROUP] [COMMAND] [OPTIONS]
 ```
 

--- a/llms.txt
+++ b/llms.txt
@@ -1,10 +1,10 @@
-# azure-functions-scaffold-python
+# azure-functions-scaffold
 
 > Scaffolding CLI for production-ready Azure Functions Python v2 projects.
 
 ## Package Info
 
-- PyPI: `pip install azure-functions-scaffold-python`
+- PyPI: `pip install azure-functions-scaffold`
 - Version: 0.5.0
 - Python: >=3.10, <3.15
 - License: MIT
@@ -20,7 +20,7 @@ tests so teams can focus on business logic from the start.
 ## CLI Commands
 
 ```bash
-azure-functions-scaffold-python [GROUP] [COMMAND] [OPTIONS]
+azure-functions-scaffold [GROUP] [COMMAND] [OPTIONS]
 afs [GROUP] [COMMAND] [OPTIONS]                    # Short alias
 ```
 
@@ -59,8 +59,8 @@ afs [GROUP] [COMMAND] [OPTIONS]                    # Short alias
 - `--preset` — Preset to apply (`minimal`, `standard`, `strict`)
 - `--with-openapi/--no-openapi` — Include OpenAPI support (HTTP template)
 - `--with-validation/--no-validation` — Include request validation support (HTTP template)
-- `--with-doctor/--no-doctor` — Include `azure-functions-doctor-python`
-- `--with-db/--no-db` — Include `azure-functions-db-python` bindings *(planned — not yet available in CLI)*
+- `--with-doctor/--no-doctor` — Include `azure-functions-doctor`
+- `--with-db/--no-db` — Include `azure-functions-db` bindings *(planned — not yet available in CLI)*
 
 ### Global options
 
@@ -91,7 +91,7 @@ Presets combine tooling levels and best practices:
 
 ```bash
 # Step 1: Install
-pip install azure-functions-scaffold-python
+pip install azure-functions-scaffold
 
 # Step 2: Create project
 afs new my-api
@@ -117,7 +117,7 @@ Use `afs advanced new <name>` for explicit feature control:
 
 - `--with-openapi` — Swagger UI + OpenAPI spec endpoints
 - `--with-validation` — Pydantic request/response validation
-- `--with-doctor` — azure-functions-doctor-python health checks
+- `--with-doctor` — azure-functions-doctor health checks
 - `--with-db` — Database bindings *(planned — not yet available in CLI)*
 
 ## Generated Project Layout
@@ -170,7 +170,7 @@ my-api/
 ## Ecosystem
 
 Part of the Azure Functions Python DX Toolkit:
-- azure-functions-validation-python — Request/response validation
-- azure-functions-openapi-python — OpenAPI spec and Swagger UI
-- azure-functions-doctor-python — Pre-deploy diagnostics CLI
-- azure-functions-langgraph-python — Deploy LangGraph agents as Functions
+- azure-functions-validation — Request/response validation
+- azure-functions-openapi — OpenAPI spec and Swagger UI
+- azure-functions-doctor — Pre-deploy diagnostics CLI
+- azure-functions-langgraph — Deploy LangGraph agents as Functions

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "azure-functions-scaffold-python"
+name = "azure-functions-scaffold"
 description = "Scaffolding CLI for Azure Functions Python v2 projects"
 keywords = ["azure-functions", "azure", "python", "v2", "scaffold", "cli", "code-generator", "serverless"]
 authors = [{ name = "Yeongseon Choe", email = "yeongseon.choe@gmail.com" }]
@@ -64,7 +64,7 @@ Repository = "https://github.com/yeongseon/azure-functions-scaffold-python"
 Issues = "https://github.com/yeongseon/azure-functions-scaffold-python/issues"
 
 [project.scripts]
-azure-functions-scaffold-python = "azure_functions_scaffold.cli:app"
+azure-functions-scaffold = "azure_functions_scaffold.cli:app"
 afs = "azure_functions_scaffold.cli:app"
 
 [build-system]

--- a/src/azure_functions_scaffold/__init__.py
+++ b/src/azure_functions_scaffold/__init__.py
@@ -1,4 +1,4 @@
-"""azure-functions-scaffold-python package."""
+"""azure-functions-scaffold package."""
 
 __all__ = ["__version__"]
 

--- a/src/azure_functions_scaffold/cli_advanced.py
+++ b/src/azure_functions_scaffold/cli_advanced.py
@@ -98,7 +98,7 @@ def advanced_new(
         bool,
         typer.Option(
             "--with-doctor/--no-doctor",
-            help="Include azure-functions-doctor-python health checks.",
+            help="Include azure-functions-doctor health checks.",
         ),
     ] = False,
     with_azd: AzdOption = False,

--- a/src/azure_functions_scaffold/generator.py
+++ b/src/azure_functions_scaffold/generator.py
@@ -10,8 +10,10 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 from azure_functions_scaffold.errors import ScaffoldError
 from azure_functions_scaffold.template_registry import list_templates
 
-FUNCTION_IMPORT_MARKER = "# azure-functions-scaffold-python: function imports"
-FUNCTION_REGISTRATION_MARKER = "# azure-functions-scaffold-python: function registrations"
+FUNCTION_IMPORT_MARKER = "# azure-functions-scaffold: function imports"
+FUNCTION_REGISTRATION_MARKER = "# azure-functions-scaffold: function registrations"
+LEGACY_FUNCTION_IMPORT_MARKER = "# azure-functions-scaffold-python: function imports"
+LEGACY_FUNCTION_REGISTRATION_MARKER = "# azure-functions-scaffold-python: function registrations"
 SUPPORTED_TRIGGERS = tuple(template.name for template in list_templates())
 PARTIALS_ROOT = Path(__file__).parent / "templates" / "partials"
 logger = logging.getLogger(__name__)
@@ -35,10 +37,13 @@ def _validate_function_app_updatable(
         raise ScaffoldError("Function is already registered in function_app.py.")
 
     has_import_target = (
-        FUNCTION_IMPORT_MARKER in content or "configure_logging()" in content
+        FUNCTION_IMPORT_MARKER in content
+        or LEGACY_FUNCTION_IMPORT_MARKER in content
+        or "configure_logging()" in content
     )
     has_registration_target = (
         FUNCTION_REGISTRATION_MARKER in content
+        or LEGACY_FUNCTION_REGISTRATION_MARKER in content
         or "app = func.FunctionApp()" in content
     )
 
@@ -52,6 +57,7 @@ def _validate_function_app_updatable(
             "Cannot update function_app.py: neither the registration marker nor "
             "'app = func.FunctionApp()' was found."
         )
+
 
 def add_function(
     *,
@@ -220,13 +226,19 @@ def _insert_near_marker(
     fallback_anchor: str,
     after_anchor: bool = False,
 ) -> str:
-    if marker in content:
+    legacy_marker = _legacy_marker_for(marker)
+    target_marker = marker
+
+    if target_marker not in content and legacy_marker is not None and legacy_marker in content:
+        target_marker = legacy_marker
+
+    if target_marker in content:
         # Insert new import before the blank line that separates imports from
         # the marker comment, keeping all imports in one contiguous block.
-        blank_then_marker = f"\n\n{marker}"
+        blank_then_marker = f"\n\n{target_marker}"
         if blank_then_marker in content:
-            return content.replace(blank_then_marker, f"\n{line}\n\n{marker}", 1)
-        return content.replace(marker, f"{line}\n{marker}", 1)
+            return content.replace(blank_then_marker, f"\n{line}\n\n{target_marker}", 1)
+        return content.replace(target_marker, f"{line}\n{target_marker}", 1)
 
     if fallback_anchor not in content:
         raise ScaffoldError(
@@ -237,6 +249,14 @@ def _insert_near_marker(
         return content.replace(fallback_anchor, f"{fallback_anchor}\n{line}", 1)
 
     return content.replace(fallback_anchor, f"{line}\n\n{fallback_anchor}", 1)
+
+
+def _legacy_marker_for(marker: str) -> str | None:
+    if marker == FUNCTION_IMPORT_MARKER:
+        return LEGACY_FUNCTION_IMPORT_MARKER
+    if marker == FUNCTION_REGISTRATION_MARKER:
+        return LEGACY_FUNCTION_REGISTRATION_MARKER
+    return None
 
 
 def _render_function_module(trigger: str, function_name: str) -> str:
@@ -693,11 +713,26 @@ def _derive_resource_names(resource_name: str) -> dict[str, str]:
     """
     # Simple English singular: strip trailing 's' when safe.
     # Guard against false positives where stripping 's' produces nonsense.
-    _NO_STRIP = frozenset({
-        "status", "bus", "news", "address", "class", "process",
-        "access", "success", "progress", "focus", "canvas",
-        "analysis", "basis", "crisis", "diagnosis", "thesis",
-    })
+    _NO_STRIP = frozenset(
+        {
+            "status",
+            "bus",
+            "news",
+            "address",
+            "class",
+            "process",
+            "access",
+            "success",
+            "progress",
+            "focus",
+            "canvas",
+            "analysis",
+            "basis",
+            "crisis",
+            "diagnosis",
+            "thesis",
+        }
+    )
     singular = resource_name
     # Check the last segment (after final underscore) for the no-strip list.
     last_segment = resource_name.rsplit("_", maxsplit=1)[-1]

--- a/src/azure_functions_scaffold/templates/langgraph/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/langgraph/pyproject.toml.j2
@@ -25,7 +25,8 @@ readme = "README.md"
 requires-python = ">={{ python_version }},<{{ python_upper_bound }}"
 dependencies = [
   "azure-functions>=1.23.0",
-  "azure-functions-langgraph>=0.5.1",
+  # "azure-functions-langgraph>=0.5.1",
+  # Uncomment after azure-functions-langgraph is published on PyPI.
   "langgraph>=0.2.0",
   "orjson>=3.10.0",
 ]

--- a/tests/e2e/test_scaffold_e2e.py
+++ b/tests/e2e/test_scaffold_e2e.py
@@ -1,7 +1,7 @@
-"""E2E tests for azure-functions-scaffold-python.
+"""E2E tests for azure-functions-scaffold.
 
 Tests that:
-1. `azure-functions-scaffold-python init` generates a valid project
+1. `azure-functions-scaffold init` generates a valid project
 2. The generated project deploys to Azure Functions
 3. The deployed app responds to HTTP requests
 

--- a/tests/test_cli_intents.py
+++ b/tests/test_cli_intents.py
@@ -373,7 +373,8 @@ class TestAiAgent:
         pyproject_text = (project_dir / "pyproject.toml").read_text(encoding="utf-8")
         assert (project_dir / "app/graphs/echo_agent.py").exists()
         assert "LangGraphApp" in function_app_text
-        assert "azure-functions-langgraph>=0.5.1" in pyproject_text
+        assert '# "azure-functions-langgraph>=0.5.1",' in pyproject_text
+        assert "Uncomment after azure-functions-langgraph is published on PyPI." in pyproject_text
 
     def test_dry_run(self, tmp_path: Path) -> None:
         result = runner.invoke(

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -99,6 +99,31 @@ def test_add_function_does_not_create_files_when_function_app_uneditable(tmp_pat
     assert not (project_root / "app/functions/orphan.py").exists()
     assert not (project_root / "tests/test_orphan.py").exists()
 
+
+def test_add_function_works_with_legacy_marker(tmp_path: Path) -> None:
+    project_root = scaffold_project("sample", tmp_path)
+    function_app_path = project_root / "function_app.py"
+    content = function_app_path.read_text(encoding="utf-8")
+    content = content.replace(
+        "# azure-functions-scaffold: function imports",
+        "# azure-functions-scaffold-python: function imports",
+    )
+    content = content.replace(
+        "# azure-functions-scaffold: function registrations",
+        "# azure-functions-scaffold-python: function registrations",
+    )
+    function_app_path.write_text(content, encoding="utf-8")
+
+    add_function(project_root=project_root, trigger="http", function_name="sync-data")
+
+    updated = function_app_path.read_text(encoding="utf-8")
+    assert "from app.functions.sync_data import sync_data_blueprint" in updated
+    assert updated.index("from app.functions.sync_data import sync_data_blueprint") < updated.index(
+        "# azure-functions-scaffold-python: function imports"
+    )
+    assert "app.register_functions(sync_data_blueprint)" in updated
+
+
 def test_add_function_can_skip_test_generation_for_minimal_preset(tmp_path: Path) -> None:
     project_root = scaffold_project(
         "sample",
@@ -540,6 +565,7 @@ class TestDeriveResourceNames:
         assert result["resource_singular"] == "order_status"
         assert result["resource_class"] == "OrderStatus"
 
+
 # ---------------------------------------------------------------------------
 # add_resource
 # ---------------------------------------------------------------------------
@@ -582,6 +608,7 @@ def test_add_resource_blueprint_guards_non_dict_json(tmp_path: Path) -> None:
     blueprint_text = (project_root / "app/functions/products.py").read_text(encoding="utf-8")
     assert "isinstance(body, dict)" in blueprint_text
     assert "Request body must be a JSON object" in blueprint_text
+
 
 def test_add_resource_service_content_is_valid_python(tmp_path: Path) -> None:
     project_root = scaffold_project("sample", tmp_path)
@@ -671,6 +698,7 @@ def test_add_resource_does_not_create_files_when_function_app_uneditable(tmp_pat
     assert not (project_root / "app/services/orphans_service.py").exists()
     assert not (project_root / "app/schemas/orphans.py").exists()
     assert not (project_root / "tests/test_orphans.py").exists()
+
 
 def test_add_resource_skips_test_when_no_tests_dir(tmp_path: Path) -> None:
     project_root = scaffold_project(
@@ -817,6 +845,7 @@ def test_add_route_rejects_non_scaffold_project(tmp_path: Path) -> None:
     ):
         add_route(project_root=project_root, route_name="status")
 
+
 def test_add_route_does_not_create_files_when_function_app_uneditable(tmp_path: Path) -> None:
     """Verify no files are left behind when function_app.py cannot be updated."""
     project_root = scaffold_project("sample", tmp_path)
@@ -828,6 +857,7 @@ def test_add_route_does_not_create_files_when_function_app_uneditable(tmp_path: 
 
     assert not (project_root / "app/functions/orphan.py").exists()
     assert not (project_root / "tests/test_orphan.py").exists()
+
 
 def test_add_route_with_hyphenated_name(tmp_path: Path) -> None:
     project_root = scaffold_project("sample", tmp_path)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,4 +1,4 @@
-"""Tests for the public API surface of azure-functions-scaffold-python."""
+"""Tests for the public API surface of azure-functions-scaffold."""
 
 from importlib import import_module
 from typing import Protocol, cast

--- a/tests/test_scaffolder.py
+++ b/tests/test_scaffolder.py
@@ -580,5 +580,6 @@ def test_scaffold_project_renders_langgraph_template(tmp_path: Path) -> None:
     assert "LangGraphApp" in function_app_text
     assert "lg_app.register" in function_app_text
     pyproject_text = (project_path / "pyproject.toml").read_text(encoding="utf-8")
-    assert "azure-functions-langgraph>=0.5.1" in pyproject_text
+    assert '# "azure-functions-langgraph>=0.5.1",' in pyproject_text
+    assert "Uncomment after azure-functions-langgraph is published on PyPI." in pyproject_text
     assert "langgraph>=0.2.0" in pyproject_text


### PR DESCRIPTION
## Summary
- Rename this package's published/PyPI-facing identity from `azure-functions-scaffold-python` to `azure-functions-scaffold`, update the long-form CLI entry point to match, and refresh README/llms/docs/install snippets accordingly while leaving GitHub repo/docs URLs unchanged.
- Keep generated scaffolds aligned with real PyPI sibling package names by using unsuffixed dependency names; for `azure-functions-langgraph`, leave a commented dependency note until that package is actually published.
- Preserve backwards compatibility for scaffold expansion by teaching the generator to recognize both legacy `# azure-functions-scaffold-python: ...` markers and the new `# azure-functions-scaffold: ...` markers.

## Priority
- BREAKING change targeted for `0.6.0`

## Verified PyPI state
| Package reference | Verified state |
| --- | --- |
| `azure-functions-scaffold-python` | 404 NOT FOUND |
| `azure-functions-scaffold` | 200 OK, `0.5.0` published |
| `azure-functions-openapi-python` | 404 NOT FOUND |
| `azure-functions-openapi` | 200 OK, `0.18.0` published |
| `azure-functions-validation-python` | 404 NOT FOUND |
| `azure-functions-validation` | 200 OK, `0.7.3` published |
| `azure-functions-doctor-python` | 404 NOT FOUND |
| `azure-functions-doctor` | 200 OK, `0.17.0` published |
| `azure-functions-logging-python` | 404 NOT FOUND |
| `azure-functions-logging` | 200 OK, `0.5.3` published |
| `azure-functions-db-python` | 404 NOT FOUND |
| `azure-functions-db` | 200 OK, `0.2.1` published |
| `azure-functions-langgraph-python` | 404 NOT FOUND |
| `azure-functions-langgraph` | not published yet |
| `azure-functions-durable-graph-python` | 404 NOT FOUND |
| `azure-functions-cookbook-python` | 404 NOT FOUND |

## Renaming policy
| Reference type | Old | New |
| --- | --- | --- |
| Self PyPI name | `azure-functions-scaffold-python` | `azure-functions-scaffold` |
| Self CLI entry point | `azure-functions-scaffold-python` | `azure-functions-scaffold` |
| Logging dep | `azure-functions-logging-python` | `azure-functions-logging` |
| OpenAPI dep | `azure-functions-openapi-python` | `azure-functions-openapi` |
| Validation dep | `azure-functions-validation-python` | `azure-functions-validation` |
| Doctor dep | `azure-functions-doctor-python` | `azure-functions-doctor` |
| DB dep | `azure-functions-db-python` | `azure-functions-db` |
| LangGraph dep | `azure-functions-langgraph-python` | `azure-functions-langgraph` |
| GitHub repo URL | `github.com/yeongseon/azure-functions-scaffold-python` | unchanged |
| Docs URL | `yeongseon.github.io/azure-functions-scaffold-python/` | unchanged |
| Generated marker comments | `# azure-functions-scaffold-python:` | `# azure-functions-scaffold:` |

## Compatibility
- `afs` remains unchanged.
- Existing scaffolded projects keep working with `afs api add`, `afs advanced add`, `afs api add-route`, and `afs api add-resource` because the generator now accepts both legacy and new marker comments.
- LangGraph scaffolds now document the pending `azure-functions-langgraph` publish instead of rendering an immediately unresolvable dependency line.

## Validation
| Command | Result |
| --- | --- |
| `pytest tests` | Passed (`237 passed, 3 skipped`, coverage `97.25%`) |
| `ruff check src tests` | Passed |
| `mypy src` | Passed |
| `hatch build` | Passed (`dist/azure_functions_scaffold-0.5.0-py3-none-any.whl`) |

## References
- Closes #71