### PR TITLE
chore(repo): harden gitignore and document generated artifacts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ env/
 .mypy_cache/
 .ruff_cache/
 .coverage
+.coverage.*
 coverage.xml
 htmlcov/
 
@@ -27,6 +28,9 @@ dist/
 # IDE
 .vscode/
 .idea/
+
+# OS
+.DS_Store
 
 # Docs
 site/

--- a/docs/contributing/development.md
+++ b/docs/contributing/development.md
@@ -55,6 +55,45 @@ Use these commands to manage your development workflow:
 | `make clean` | Remove build artifacts and temporary files |
 | `make clean-all` | Full cleanup including virtual environments |
 
+## Generated Artifacts
+
+Several development tools produce files that must **never** be committed to source control. They bloat the repository, create noisy diffs across machines, and can leak environment-specific data.
+
+The repository's `.gitignore` already blocks the common offenders, but contributors should still verify before staging:
+
+| Path / Pattern | Produced By | How To Clean |
+| :--- | :--- | :--- |
+| `.venv/`, `venv/`, `env/` | Virtual environment creation (`make install`, `hatch env create`) | `make clean-all` |
+| `.coverage`, `.coverage.*` | `pytest --cov` (the `.coverage.*` files are per-process data emitted by `coverage run --parallel`) | `make clean` |
+| `coverage.xml`, `htmlcov/` | `make cov` and CI coverage steps | `make clean` |
+| `.pytest_cache/`, `.mypy_cache/`, `.ruff_cache/` | `pytest`, `mypy`, `ruff` | `make clean` |
+| `build/`, `dist/`, `*.egg-info/` | `make build`, `hatch build` | `make clean` |
+| `site/` | `make docs` (MkDocs output) | `make clean` |
+| `__pycache__/`, `*.py[cod]` | Python interpreter bytecode | `make clean` |
+| `.DS_Store` | macOS Finder metadata | `make clean-all` |
+
+### Verify before committing
+
+Always run `git status` before `git add`, and avoid bulk-staging from the repository root:
+
+```bash
+git status
+git add <specific file>      # preferred over `git add .` or `git add -A`
+```
+
+If a generated artifact appears in `git status`, prefer fixing `.gitignore` (and submitting that fix as part of your change) over committing the artifact.
+
+### If something was committed by mistake
+
+Generated artifacts that slip into history should be removed in a dedicated cleanup commit:
+
+```bash
+git rm -r --cached <path>    # untrack without deleting from disk
+git commit -m "chore: stop tracking <path>"
+```
+
+Then confirm `.gitignore` blocks the path so it cannot be reintroduced.
+
 ## Code Quality Tools
 
 The project uses several tools to maintain high standards:


### PR DESCRIPTION
Closes #113.

## Summary

- Hardens `.gitignore` with two patterns missing from the previous list:
  - `.coverage.*` — per-process data files from `coverage run --parallel` (e.g. `.coverage.<host>.pid<pid>.<rand>` emitted by `pytest-cov`). Verified locally: nine such files in my working tree were untracked-and-shown before this change, ignored after.
  - `.DS_Store` — macOS Finder metadata. Referenced by `make clean-all` but not previously listed.
- Adds a **Generated Artifacts** section to `docs/contributing/development.md` covering every ignored path, its producing tool, the relevant `make` target to clean it, the `git status` / specific-`git add` habit, and the `git rm --cached` recovery flow for artifacts that slip into history.

## Acceptance Checklist Mapping

| Item | Status | Where |
|------|--------|-------|
| Remove committed `.venv/` and other generated environment directories | Already satisfied on `origin/main` | (no committed `.venv/` exists in `git ls-tree -r origin/main`) |
| Remove committed `coverage.xml` and other generated reports | Already satisfied on `origin/main` | (no committed `coverage.xml` exists in `git ls-tree -r origin/main`) |
| Verify `.gitignore` blocks these paths from being reintroduced | This PR | `.gitignore` already covered `.venv/`, `coverage.xml`; now also blocks `.coverage.*` and `.DS_Store` |
| Add or update contributor guidance to avoid recommitting generated artifacts | This PR | `docs/contributing/development.md` new section |

Items 1 and 2 were closed by earlier cleanup commits before this issue was opened; verified via `git ls-tree -r origin/main --name-only` showing no `.venv/` or `coverage.xml` entries. This PR delivers items 3 (hardening) and 4 (guidance).

## Verification

```bash
# Before
git status   # 9 untracked .coverage.devbox.pid* files

# After (this PR)
git status   # clean (apart from this PR's two staged edits)
```

Out-of-scope per the issue: scaffold template feature changes and CI auth fixes (tracked elsewhere). No template / runtime code touched.

## Test Plan

- Documentation-only + `.gitignore` change. No code paths affected, no behavior changes, no test changes required.
- `mkdocs build --strict` is exercised on PR by the existing docs workflow; the new section uses the same pipe-table syntax already in the file.