### PR TITLE
ci: add generated-project smoke E2E for every template

### DIFF
--- a/.github/workflows/templates-smoke.yml
+++ b/.github/workflows/templates-smoke.yml
@@ -1,0 +1,315 @@
+name: Generated Project Smoke Tests
+
+on:
+  pull_request:
+    paths:
+      - "src/azure_functions_scaffold/templates/**"
+      - "src/azure_functions_scaffold/template_registry.py"
+      - "src/azure_functions_scaffold/scaffolder.py"
+      - "src/azure_functions_scaffold/generator.py"
+      - ".github/workflows/templates-smoke.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "src/azure_functions_scaffold/templates/**"
+      - "src/azure_functions_scaffold/template_registry.py"
+      - "src/azure_functions_scaffold/scaffolder.py"
+      - "src/azure_functions_scaffold/generator.py"
+      - ".github/workflows/templates-smoke.yml"
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * *"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  scaffold-and-validate:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Full template registry coverage is currently 10 entries, so we keep
+        # every template in the required matrix.
+        template:
+          - http
+          - timer
+          - queue
+          - blob
+          - servicebus
+          - eventhub
+          - cosmosdb
+          - durable
+          - ai
+          - langgraph
+        python-version:
+          - "3.12"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install scaffold CLI
+        run: pip install -e .[dev]
+
+      - name: Scaffold template project
+        env:
+          TEMPLATE: ${{ matrix.template }}
+          PYTHON_VERSION: ${{ matrix.python-version }}
+        run: |
+          workdir="${RUNNER_TEMP}/scaffold-test"
+          project_name="smoke_${TEMPLATE}"
+          rm -rf "${workdir}"
+          mkdir -p "${workdir}"
+          afs advanced new "${project_name}" \
+            --destination "${workdir}" \
+            --template "${TEMPLATE}" \
+            --preset strict \
+            --python-version "${PYTHON_VERSION}"
+
+      - name: Install generated project dependencies
+        env:
+          TEMPLATE: ${{ matrix.template }}
+        working-directory: ${{ runner.temp }}/scaffold-test/smoke_${{ matrix.template }}
+        run: pip install -e .[dev]
+
+      - name: Compile generated project
+        working-directory: ${{ runner.temp }}/scaffold-test/smoke_${{ matrix.template }}
+        run: python -m compileall -q .
+
+      - name: Lint generated project
+        working-directory: ${{ runner.temp }}/scaffold-test/smoke_${{ matrix.template }}
+        run: |
+          if grep -Eq '^\[tool\.ruff' pyproject.toml; then
+            ruff check .
+          else
+            echo "Skipping ruff: generated project has no Ruff config"
+          fi
+
+      - name: Type-check generated project
+        working-directory: ${{ runner.temp }}/scaffold-test/smoke_${{ matrix.template }}
+        run: |
+          if grep -Eq '^\[tool\.mypy' pyproject.toml; then
+            mypy .
+          else
+            echo "Skipping mypy: generated project has no mypy config"
+          fi
+
+      - name: Test generated project
+        working-directory: ${{ runner.temp }}/scaffold-test/smoke_${{ matrix.template }}
+        run: |
+          set +e
+          pytest -q
+          status=$?
+          set -e
+          if [ "${status}" -ne 0 ] && [ "${status}" -ne 5 ]; then
+            exit "${status}"
+          fi
+
+  scaffold-with-features:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        flags:
+          - --with-openapi
+          - --with-validation
+          - --with-doctor
+          - --with-openapi --with-validation
+          - --with-openapi --with-validation --with-doctor
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install scaffold CLI
+        run: pip install -e .[dev]
+
+      - name: Scaffold http project with features
+        env:
+          FEATURE_FLAGS: ${{ matrix.flags }}
+        run: |
+          workdir="${RUNNER_TEMP}/scaffold-features"
+          rm -rf "${workdir}"
+          mkdir -p "${workdir}"
+          afs advanced new smoke_http_features \
+            --destination "${workdir}" \
+            --template http \
+            --preset strict \
+            --python-version 3.12 \
+            ${FEATURE_FLAGS}
+
+      - name: Install generated project dependencies
+        working-directory: ${{ runner.temp }}/scaffold-features/smoke_http_features
+        run: pip install -e .[dev]
+
+      - name: Compile generated project
+        working-directory: ${{ runner.temp }}/scaffold-features/smoke_http_features
+        run: python -m compileall -q .
+
+      - name: Lint generated project
+        working-directory: ${{ runner.temp }}/scaffold-features/smoke_http_features
+        run: ruff check .
+
+      - name: Type-check generated project
+        working-directory: ${{ runner.temp }}/scaffold-features/smoke_http_features
+        run: mypy .
+
+      - name: Test generated project
+        working-directory: ${{ runner.temp }}/scaffold-features/smoke_http_features
+        run: |
+          set +e
+          pytest -q
+          status=$?
+          set -e
+          if [ "${status}" -ne 0 ] && [ "${status}" -ne 5 ]; then
+            exit "${status}"
+          fi
+
+  add-commands-smoke:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install scaffold CLI
+        run: pip install -e .[dev]
+
+      - name: Scaffold base http project
+        run: |
+          workdir="${RUNNER_TEMP}/scaffold-add-commands"
+          rm -rf "${workdir}"
+          mkdir -p "${workdir}"
+          afs new smoke_http_additions \
+            --destination "${workdir}" \
+            --python-version 3.12
+
+      - name: Add commands to generated project
+        working-directory: ${{ runner.temp }}/scaffold-add-commands/smoke_http_additions
+        run: |
+          afs api add get-status --project-root .
+          afs api add-route status --project-root .
+          afs api add-resource products --project-root .
+          afs advanced add servicebus process-events --project-root .
+
+      - name: Install generated project dependencies
+        working-directory: ${{ runner.temp }}/scaffold-add-commands/smoke_http_additions
+        run: pip install -e .[dev]
+
+      - name: Compile generated project
+        working-directory: ${{ runner.temp }}/scaffold-add-commands/smoke_http_additions
+        run: python -m compileall -q .
+
+      - name: Lint generated project
+        working-directory: ${{ runner.temp }}/scaffold-add-commands/smoke_http_additions
+        run: ruff check .
+
+      - name: Type-check generated project
+        working-directory: ${{ runner.temp }}/scaffold-add-commands/smoke_http_additions
+        run: mypy .
+
+      - name: Test generated project
+        working-directory: ${{ runner.temp }}/scaffold-add-commands/smoke_http_additions
+        run: |
+          set +e
+          pytest -q
+          status=$?
+          set -e
+          if [ "${status}" -ne 0 ] && [ "${status}" -ne 5 ]; then
+            exit "${status}"
+          fi
+
+  preview-python:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    strategy:
+      fail-fast: false
+      matrix:
+        template:
+          - http
+          - durable
+        python-version:
+          - "3.14"
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install scaffold CLI
+        run: pip install -e .[dev]
+
+      - name: Scaffold preview template project
+        env:
+          TEMPLATE: ${{ matrix.template }}
+          PYTHON_VERSION: ${{ matrix.python-version }}
+        run: |
+          workdir="${RUNNER_TEMP}/scaffold-preview"
+          project_name="preview_${TEMPLATE}"
+          rm -rf "${workdir}"
+          mkdir -p "${workdir}"
+          afs advanced new "${project_name}" \
+            --destination "${workdir}" \
+            --template "${TEMPLATE}" \
+            --preset strict \
+            --python-version "${PYTHON_VERSION}"
+
+      - name: Install generated project dependencies
+        working-directory: ${{ runner.temp }}/scaffold-preview/preview_${{ matrix.template }}
+        run: pip install -e .[dev]
+
+      - name: Compile generated project
+        working-directory: ${{ runner.temp }}/scaffold-preview/preview_${{ matrix.template }}
+        run: python -m compileall -q .
+
+      - name: Lint generated project
+        working-directory: ${{ runner.temp }}/scaffold-preview/preview_${{ matrix.template }}
+        run: ruff check .
+
+      - name: Type-check generated project
+        working-directory: ${{ runner.temp }}/scaffold-preview/preview_${{ matrix.template }}
+        run: mypy .
+
+      - name: Test generated project
+        working-directory: ${{ runner.temp }}/scaffold-preview/preview_${{ matrix.template }}
+        run: |
+          set +e
+          pytest -q
+          status=$?
+          set -e
+          if [ "${status}" -ne 0 ] && [ "${status}" -ne 5 ]; then
+            exit "${status}"
+          fi

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -88,6 +88,21 @@ Each pull request is tested against a matrix of environments to ensure broad com
 - **OS:** `ubuntu-latest`
 - **Python versions:** 3.10, 3.11, 3.12, 3.13, 3.14 (Preview - allowed to fail)
 
+## Generated-project smoke tests
+
+The `templates-smoke.yml` workflow scaffolds every template on every push that touches `src/azure_functions_scaffold/templates/**` or related code, then runs `compileall`, `ruff`, `mypy`, and `pytest` against each generated project. This catches template-level breakage that unit tests cannot - for example, a marker-string drift between `generator.py` constants and template comments.
+
+Local equivalent:
+
+```bash
+tmpdir=$(mktemp -d)
+cd "$tmpdir"
+afs new smoke --python-version 3.12
+cd smoke
+python -m compileall -q .
+ruff check . && mypy . && pytest -q
+```
+
 ## Troubleshooting
 
 - **Temporary files:** If a test fails, `tmp_path` is automatically cleaned up. To inspect generated files, you can print the path during a local run.


### PR DESCRIPTION
## Summary

Adds `.github/workflows/templates-smoke.yml` — a CI workflow that scaffolds every template and runs the **generated project's own toolchain** (`compileall`, `ruff`, `mypy`, `pytest`) against it.

## Motivation

Today the repo's tests cover the scaffolder logic but never invoke the generated project's own toolchain end-to-end. PR #81 (marker constant drift) is exactly the bug class this gap allowed: unit tests stayed green while every template was broken in production. We need a CI lane that says \"after `afs new <template>`, the resulting project is itself lintable, type-clean, and its own tests pass.\"

## Jobs

| Job | Required? | Matrix |
|---|---|---|
| `scaffold-and-validate` | yes | every template (`http`, `timer`, `queue`, `blob`, `servicebus`, `eventhub`, `cosmosdb`, `durable`, `ai`, `langgraph`) × Python 3.12 |
| `scaffold-with-features` | yes | `http` × every supported feature-flag combination |
| `add-commands-smoke` | yes | scaffold http, then `afs api add` / `add-route` / `add-resource` / `advanced add`; validates legacy + new marker recognition (PR #90) |
| `preview-python` | no (`continue-on-error: true`) | `http`, `durable` × Python 3.14 Preview |

## Triggers

- `pull_request` and `push` to main, scoped to paths that affect templates, generator, scaffolder, or the workflow itself.
- `schedule`: nightly 06:00 UTC, to catch upstream drift (Azure Functions worker / Python release / sibling-package version churn).
- `workflow_dispatch`: manual.

Concurrency: cancel-in-progress per branch. Permissions: `contents: read`. Action versions pinned to major.

## Proof of value

This workflow's first manual runs during development surfaced **two real defects** that existing unit tests missed:

1. **`http` template** — generated `app/functions/webhooks.py` and `app/schemas/webhooks.py` tripped `ruff E501` (lines >100 chars added by PR #83). Fixed in commit `646c09f` on PR #83's branch.
2. **All 10 templates** — generated `pytest` invocation failed at collection time with `ModuleNotFoundError: No module named 'app.functions.timer'` (and equivalents for every other template). Root cause: `pyproject.toml` didn't set `pythonpath = [\".\"]` under `[tool.pytest.ini_options]`. Fixed in PR #93.

Both bugs were invisible to existing tests because those tests never run the generated project's own toolchain.

## Expected initial state

This PR's first CI run will be **red on the http and pytest lanes** until PR #83 and PR #93 merge. That is intentional and proves the workflow is doing its job. Order:

1. Merge PR #83 (auth defaults + the ruff fixup commit `646c09f`).
2. Merge PR #93 (pytest pythonpath in 10 templates).
3. Re-run this workflow on `main` — it will go green.

## Validation

- YAML parses (`python -c \"import yaml; yaml.safe_load(open('.github/workflows/templates-smoke.yml'))\"` exit 0).
- Manual smoke against `timer` and `queue` (post-PR-#93): `pytest --collect-only -q` exits 0 with one collected test each.
- LSP diagnostics on the workflow file: clean.

## Out of scope

- Adding `actionlint` to the repo's pre-commit hooks (separate concern).
- Expanding the matrix to more Python versions (`3.10`, `3.11`, `3.13`) — defer until 3.12 lane is stable on main.
- Caching strategy beyond `actions/setup-python@v5 cache: pip`.

## References

- Closes the gap that allowed PR #81 to land broken.
- Depends on PR #83 (`fix/p0-secure-auth-defaults`) and PR #93 (`fix/p1-template-pytest-pythonpath`) for green CI.