### PR TITLE
fix(ci): normalize e2e-azure OIDC subject via environment declaration

### DIFF
--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -18,6 +18,14 @@ jobs:
   deploy_and_test:
     name: Generate, Deploy & Test
     runs-on: ubuntu-latest
+    # OIDC subject must match the Azure AD federated credential behind AZURE_CLIENT_ID:
+    #   repo:yeongseon/azure-functions-scaffold-python:environment:azure-e2e
+    # The environment declaration normalizes the OIDC `sub` claim across both
+    # workflow_dispatch and tag-push triggers (otherwise GitHub mints
+    # ref-based subjects like refs/heads/main or refs/tags/v0.6.1). See
+    # docs/contributing/testing.md ("Azure End-to-End Tests") for setup and
+    # troubleshooting AADSTS700213.
+    environment: azure-e2e
     outputs:
       resource_group: ${{ steps.names.outputs.rg }}
 
@@ -127,6 +135,8 @@ jobs:
   cleanup:
     name: Cleanup Azure Resources
     runs-on: ubuntu-latest
+    # Same OIDC subject as deploy_and_test; see docs/contributing/testing.md.
+    environment: azure-e2e
     needs: [deploy_and_test]
     if: always()
     steps:

--- a/docs/contributing/testing.md
+++ b/docs/contributing/testing.md
@@ -103,6 +103,78 @@ python -m compileall -q .
 ruff check . && mypy . && pytest -q
 ```
 
+## Azure End-to-End Tests
+
+The `.github/workflows/e2e-azure.yml` workflow generates a scaffolded project, deploys it to Azure, and validates HTTP endpoints against a real Function App.
+
+### Workflow
+
+- **File**: `.github/workflows/e2e-azure.yml`
+- **Trigger**: Tag push (`v*`) or manual (`workflow_dispatch`)
+- **Infrastructure**: Azure Consumption plan, `koreacentral` region (`AZURE_LOCATION` variable)
+- **Cleanup**: Resource group deleted immediately after tests (`if: always()`)
+
+### Required Secrets & Variables
+
+Both `deploy_and_test` and `cleanup` jobs declare `environment: azure-e2e`. The Azure OIDC secrets (`AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_SUBSCRIPTION_ID`) may be provided either as environment secrets on `azure-e2e` or as repository-level secrets with the same names. `AZURE_LOCATION` is read from the `vars` context with a fallback to `koreacentral`.
+
+If `azure-e2e` later enables required reviewers or wait timers, both `deploy_and_test` and `cleanup` will pause for approval before Azure access because both jobs declare that environment.
+
+| Name | Type | Description |
+| --- | --- | --- |
+| `AZURE_CLIENT_ID` | Secret | App Registration Client ID (OIDC) |
+| `AZURE_TENANT_ID` | Secret | Azure Tenant ID |
+| `AZURE_SUBSCRIPTION_ID` | Secret | Azure Subscription ID |
+| `AZURE_LOCATION` | Variable | Azure region (default: `koreacentral`) |
+
+### Federated Credential (OIDC) Setup
+
+Azure login uses [GitHub OIDC](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect) to exchange a short-lived token with the Azure AD app registration referenced by `AZURE_CLIENT_ID`. The app registration must have a federated credential whose **subject claim matches exactly** the value GitHub presents.
+
+For this workflow, the expected subject is:
+
+```text
+repo:yeongseon/azure-functions-scaffold-python:environment:azure-e2e
+```
+
+The subject is composed of `repo:<owner>/<repo>:environment:<environment_name>`, where:
+
+- `<owner>/<repo>` is the GitHub repository slug (`github.repository`). Not the PyPI package name (`azure-functions-scaffold-python`) or the Python import name (`azure_functions_scaffold`).
+- `<environment_name>` is the GitHub Environment declared on the workflow jobs (`environment: azure-e2e`).
+
+The match is **case-sensitive** and exact. Renaming the GitHub owner, repository, or environment requires updating the federated credential in Azure to match the new subject; otherwise Azure login fails with `AADSTS700213`.
+
+#### Why one environment-based subject (and not branch / tag subjects)?
+
+The workflow runs from both `workflow_dispatch` (typically against `main`) and `push` of `v*` tags. Without an environment, GitHub mints ref-based OIDC subjects such as:
+
+- `repo:yeongseon/azure-functions-scaffold-python:ref:refs/heads/main` (for dispatches against `main`)
+- `repo:yeongseon/azure-functions-scaffold-python:ref:refs/tags/v0.6.1` (for tag pushes)
+
+Maintaining ref-based credentials is brittle: you need one for `refs/heads/main` and, for tag runs, either flexible tag matching in Entra or separate credentials for concrete tag refs. Using a GitHub environment avoids that drift and keeps one stable subject, which only changes if the owner/repo/environment is renamed.
+
+Reference:
+
+- Workflow declares `environment: azure-e2e` on both `deploy_and_test` and `cleanup` jobs in `.github/workflows/e2e-azure.yml`.
+- Azure docs: [Configure a federated identity credential on an app](https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation-create-trust?pivots=identity-wif-apps-methods-azp).
+
+### Troubleshooting Azure E2E
+
+#### `AADSTS700213: No matching federated identity record found`
+
+The OIDC subject GitHub presented does not match any federated credential on the Azure AD app registration behind `AZURE_CLIENT_ID`. Typical causes:
+
+1. The repository was renamed (for example, the toolkit-wide `-python` suffix migration) and the federated credential still references the old subject.
+2. The `environment:` value on the workflow job changed and the federated credential references the old environment name.
+3. A different app registration is configured in the `azure-e2e` environment secrets than the one carrying the federated credential.
+4. The federated credential still references a ref-based subject (`refs/heads/main` or a concrete `refs/tags/<tag>`) from a version of the workflow that did not declare `environment:`.
+
+To recover:
+
+1. Confirm which Azure AD app registration is referenced by the `AZURE_CLIENT_ID` value used by the `azure-e2e` GitHub Environment (or the repository).
+2. On that app registration, add or update a federated credential with subject `repo:yeongseon/azure-functions-scaffold-python:environment:azure-e2e`, issuer `https://token.actions.githubusercontent.com`, and audience `api://AzureADTokenExchange`.
+3. Re-run `e2e-azure` (tag push or `workflow_dispatch`) and confirm the `Azure login (OIDC)` step succeeds.
+
 ## Troubleshooting
 
 - **Temporary files:** If a test fails, `tmp_path` is automatically cleaned up. To inspect generated files, you can print the path during a local run.


### PR DESCRIPTION
## Summary

- Add `environment: azure-e2e` to both `deploy_and_test` and `cleanup` jobs in `.github/workflows/e2e-azure.yml` so GitHub mints one stable OIDC `sub` claim (`repo:yeongseon/azure-functions-scaffold-python:environment:azure-e2e`) regardless of trigger (workflow_dispatch on `main` vs `v*` tag push).
- Document the federated credential setup, the exact expected subject, case-sensitivity, and `AADSTS700213` troubleshooting in `docs/contributing/testing.md` under a new "Azure End-to-End Tests" section.
- Add inline workflow comments at each `environment:` declaration pointing maintainers to the docs.

Closes #111.

## Why one environment-based subject (Option A)

Without an `environment:` declaration, GitHub mints ref-based subjects that differ per trigger:
- `repo:yeongseon/azure-functions-scaffold-python:ref:refs/heads/main` (workflow_dispatch on main)
- `repo:yeongseon/azure-functions-scaffold-python:ref:refs/tags/v0.6.1` (tag push)

Maintaining ref-based credentials is brittle: you need one credential for `refs/heads/main` and, for tag runs, either flexible tag matching in Entra or a credential per concrete tag ref. Declaring `environment: azure-e2e` on the jobs normalizes the `sub` claim to a single stable value that only changes if the owner/repo/environment is renamed. Cleanup also runs with the same environment so it inherits the same OIDC identity.

## Maintainer action still required

This PR does not modify Azure. To unblock the failing `e2e-azure` workflow run, a repository maintainer with access to the Azure AD app registration referenced by `AZURE_CLIENT_ID` must:

1. Identify the app registration referenced by `AZURE_CLIENT_ID` in the `azure-e2e` environment (or repository) secrets.
2. Add or update a federated credential on that app registration with:
   - **Issuer:** `https://token.actions.githubusercontent.com`
   - **Subject identifier:** `repo:yeongseon/azure-functions-scaffold-python:environment:azure-e2e` (case-sensitive, exact)
   - **Audience:** `api://AzureADTokenExchange`
3. Confirm the Azure secrets (`AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, `AZURE_SUBSCRIPTION_ID`) are available to the `azure-e2e` environment (as environment secrets) or as repository secrets visible to that environment.
4. Re-run the `e2e-azure` workflow (tag push or `workflow_dispatch`) and confirm the `Azure login (OIDC)` step now succeeds.

Step 3 in `docs/contributing/testing.md` ("Federated Credential (OIDC) Setup") describes this exactly.

## Acceptance Checklist (from #111)

- [ ] Confirm the Azure app registration used by `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_SUBSCRIPTION_ID` *(maintainer)*
- [ ] Add or update the federated credential to accept the new environment-based subject *(maintainer)*
- [x] Decide whether tag-triggered runs also need a tag-based subject and document it — chose Option A (single environment-based subject, no tag-based credentials needed); documented in `docs/contributing/testing.md`
- [ ] Re-run `e2e-azure` on `main` and confirm Azure login succeeds *(maintainer, after step 2)*
- [ ] Verify the workflow proceeds beyond `Azure login (OIDC)` *(maintainer, after step 2)*

## Verification done in this PR

- `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/e2e-azure.yml'))"` → OK
- Inline workflow comments cross-reference `docs/contributing/testing.md` ("Azure End-to-End Tests") so maintainers see the exact required subject without leaving the workflow file.
- Doc and workflow share one source of truth for the subject string and the AADSTS700213 recovery steps.

## Out of scope

- Changes to scaffold generation logic
- Template feature changes unrelated to CI authentication
- Removing untracked `.coverage.devbox.pid*` files in working tree (tracked by #113)

## References

- Workflow: `.github/workflows/e2e-azure.yml`
- Sibling pattern: yeongseon/azure-functions-validation-python#192 (same OIDC documentation pattern for the validation repo)