### PR TITLE
fix(templates): order imports per PEP 8 in route and langgraph templates

### DIFF
--- a/src/azure_functions_scaffold/templates/langgraph/function_app.py.j2
+++ b/src/azure_functions_scaffold/templates/langgraph/function_app.py.j2
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import azure.functions as func
-
 from azure_functions_langgraph import LangGraphApp
 
 from app.graphs.echo_agent import graph

--- a/src/azure_functions_scaffold/templates/partials/route_blueprint.py.j2
+++ b/src/azure_functions_scaffold/templates/partials/route_blueprint.py.j2
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-import azure.functions as func
 import logging
+
+import azure.functions as func
 
 {{ resource_name }}_blueprint = func.Blueprint()  # type: ignore[no-untyped-call]
 

--- a/tests/test_cli_intents.py
+++ b/tests/test_cli_intents.py
@@ -393,6 +393,16 @@ class TestAiAgent:
         assert '# "azure-functions-langgraph>=0.5.1",' in pyproject_text
         assert "Uncomment after azure-functions-langgraph is published on PyPI." in pyproject_text
 
+    def test_function_app_imports_have_no_blank_lines_within_third_party_section(
+        self, tmp_path: Path
+    ) -> None:
+        result = runner.invoke(app, ["ai", "agent", "my-agent", "--destination", str(tmp_path)])
+        assert result.exit_code == 0
+
+        function_app_text = (tmp_path / "my-agent" / "function_app.py").read_text(encoding="utf-8")
+        head = function_app_text.split("# Create LangGraph app")[0]
+        assert "import azure.functions as func\nfrom azure_functions_langgraph" in head
+
     def test_dry_run(self, tmp_path: Path) -> None:
         result = runner.invoke(
             app, ["ai", "agent", "my-agent", "--destination", str(tmp_path), "--dry-run"]

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -951,6 +951,16 @@ def test_add_route_blueprint_content_is_valid_python(tmp_path: Path) -> None:
     assert 'body="TODO: implement status"' in blueprint_text
 
 
+def test_add_route_blueprint_imports_follow_pep8_grouping(tmp_path: Path) -> None:
+    project_root = scaffold_project("sample", tmp_path)
+    add_route(project_root=project_root, route_name="status")
+
+    blueprint_text = (project_root / "app/functions/status.py").read_text(encoding="utf-8")
+    stdlib_index = blueprint_text.index("import logging")
+    third_party_index = blueprint_text.index("import azure.functions as func")
+    assert stdlib_index < third_party_index
+
+
 def test_add_route_test_content_is_valid_python(tmp_path: Path) -> None:
     project_root = scaffold_project("sample", tmp_path)
     add_route(project_root=project_root, route_name="status")


### PR DESCRIPTION
## Priority: P1

## Context

PR #94's smoke-E2E surfaced two real ruff `I001` failures in generated projects:

- `partials/route_blueprint.py.j2`: stdlib (`logging`) placed after third-party (`azure.functions`). Hits any user running `afs api add-route` and then linting.
- `langgraph/function_app.py.j2`: blank lines split the third-party section (`azure.functions`, `azure_functions_langgraph`), violating ruff's contiguous-block rule. Hits any user running `afs ai agent` and then linting.

Both produced ruff failures the moment the user ran linting on the generated project.

## Acceptance Checklist

- [x] `ruff check` passes on output of `afs api add-route status`
- [x] `ruff check` passes on output of `afs ai agent <name>`
- [x] Unit tests guard import ordering (`tests/test_generator.py::test_add_route_blueprint_imports_follow_pep8_grouping`, `tests/test_cli_intents.py::TestAiAgent::test_function_app_imports_have_no_blank_lines_within_third_party_section`)
- [x] `make check-all` equivalents pass locally

## Out of scope

- Other ruff failures surfaced by #94 (tracked as separate PRs per project policy)
- `--with-openapi` mypy errors (separate PR)
- `durable` template mypy errors (separate PR)

## References

- Surfaced by #94 (smoke E2E)
- Sibling fixes: #96 (import-sort after marker insertion)