### PR TITLE
fix(templates): add pythonpath to generated pytest config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ All notable changes to this project will be documented in this file.
 - Users with previously-scaffolded projects do not need to take action; the marker constants only matter when running `afs api add` / `afs advanced add` / `afs api add-route` / `afs api add-resource` against an existing project. If those commands fail with "marker not found" against an old scaffold, replace the comment in `function_app.py` from `# azure-functions-scaffold-python:` to `# azure-functions-scaffold:`.
 - Users following the previous suffixed install instructions will hit a 404. The README and docs are updated; PyPI package name is now `azure-functions-scaffold`.
 
+### Fixed
+
+- Generated projects' `pytest` invocation no longer fails with `ModuleNotFoundError` for `app.*` imports. Templates now ship `pythonpath = ["."]` in `[tool.pytest.ini_options]`, which pytest 8+ requires when test files live as siblings to the package root (no `tests/__init__.py` convention).
+
 ## [0.5.0] - 2025-04-09
 
 ### Features

--- a/src/azure_functions_scaffold/templates/ai/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/ai/pyproject.toml.j2
@@ -48,6 +48,7 @@ dev = [
 
 {% if include_pytest -%}
 [tool.pytest.ini_options]
+pythonpath = ["."]
 testpaths = ["tests"]
 {% endif %}
 

--- a/src/azure_functions_scaffold/templates/blob/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/blob/pyproject.toml.j2
@@ -47,6 +47,7 @@ dev = [
 
 {% if include_pytest -%}
 [tool.pytest.ini_options]
+pythonpath = ["."]
 testpaths = ["tests"]
 {% endif %}
 

--- a/src/azure_functions_scaffold/templates/cosmosdb/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/cosmosdb/pyproject.toml.j2
@@ -47,6 +47,7 @@ dev = [
 
 {% if include_pytest -%}
 [tool.pytest.ini_options]
+pythonpath = ["."]
 testpaths = ["tests"]
 {% endif %}
 

--- a/src/azure_functions_scaffold/templates/durable/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/durable/pyproject.toml.j2
@@ -48,6 +48,7 @@ dev = [
 
 {% if include_pytest -%}
 [tool.pytest.ini_options]
+pythonpath = ["."]
 testpaths = ["tests"]
 {% endif %}
 

--- a/src/azure_functions_scaffold/templates/eventhub/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/eventhub/pyproject.toml.j2
@@ -47,6 +47,7 @@ dev = [
 
 {% if include_pytest -%}
 [tool.pytest.ini_options]
+pythonpath = ["."]
 testpaths = ["tests"]
 {% endif %}
 

--- a/src/azure_functions_scaffold/templates/http/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/http/pyproject.toml.j2
@@ -56,6 +56,7 @@ dev = [
 
 {% if include_pytest -%}
 [tool.pytest.ini_options]
+pythonpath = ["."]
 testpaths = ["tests"]
 {% endif %}
 

--- a/src/azure_functions_scaffold/templates/langgraph/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/langgraph/pyproject.toml.j2
@@ -46,6 +46,7 @@ dev = [
 
 {% if include_pytest -%}
 [tool.pytest.ini_options]
+pythonpath = ["."]
 testpaths = ["tests"]
 {% endif %}
 

--- a/src/azure_functions_scaffold/templates/queue/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/queue/pyproject.toml.j2
@@ -47,6 +47,7 @@ dev = [
 
 {% if include_pytest -%}
 [tool.pytest.ini_options]
+pythonpath = ["."]
 testpaths = ["tests"]
 {% endif %}
 

--- a/src/azure_functions_scaffold/templates/servicebus/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/servicebus/pyproject.toml.j2
@@ -47,6 +47,7 @@ dev = [
 
 {% if include_pytest -%}
 [tool.pytest.ini_options]
+pythonpath = ["."]
 testpaths = ["tests"]
 {% endif %}
 

--- a/src/azure_functions_scaffold/templates/timer/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/timer/pyproject.toml.j2
@@ -47,6 +47,7 @@ dev = [
 
 {% if include_pytest -%}
 [tool.pytest.ini_options]
+pythonpath = ["."]
 testpaths = ["tests"]
 {% endif %}
 

--- a/tests/test_generated_pytest_collection.py
+++ b/tests/test_generated_pytest_collection.py
@@ -1,0 +1,35 @@
+# pyright: reportMissingImports=false
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from azure_functions_scaffold.scaffolder import scaffold_project
+from azure_functions_scaffold.template_registry import build_project_options, list_templates
+
+
+def _templates_with_generated_tests() -> list[str]:
+    return [template.name for template in list_templates() if (template.root / "tests").is_dir()]
+
+
+@pytest.mark.parametrize("template_name", _templates_with_generated_tests())
+def test_generated_projects_include_pytest_pythonpath(tmp_path: Path, template_name: str) -> None:
+    project_root = scaffold_project(
+        project_name=f"{template_name}-pytest-pythonpath",
+        destination=tmp_path,
+        template_name=template_name,
+        options=build_project_options(
+            preset_name="standard",
+            python_version="3.12",
+            include_github_actions=False,
+            initialize_git=False,
+            include_openapi=False,
+            include_validation=False,
+            include_doctor=False,
+        ),
+    )
+
+    generated_pyproject_text = (project_root / "pyproject.toml").read_text(encoding="utf-8")
+
+    assert 'pythonpath = ["."]' in generated_pyproject_text


### PR DESCRIPTION
## Summary
- Fix generated projects that failed pytest collection with `ModuleNotFoundError: No module named 'app.functions.timer'` by adding `pythonpath = [\".\"]` to `[tool.pytest.ini_options]` in all 10 affected templates.
- Root cause: pytest 8+ does not auto-prepend the project root to `sys.path` for the generated sibling `app/` + `tests/` layout when `tests/__init__.py` is intentionally absent.
- Add a regression test that scaffolds every template with generated tests and asserts the rendered `pyproject.toml` includes the new `pythonpath` line.
- Found during manual smoke verification for the generated-project E2E workflow; this blocks the templates-smoke.yml workflow PR.

## Validation
- `pytest tests`
- `ruff check src tests`
- `mypy src`
- Manual `pytest --collect-only -q` smoke for generated `timer` and `queue` projects on Python 3.12