### PR TITLE
fix(templates): correct durable Functions imports and types

### DIFF
--- a/src/azure_functions_scaffold/templates/durable/app/functions/durable.py.j2
+++ b/src/azure_functions_scaffold/templates/durable/app/functions/durable.py.j2
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Generator
+from typing import Any
 
+import azure.durable_functions as df  # type: ignore[import-untyped]
 import azure.functions as func
-import azure.functions.durable_functions as df
 
 from app.services.durable_service import build_greeting
 
@@ -15,24 +17,27 @@ durable_blueprint = func.Blueprint()  # type: ignore[no-untyped-call]
     methods=["POST"],
     auth_level=func.AuthLevel.FUNCTION,
 )
-@durable_blueprint.durable_client_input(client_name="client")
+@durable_blueprint.durable_client_input(client_name="client")  # type: ignore[untyped-decorator]
 async def http_start(
     req: func.HttpRequest, client: df.DurableOrchestrationClient
 ) -> func.HttpResponse:
     instance_id = await client.start_new(req.route_params["functionName"])
     logging.info("Started orchestration with ID '%s'.", instance_id)
-    return client.create_check_status_response(req, instance_id)
+    response: func.HttpResponse = client.create_check_status_response(req, instance_id)
+    return response
 
 
-@durable_blueprint.orchestration_trigger(context_name="context")
-def hello_orchestrator(context: df.DurableOrchestrationContext) -> list[str]:
+@durable_blueprint.orchestration_trigger(context_name="context")  # type: ignore[untyped-decorator]
+def hello_orchestrator(
+    context: df.DurableOrchestrationContext,
+) -> Generator[Any, Any, list[str]]:
     results: list[str] = []
-    results.append(yield context.call_activity("say_hello", "Tokyo"))
-    results.append(yield context.call_activity("say_hello", "Seattle"))
-    results.append(yield context.call_activity("say_hello", "London"))
+    results.append((yield context.call_activity("say_hello", "Tokyo")))
+    results.append((yield context.call_activity("say_hello", "Seattle")))
+    results.append((yield context.call_activity("say_hello", "London")))
     return results
 
 
-@durable_blueprint.activity_trigger(input_name="city")
+@durable_blueprint.activity_trigger(input_name="city")  # type: ignore[untyped-decorator]
 def say_hello(city: str) -> str:
     return build_greeting(city)

--- a/tests/test_scaffolder.py
+++ b/tests/test_scaffolder.py
@@ -369,6 +369,19 @@ def test_scaffold_project_generates_expected_project_contract(
     assert "azure-functions-logging>=0.5.0" in pyproject_text
 
 
+def test_durable_template_uses_correct_durable_module_path(tmp_path: Path) -> None:
+    project_path = scaffold_project(
+        "durable-sample",
+        tmp_path,
+        template_name="durable",
+    )
+
+    durable_text = (project_path / "app/functions/durable.py").read_text(encoding="utf-8")
+    assert "import azure.durable_functions as df" in durable_text
+    assert "azure.functions.durable_functions" not in durable_text
+    assert "Generator[Any, Any, list[str]]" in durable_text
+
+
 @pytest.mark.parametrize("template_name", ["queue", "blob", "servicebus", "eventhub", "cosmosdb"])
 def test_binding_templates_include_extension_bundle(tmp_path: Path, template_name: str) -> None:
     project_path = scaffold_project(


### PR DESCRIPTION
## Priority: P1

## Context

PR #94's smoke-E2E surfaced 7 mypy errors in the generated \`durable\` template. Two distinct defects:

1. **Wrong module path**. The template imported \`azure.functions.durable_functions as df\`, which does not exist in the published \`azure-functions-durable\` package. The actual module is \`azure.durable_functions\` (matches every Microsoft official sample). Result: every reference like \`df.DurableOrchestrationClient\` or \`df.DurableOrchestrationContext\` reported \`[name-defined]\` under mypy and would crash at runtime on \`func start\`.
2. **Strict mypy violations** even after fixing the import:
   - \`azure-durable-functions\` ships without \`py.typed\` → \`[import-untyped]\` under \`strict = true\` (which the generated \`pyproject.toml\` enables).
   - \`durable_client_input\`, \`orchestration_trigger\`, \`activity_trigger\` are all untyped decorators → \`[untyped-decorator]\`.
   - The orchestrator function uses \`yield\` but was annotated \`-> list[str]\` instead of a \`Generator\` type → \`[misc]\`.
   - \`client.create_check_status_response\` returns \`Any\` from an untyped library → \`[no-any-return]\`.

## Fix

- Import \`azure.durable_functions as df\` with \`# type: ignore[import-untyped]\` (matches Microsoft samples).
- Add \`# type: ignore[untyped-decorator]\` on each of the three durable decorators.
- Annotate the orchestrator as \`-> Generator[Any, Any, list[str]]\` and parenthesise yield expressions.
- Bind the http_start return into a typed local before returning so mypy sees a concrete \`HttpResponse\`.

## Acceptance Checklist

- [x] \`mypy .\` passes on a generated durable project (with \`pip install -e .[dev]\` deps installed)
- [x] \`ruff check .\` passes on a generated durable project
- [x] \`pytest -q\` passes on the generated test
- [x] Unit test \`test_durable_template_uses_correct_durable_module_path\` guards the import path and Generator annotation
- [x] \`make check-all\` equivalents pass locally

## Out of scope

- Other ruff failures surfaced by #94 (separate PR #97)
- \`--with-openapi\` mypy errors (separate PR)
- Adding upstream type stubs

## References

- Surfaced by #94 (smoke E2E)
- Sibling PRs: #96 (sort imports after marker insert), #97 (route/langgraph import order)
- Microsoft official samples consistently use \`import azure.durable_functions as df\`