### PR TITLE
fix(generator): sort app.functions imports after marker-based insertion

### DIFF
--- a/src/azure_functions_scaffold/generator.py
+++ b/src/azure_functions_scaffold/generator.py
@@ -433,8 +433,12 @@ def _insert_near_marker(
         # the marker comment, keeping all imports in one contiguous block.
         blank_then_marker = f"\n\n{target_marker}"
         if blank_then_marker in content:
-            return content.replace(blank_then_marker, f"\n{line}\n\n{target_marker}", 1)
-        return content.replace(target_marker, f"{line}\n{target_marker}", 1)
+            updated = content.replace(blank_then_marker, f"\n{line}\n\n{target_marker}", 1)
+        else:
+            updated = content.replace(target_marker, f"{line}\n{target_marker}", 1)
+        if marker == FUNCTION_IMPORT_MARKER or marker == LEGACY_FUNCTION_IMPORT_MARKER:
+            updated = _sort_app_functions_imports(updated, target_marker)
+        return updated
 
     if fallback_anchor not in content:
         raise ScaffoldError(
@@ -445,6 +449,39 @@ def _insert_near_marker(
         return content.replace(fallback_anchor, f"{fallback_anchor}\n{line}", 1)
 
     return content.replace(fallback_anchor, f"{line}\n\n{fallback_anchor}", 1)
+
+
+def _sort_app_functions_imports(content: str, marker: str) -> str:
+    """Sort the contiguous ``from app.functions.* import ...`` block alphabetically.
+
+    Ruff's ``I001`` rule requires imports within the same isort section to be
+    sorted. New entries are appended in insertion order, so we re-sort the
+    contiguous run that ends just before the import marker. Only ``app.functions.*``
+    lines are reordered; surrounding imports keep their original positions.
+    """
+
+    lines = content.split("\n")
+    marker_index = next((i for i, ln in enumerate(lines) if ln.strip() == marker), -1)
+    if marker_index <= 0:
+        return content
+
+    # Walk backwards from the marker, skipping the blank line that separates
+    # imports from the marker, then collect the contiguous app.functions.* run.
+    end = marker_index
+    while end > 0 and lines[end - 1].strip() == "":
+        end -= 1
+    start = end
+    while start > 0 and lines[start - 1].startswith("from app.functions."):
+        start -= 1
+    if end - start < 2:
+        return content
+
+    block = lines[start:end]
+    sorted_block = sorted(block)
+    if block == sorted_block:
+        return content
+    lines[start:end] = sorted_block
+    return "\n".join(lines)
 
 
 def _legacy_marker_for(marker: str) -> str | None:

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -142,6 +142,8 @@ def test_add_function_works_with_legacy_marker(tmp_path: Path) -> None:
         "# azure-functions-scaffold-python: function imports"
     )
     assert "app.register_functions(sync_data_blueprint)" in updated
+
+
 def test_add_function_rolls_back_on_host_json_failure(tmp_path: Path) -> None:
     project_root = scaffold_project("sample", tmp_path)
     function_app_path = project_root / "function_app.py"
@@ -207,6 +209,21 @@ def test_add_function_succeeds_atomically_for_queue_trigger(tmp_path: Path) -> N
     function_app_text = function_app_path.read_text(encoding="utf-8")
     assert "from app.functions.foo import foo_blueprint" in function_app_text
     assert "app.register_functions(foo_blueprint)" in function_app_text
+
+
+def test_add_function_keeps_app_function_imports_sorted(tmp_path: Path) -> None:
+    project_root = scaffold_project("sample", tmp_path)
+
+    add_function(project_root=project_root, trigger="http", function_name="zeta")
+    add_function(project_root=project_root, trigger="http", function_name="alpha")
+    add_function(project_root=project_root, trigger="http", function_name="mango")
+
+    function_app_text = (project_root / "function_app.py").read_text(encoding="utf-8")
+    app_function_imports = [
+        line for line in function_app_text.splitlines() if line.startswith("from app.functions.")
+    ]
+
+    assert app_function_imports == sorted(app_function_imports)
 
 
 def test_add_function_can_skip_test_generation_for_minimal_preset(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

`afs api add`, `afs api add-route`, `afs api add-resource`, and `afs advanced add` append new `from app.functions.X import X_blueprint` lines to `function_app.py` in insertion order. Once the generated project enables linting (which `pyproject.toml` template configures by default), ruff's `I001` rule fails because the local-imports section is no longer alphabetically sorted.

This was surfaced by PR #94's smoke-E2E workflow, which scaffolds and lints generated projects on every push.

## Fix

After inserting near `FUNCTION_IMPORT_MARKER` (and its legacy variant), `_insert_near_marker` now sorts the contiguous `from app.functions.*` block immediately above the marker. Registration ordering is intentional and left untouched.

## Verification

- New unit test `test_add_function_keeps_app_function_imports_sorted` adds three out-of-order functions and asserts the import block is alphabetically sorted.
- Local repro: `afs new repro && afs api add-route status && afs api add-resource products && afs api add get-status && afs advanced add servicebus process-events && ruff check function_app.py` now passes.
- `make check-all` equivalents (pytest + ruff + mypy) all green; coverage 93.22%.

## Out of scope

- Other ruff rules that the smoke E2E may surface (separate fix per defect, per project policy).
- Re-formatting registration order.

## References

- Surfaced by #94 (smoke E2E)
- Related: #84 (ADDABLE_TRIGGERS split), #90 (legacy marker compat)