### PR TITLE
fix(templates): correct azure-functions-openapi API usage in http template

### DIFF
--- a/src/azure_functions_scaffold/templates/http/function_app.py.j2
+++ b/src/azure_functions_scaffold/templates/http/function_app.py.j2
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import azure.functions as func
 {%- if include_openapi %}
-from azure_functions_openapi.openapi import get_openapi_json, get_openapi_yaml
+from azure_functions_openapi.spec import get_openapi_json, get_openapi_yaml
 from azure_functions_openapi.swagger_ui import render_swagger_ui
 {%- endif %}
 
@@ -24,7 +24,7 @@ app.register_functions(webhooks_blueprint)
 @app.route(route="openapi.json", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
 def openapi_json(req: func.HttpRequest) -> func.HttpResponse:
     return func.HttpResponse(
-        body=get_openapi_json(app, title="{{ project_name }}", version="0.1.0"),
+        body=get_openapi_json(title="{{ project_name }}", version="0.1.0"),
         mimetype="application/json",
     )
 
@@ -32,15 +32,12 @@ def openapi_json(req: func.HttpRequest) -> func.HttpResponse:
 @app.route(route="openapi.yaml", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
 def openapi_yaml(req: func.HttpRequest) -> func.HttpResponse:
     return func.HttpResponse(
-        body=get_openapi_yaml(app, title="{{ project_name }}", version="0.1.0"),
+        body=get_openapi_yaml(title="{{ project_name }}", version="0.1.0"),
         mimetype="text/yaml",
     )
 
 
 @app.route(route="docs", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
 def swagger_ui(req: func.HttpRequest) -> func.HttpResponse:
-    return func.HttpResponse(
-        body=render_swagger_ui(openapi_url="/api/openapi.json"),
-        mimetype="text/html",
-    )
+    return render_swagger_ui(openapi_url="/api/openapi.json")
 {%- endif %}

--- a/tests/test_cli_intents.py
+++ b/tests/test_cli_intents.py
@@ -43,6 +43,8 @@ class TestApiNew:
         assert "health_blueprint" in function_app_text
         assert "webhooks_blueprint" in function_app_text
         assert "get_openapi_json" in function_app_text
+        assert "from azure_functions_openapi.spec import" in function_app_text
+        assert "azure_functions_openapi.openapi" not in function_app_text
         assert "doctor:" in makefile_text or "make doctor" in makefile_text
         # no azd by default
         assert not (project_dir / "azure.yaml").exists()


### PR DESCRIPTION
## Priority: P1

## Context

PR #94's smoke-E2E surfaced mypy + would-be runtime errors in the generated \`http --with-openapi\` template. Three distinct misuses of \`azure-functions-openapi\`:

1. **Deprecated import path.** Generated code imports from \`azure_functions_openapi.openapi\`, which is a deprecated shim slated for removal in 1.0. The current path is \`azure_functions_openapi.spec\`.
2. **Bogus first positional argument.** Generated code calls \`get_openapi_json(app, title=..., version=...)\` and \`get_openapi_yaml(app, title=..., version=...)\`. The actual signatures (verified against \`azure-functions-openapi==0.17.1\`) are:
   - \`get_openapi_json(title='API', version='1.0.0', openapi_version='3.0.0', description='...', security_schemes=None, route_prefix='/api') -> str\`
   - \`get_openapi_yaml(...)\` - same shape
   They do NOT take the \`FunctionApp\` instance. Passing \`app\` as the \`title\` produced a mypy type error and would have produced a malformed spec at runtime.
3. **Double-wrapped HttpResponse.** \`render_swagger_ui\` already returns an \`HttpResponse\` (verified: \`render_swagger_ui(title='API Documentation', openapi_url='/api/openapi.json', custom_csp=None, enable_client_logging=False) -> HttpResponse\`). The generated code wrapped it inside \`func.HttpResponse(body=render_swagger_ui(...))\`, which raises a \`TypeError\` at runtime (HttpResponse is not bytes/str) and trips a mypy \`arg-type\` error.

## Fix

- Switch import to \`from azure_functions_openapi.spec import get_openapi_json, get_openapi_yaml\`.
- Drop the \`app\` positional arg from both \`get_openapi_json\` and \`get_openapi_yaml\` calls.
- Return \`render_swagger_ui(openapi_url=...)\` directly from the \`/docs\` route.
- Strengthen \`TestOpenApi\` intent test to assert the non-deprecated import path is used and the deprecated one is absent.

## Acceptance Checklist

- [x] \`mypy .\` passes on a generated \`http --with-openapi --with-validation\` project (project-strict config, dev deps installed)
- [x] \`ruff check function_app.py\` passes on the generated project
- [x] \`compileall .\` passes
- [x] In-repo \`pytest -q\` passes (coverage 93.22%)
- [x] In-repo \`mypy src tests\` and \`ruff check src tests\` pass
- [x] Test guards both the new import path and absence of the deprecated one

## Out of scope

- Other smoke-E2E findings (durable types - separate PR #98; injected-import order - merged #96; route_blueprint/langgraph order - separate PR #97)
- Adding upstream type stubs

## References

- Surfaced by #94 (smoke E2E)
- Sibling PRs: #96 (sort imports after marker insert, merged), #97 (route/langgraph import order), #98 (durable template types)
- Verified against installed \`azure-functions-openapi==0.17.1\`