### PR TITLE
docs(readme): add afs new vs func init comparison table

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -16,6 +16,32 @@
 
 Python バージョンサポート: Azure Functions では 3.10-3.13 は GA、3.14 は **Preview** です。詳しくは [Python バージョンサポート](docs/guide/configuration.md#python-version-support) を参照してください。
 
+## なぜ `func init` ではなく `afs new` を使うのか？
+
+`afs new` は [Azure Functions Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local) の代替ではなく、それらを補完するものです。状況に合わせて最適な方を選択してください。
+
+| 項目 | `func init` + `func new` (公式) | `afs new` (本プロジェクト) |
+|---|---|---|
+| メンテナンス | Microsoft | コミュニティ |
+| スコープ | 最小限の Functions スケルトン | 意見を反映した、プロダクション志向のスターター |
+| プロジェクト構成 | 基本的な `function_app.py` + `host.json` | 階層型: `api/`, `domain/`, `infra/`, テスト, CI |
+| 認証の既定値 | `AuthLevel.ANONYMOUS` | `AuthLevel.ANONYMOUS` (Webhook 用の HMAC 検証コードを含む) |
+| ロギング | `logging` 標準ライブラリ | `azure-functions-logging` 構造化 JSON ロギング設定済み |
+| 可観測性 | なし | オプションの `azure-functions-doctor` ヘルスチェック |
+| OpenAPI | なし | オプションの `azure-functions-openapi` Swagger UI |
+| バリデーション | なし | オプションの `azure-functions-validation` (Pydantic) |
+| テスト構成 | なし | `pytest` 設定 + サンプルテスト |
+| CI | なし | GitHub Actions ワークフロー生成 |
+| テンプレート | トリガーごとの空関数 | トリガー + ビジネスパターンテンプレート (HTTP CRUD, Webhook, ワーク等) |
+| 再入可能性 | 一回限り | `afs api add`, `afs advanced add` 等で既存プロジェクトを拡張可能 |
+| ロックイン | なし | コード生成方式; スキャフォールディング後に `afs` への実行時依存なし |
+
+**`func init` を選ぶべきケース:** 最小限の構成から始めたい場合、Microsoft の公式チュートリアルに従う場合、または Azure Functions のドキュメントと同じレイアウトが必要な場合。
+
+**`afs new` を選ぶべきケース:** 構造化ロギング、適切な認証の既定値、階層化された構成、CI 設定などが最初から含まれたプロジェクトを望み、後から `afs api add` 等で拡張したい場合。
+
+`func init` で始めてから手動で移行することも可能です。`afs new` は利用者を拘束しません。生成されるプロジェクトは標準的な Azure Functions Python コードであり、この CLI への実行時の依存関係はありません。
+
 ## なぜこのツールを使うのか
 
 新しい Azure Functions プロジェクトを始めるには、ボイラープレートの設定が必要です: `host.json`、`function_app.py`、ディレクトリ構造、ツール設定、テスト。`azure-functions-scaffold` は一つのコマンドでプロダクションレベルのプロジェクトレイアウトを生成し、最初からビジネスロジックに集中できるようにします。

--- a/README.ko.md
+++ b/README.ko.md
@@ -16,6 +16,32 @@
 
 Python 버전 지원: Azure Functions에서 3.10-3.13은 GA이며, 3.14는 **Preview**입니다. 자세한 내용은 [Python 버전 지원](docs/guide/configuration.md#python-version-support)을 참고하세요.
 
+## 왜 `func init` 대신 `afs new`를 사용해야 할까?
+
+`afs new`는 [Azure Functions Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local)의 대체제가 아니며, 이를 보완하는 도구입니다. 상황에 맞는 도구를 선택하세요.
+
+| 항목 | `func init` + `func new` (공식) | `afs new` (본 프로젝트) |
+|---|---|---|
+| 유지관리 | Microsoft | 커뮤니티 |
+| 범위 | 최소한의 Functions 스켈레톤 | 의견이 반영된 프로덕션 지향 스타터 |
+| 프로젝트 레이아웃 | 기본적인 `function_app.py` + `host.json` | 계층화된 구조: `api/`, `domain/`, `infra/`, 테스트, CI |
+| 기본 인증 | `AuthLevel.ANONYMOUS` | `AuthLevel.ANONYMOUS` (웹훅 HMAC 검증 코드 포함) |
+| 로깅 | `logging` 표준 라이브러리 | `azure-functions-logging` 구조화된 JSON 로깅 포함 |
+| 관측성 | 없음 | 선택적 `azure-functions-doctor` 상태 확인 |
+| OpenAPI | 없음 | 선택적 `azure-functions-openapi` Swagger UI |
+| 유효성 검사 | 없음 | 선택적 `azure-functions-validation` (Pydantic) |
+| 테스트 스캐폴딩 | 없음 | `pytest` 설정 + 샘플 테스트 |
+| CI | 없음 | GitHub Actions 워크플로우 생성 |
+| 템플릿 | 트리거별 빈 함수 | 트리거 + 비즈니스 패턴 템플릿 (HTTP CRUD, 웹훅, 큐 워커 등) |
+| 재진입성 | 1회성 생성 | `afs api add`, `afs advanced add` 등으로 기존 프로젝트 확장 가능 |
+| 종속성 고착 (Lock-in) | 없음 | 코드 생성 방식; 스캐폴딩 후 `afs`에 대한 런타임 종속성 없음 |
+
+**`func init` 선택 시기:** 가장 작은 시작점이 필요하거나, Microsoft 공식 튜토리얼을 따르거나, Azure Functions 문서에 사용된 정확한 레이아웃이 필요한 경우.
+
+**`afs new` 선택 시기:** 구조화된 로깅, 합리적인 인증 기본값, 계층화된 구조, CI 설정 등이 첫 커밋부터 포함된 프로젝트를 원하며, 이후 `afs api add` 등을 통해 확장하고 싶은 경우.
+
+`func init`으로 시작한 후 수동으로 마이그레이션할 수도 있습니다. `afs new`는 사용자를 가두지 않습니다. 생성된 프로젝트는 일반적인 Azure Functions Python 코드이며 이 CLI에 대한 런타임 종속성이 없습니다.
+
 ## 왜 사용해야 할까
 
 새로운 Azure Functions 프로젝트를 시작하려면 보일러플레이트 설정이 필요합니다: `host.json`, `function_app.py`, 디렉터리 구조, 도구 설정, 테스트. `azure-functions-scaffold`는 한 번의 명령으로 프로덕션 수준의 프로젝트 레이아웃을 생성하여, 처음부터 비즈니스 로직에 집중할 수 있게 합니다.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,32 @@ Scaffolding CLI for production-ready Azure Functions Python v2 projects.
 
 Python version support: 3.10-3.13 are GA on Azure Functions; 3.14 is accepted as **Preview**. See [Python version support](docs/guide/configuration.md#python-version-support).
 
+## Why `afs new` instead of `func init`?
+
+`afs new` is **not** a replacement for [Azure Functions Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local). It complements them. Use whichever fits your situation.
+
+| Concern | `func init` + `func new` (official) | `afs new` (this project) |
+|---|---|---|
+| Maintained by | Microsoft | Community |
+| Scope | Minimal Functions skeleton | Opinionated, production-leaning starter |
+| Project layout | Bare `function_app.py` + `host.json` | Layered: `api/`, `domain/`, `infra/`, tests, CI |
+| Auth defaults | `AuthLevel.ANONYMOUS` | `AuthLevel.ANONYMOUS` (pre-wired for HMAC verification in webhooks) |
+| Logging | `logging` stdlib | `azure-functions-logging` structured JSON, pre-wired |
+| Observability | None pre-wired | Optional `azure-functions-doctor` health checks |
+| OpenAPI | None | Optional `azure-functions-openapi` Swagger UI |
+| Validation | None | Optional `azure-functions-validation` (Pydantic) |
+| Test scaffolding | None | `pytest` setup + sample tests |
+| CI | None | GitHub Actions workflow generated |
+| Templates | Per-trigger blank function | Trigger + business-pattern templates (HTTP CRUD, webhook, queue worker, etc.) |
+| Re-entry | One-shot | `afs api add`, `afs advanced add`, `afs api add-route` extend the same project |
+| Lock-in | None | Generates code; no runtime dependency on `afs` after scaffolding |
+
+**Pick `func init`** when you want the smallest possible starting point, are following Microsoft's official tutorials, or need to match the exact layout used in Azure Functions documentation.
+
+**Pick `afs new`** when you want a project that already has structured logging, sane auth defaults, an opinionated layered structure, and CI in place from the first commit - and you can extend it later with `afs api add` / `afs advanced add`.
+
+You can also start with `func init` and migrate manually; `afs new` does not lock you in. The generated project is plain Azure Functions Python code - no runtime dependency on this CLI.
+
 ## Why Use It
 
 Starting a new Azure Functions project means setting up boilerplate: `host.json`, `function_app.py`, directory structure, tooling config, and tests. `azure-functions-scaffold` generates a production-ready project layout in one command, so you can focus on business logic from the start.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -16,6 +16,32 @@
 
 Python 版本支持: Azure Functions 上 3.10-3.13 为 GA，3.14 为 **Preview**。详情请参阅 [Python 版本支持](docs/guide/configuration.md#python-version-support)。
 
+## 为什么使用 `afs new` 而不是 `func init`？
+
+`afs new` **不是** [Azure Functions Core Tools](https://learn.microsoft.com/azure/azure-functions/functions-run-local) 的替代品，而是它们的补充。请根据您的具体情况选择。
+
+| 关注点 | `func init` + `func new` (官方) | `afs new` (本项目) |
+|---|---|---|
+| 维护者 | Microsoft | 社区 |
+| 范围 | 最小化 Functions 骨架 | 生产导向的、带最佳实践的启动模板 |
+| 项目布局 | 仅 `function_app.py` + `host.json` | 分层结构：`api/`, `domain/`, `infra/`, 测试, CI |
+| 默认身份验证 | `AuthLevel.ANONYMOUS` | `AuthLevel.ANONYMOUS` (预置 Webhook HMAC 签名验证) |
+| 日志 | `logging` 标准库 | `azure-functions-logging` 结构化 JSON 日志，预置 |
+| 可观测性 | 无 | 可选 `azure-functions-doctor` 健康检查 |
+| OpenAPI | 无 | 可选 `azure-functions-openapi` Swagger UI |
+| 校验 | 无 | 可选 `azure-functions-validation` (Pydantic) |
+| 测试脚手架 | 无 | `pytest` 设置 + 示例测试 |
+| CI | 无 | 生成 GitHub Actions 工作流 |
+| 模板 | 按触发器的空白函数 | 触发器 + 业务模式模板 (HTTP CRUD, Webhook, 队列工人等) |
+| 可扩展性 | 一次性 | `afs api add`, `afs advanced add` 等可扩展现有项目 |
+| 锁定 (Lock-in) | 无 | 生成代码方式；脚手架生成后对 `afs` 无运行时依赖 |
+
+**选择 `func init` 的场景：** 当您需要最小的起始点、正在遵循 Microsoft 官方教程，或需要匹配 Azure Functions 文档中的确切布局时。
+
+**选择 `afs new` 的场景：** 当您想要一个从第一次提交就具备结构化日志、合理的身份验证默认值、分层结构和 CI 的项目，并且之后可以通过 `afs api add` 等命令进行扩展时。
+
+您也可以从 `func init` 开始并手动迁移；`afs new` 不会锁定您。生成的项目是纯粹的 Azure Functions Python 代码 —— 对此 CLI 没有运行时依赖。
+
 ## 为什么使用它
 
 启动新的 Azure Functions 项目意味着设置样板文件：`host.json`、`function_app.py`、目录结构、工具配置和测试。`azure-functions-scaffold` 通过一个命令生成生产级项目布局，让你从一开始就专注于业务逻辑。

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -1,5 +1,7 @@
 # Getting Started
 
+> New here? See [Why `afs new` instead of `func init`?](../../README.md#why-afs-new-instead-of-func-init) in the README for context on how this scaffolder differs from Azure Functions Core Tools.
+
 Follow this guide to install the CLI and generate your first production-ready Azure Functions Python v2 project.
 
 ### Prerequisites


### PR DESCRIPTION
## Summary
- Added an honest comparison table between `afs new` and Microsoft's official `func init` / `func new` in `README.md`.
- Translated the comparison section into Korean (`README.ko.md`), Japanese (`README.ja.md`), and Simplified Chinese (`README.zh-CN.md`).
- Cross-linked the comparison section from `docs/guide/getting-started.md`.

## Motivation
New users often ask why they should use this project instead of the official Azure Functions Core Tools. This PR clarifies the positioning: `afs new` is an opinionated, production-leaning scaffolder that complements the official tool.

## Changes
- `README.md`: Added "Why `afs new` instead of `func init`?" section.
- `README.ko.md`: Added Korean translation of the section.
- `README.ja.md`: Added Japanese translation of the section.
- `README.zh-CN.md`: Added Simplified Chinese translation of the section.
- `docs/guide/getting-started.md`: Added a callout linking to the comparison.

## Verification
- Verified factual claims against the current codebase:
    - Confirmed `AuthLevel.ANONYMOUS` is currently the default in templates (though webhooks include HMAC verification).
    - Confirmed `azure-functions-logging` (JSON) is pre-wired in `app/core/logging.py.j2`.
    - Confirmed optional features (`--with-openapi`, etc.) are available in `cli_advanced.py`.
    - Confirmed GitHub Actions workflows and `pytest` samples exist in templates.
    - Confirmed `afs api add` etc. commands are implemented in the CLI.
- `make lint` passed.
- `pytest tests` passed (236 passed, 3 skipped).
- Visual check of Markdown table formatting.

No source code changes included.