### PR TITLE
chore(ci): standardize Action pinning to immutable SHAs

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.10' && github.actor != 'dependabot[bot]'
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v5
+        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354 # v6.0.1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -22,7 +22,7 @@ jobs:
       resource_group: ${{ steps.names.outputs.rg }}
 
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Compute resource names
         id: names
@@ -37,7 +37,7 @@ jobs:
           echo "st=${ST}"   >> "$GITHUB_OUTPUT"
 
       - name: Set up Python 3.10
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.10"
 
@@ -59,7 +59,7 @@ jobs:
           E2E_SCAFFOLDED_DIR: ${{ env.E2E_SCAFFOLDED_DIR }}
 
       - name: Azure login (OIDC)
-        uses: azure/login@v3.0.0
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
@@ -118,7 +118,7 @@ jobs:
 
       - name: Upload e2e report
         if: always()
-        uses: actions/upload-artifact@v7.0.1
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: e2e-report-${{ github.run_id }}-${{ github.run_attempt }}
           path: e2e-report/
@@ -131,7 +131,7 @@ jobs:
     if: always()
     steps:
       - name: Azure login (OIDC)
-        uses: azure/login@v3.0.0
+        uses: azure/login@532459ea530d8321f2fb9bb10d1e0bcf23869a43 # v3.0.0
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -54,4 +54,7 @@ jobs:
         run: python -m build
 
       - name: Publish to PyPI
+        # Documented exception to the SHA-pinning policy: PyPA officially
+        # recommends pinning to the rolling `release/v1` branch. See
+        # CONTRIBUTING.md "GitHub Actions Pinning" for rationale.
         uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/templates-smoke.yml
+++ b/.github/workflows/templates-smoke.yml
@@ -52,10 +52,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip
@@ -132,10 +132,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
           cache: pip
@@ -190,10 +190,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
           cache: pip
@@ -260,10 +260,10 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ matrix.python-version }}
           cache: pip

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@
 - Keep repository structure aligned with sibling azure-functions-* repositories.
 - `make check-all` is the minimum merge gate.
 - Use Conventional Commits with allowed types: `feat`, `fix`, `refactor`, `docs`, `test`, `chore`, `ci`.
+- Pin every external GitHub Action `uses:` ref to a full commit SHA with a `# vX.Y.Z` comment. See [`CONTRIBUTING.md` § "GitHub Actions Pinning"](CONTRIBUTING.md#github-actions-pinning) for the policy and approved exceptions.
 
 ## Issue Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,6 +43,64 @@ make cov         # Run tests with coverage
 make check-all   # Run the full local gate
 ```
 
+## GitHub Actions Pinning
+
+All external `uses:` references in `.github/workflows/` MUST pin to a
+full 40-character commit SHA with a trailing comment documenting the
+released version or channel. Example:
+
+```yaml
+- uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+```
+
+This applies to first-party (`actions/*`, `github/*`, `azure/*`) and
+third-party Actions alike.
+
+**Rationale.** Mutable tags (including immutable-looking version tags
+like `@v6.0.1`) can be retroactively moved by an attacker who gains
+write access to the upstream repository. The
+[`tj-actions/changed-files` compromise (CVE-2025-30066, March 2025)](https://www.cisa.gov/news-events/alerts/2025/03/18/supply-chain-compromise-third-party-tj-actionschanged-files-cve-2025-30066)
+demonstrated this exact failure mode: ~23,000 repositories had their CI
+secrets exfiltrated, and only workflows that pinned to a commit SHA were
+safe. GitHub's own guidance now identifies SHA pinning as
+[the only way to use an Action as an immutable release](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions),
+and OpenSSF Scorecard's
+[`Pinned-Dependencies` check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies)
+flags anything weaker as Medium-risk.
+
+Dependabot updates SHA-pinned references on the configured schedule and
+keeps the trailing version comment in sync, so the human-readable
+context never drifts from the pinned commit.
+
+**Approved exceptions.** The following mutable refs are the only ones
+permitted in this repository and are flagged with an inline comment at
+the call site:
+
+- `pypa/gh-action-pypi-publish@release/v1` — PyPA-maintained stable
+  release channel; this pinning style is explicitly recommended upstream.
+- Local composite actions (`uses: ./...`) — versioned with the repo.
+
+When adding a new external Action, resolve the SHA with
+`git ls-remote <repo-url> 'refs/tags/<tag>^{}'`. The trailing `^{}`
+**dereferences** the ref to its target commit; without it, an
+*annotated* tag returns the tag-object SHA instead of the commit SHA,
+and the tag-object SHA is **not** a valid `uses:` target.
+
+```bash
+# Annotated tag — the two forms return *different* SHAs:
+git ls-remote https://github.com/Azure/login 'refs/tags/v3.0.0' 'refs/tags/v3.0.0^{}'
+# 93381592...   refs/tags/v3.0.0       <- tag object, do NOT pin to this
+# 532459ea...   refs/tags/v3.0.0^{}    <- commit, pin to this one
+
+# Lightweight tag — only the non-deref form returns a row, and it is
+# already the commit SHA. Always include the `^{}` form anyway so the
+# same command works for both tag types:
+git ls-remote https://github.com/actions/setup-python 'refs/tags/v6' 'refs/tags/v6^{}'
+```
+
+Single-quote the `refs/...^{}` argument so the `{}` and `^` are not
+interpreted by your shell (notably zsh with `EXTENDED_GLOB`).
+
 ## Example Coverage Policy
 
 Examples are part of the supported API experience and should stay verified.


### PR DESCRIPTION
## Summary

- Pin every external GitHub Action `uses:` reference in `.github/workflows/` to a full 40-character commit SHA with a trailing `# vX.Y.Z` version comment.
- Document the policy and its single approved exception (`pypa/gh-action-pypi-publish@release/v1`) in `CONTRIBUTING.md` (new "GitHub Actions Pinning" subsection) and add a one-line pointer in `AGENTS.md`.
- After this change all **40** external `uses:` refs resolve to an immutable commit SHA, plus the single `release/v1` documented exception (**41** `uses:` lines total across the 11 workflow files). The exception is flagged with an inline comment at the call site.

Closes #114.

## Why

Mutable version tags (including `@v6`, `@v6.0.1`, `@v3.0.0`, `@v7.0.1`) can be retroactively moved by an attacker who gains write access to the upstream Action repository. The [`tj-actions/changed-files` compromise (CVE-2025-30066, March 2025)](https://www.cisa.gov/news-events/alerts/2025/03/18/supply-chain-compromise-third-party-tj-actionschanged-files-cve-2025-30066) demonstrated this exact failure mode: ~23,000 repositories had their CI secrets exfiltrated, and only workflows that pinned to a commit SHA were safe.

- GitHub's own hardening guidance identifies SHA pinning as [the only way to use an Action as an immutable release](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions).
- OpenSSF Scorecard's [`Pinned-Dependencies` check](https://github.com/ossf/scorecard/blob/main/docs/checks.md#pinned-dependencies) flags anything weaker as Medium risk.
- Dependabot already runs weekly for `github-actions` in this repo (`.github/dependabot.yml`) and natively understands the `<sha> # vX.Y.Z` pattern — it bumps the SHA and keeps the trailing version comment in sync, so the human-readable context never drifts from the pinned commit.

This PR follows the sibling [`azure-functions-db-python#146`](https://github.com/yeongseon/azure-functions-db-python/pull/146) canary, which Oracle-reviewed the policy text and shipped it as the reference implementation.

## What changed

| File | Change |
|------|--------|
| `.github/workflows/ci-test.yml` | Fix stale `# v5` comment beside the already-SHA-pinned `codecov/codecov-action@e79a6962...` so it correctly reads `# v6.0.1` (matches the SHA's actual upstream tag). |
| `.github/workflows/e2e-azure.yml` | Pin 5 tag refs to SHAs: `actions/checkout@v6`, `actions/setup-python@v6`, `azure/login@v3.0.0` (×2), `actions/upload-artifact@v7.0.1`. |
| `.github/workflows/templates-smoke.yml` | Pin 8 tag refs to SHAs: `actions/checkout@v6` (×4), `actions/setup-python@v6` (×4) — covers `scaffold-and-validate`, `scaffold-with-features`, `add-commands-smoke`, and `preview-python` jobs. |
| `.github/workflows/publish-pypi.yml` | Add inline exception comment beside `pypa/gh-action-pypi-publish@release/v1` so the rationale is visible at the call site. |
| `CONTRIBUTING.md` | Add "GitHub Actions Pinning" subsection (policy, rationale, exception list, lookup workflow) — verbatim copy of the sibling `azure-functions-db` policy to keep the toolkit consistent. |
| `AGENTS.md` | Add one-line Working Rules pointer to the new section. |

Workflows already 100% compliant (no edits): `codeql.yml`, `docs.yml`, `maintenance.yml`, `performance.yml`, `sbom.yml`, `security.yml`, `stale.yml`.

## Before / After audit

Total external `uses:` references across all 11 workflows: **41** `uses:` lines (in all states). The table below excludes the documented `release/v1` exception (which is unchanged in both states).

| Repo state | SHA-pinned (correct comment) | Tag-pinned | Wrong `# vX` comment |
|------------|-----------------------------:|-----------:|---------------------:|
| Before this PR | 26 | 13 | 1 |
| After this PR  | **40** | **0** | **0** |

Documented exception (1, unchanged): `pypa/gh-action-pypi-publish@release/v1` in `publish-pypi.yml`. Final state: 40 SHA-pinned + 1 exception = 41 total.

## SHA provenance

Every new SHA was resolved with `git ls-remote <upstream> 'refs/tags/<tag>^{}'` (dereferenced commit) and matches an existing SHA already in use elsewhere in this repo or in the sibling `azure-functions-db` repo (canary):

| Ref | SHA | Tag resolved via |
|-----|-----|------------------|
| `actions/checkout` | `de0fac2e4500dabe0009e67214ff5f5447ce83dd` | Already in use in this repo (`ci-test.yml`, `publish-pypi.yml`) as `# v6`; matches `refs/tags/v6.0.2` |
| `actions/setup-python` | `a309ff8b426b58ec0e2a45f0f869d46889d02405` | Already in use in this repo (`ci-test.yml`, `publish-pypi.yml`) as `# v6` |
| `actions/upload-artifact` | `043fb46d1a93c77aae656e7c1c64a875d1fc6a0a` | Already in use in `sbom.yml` as `# v7.0.1` |
| `azure/login@v3.0.0` | `532459ea530d8321f2fb9bb10d1e0bcf23869a43` | `git ls-remote https://github.com/Azure/login 'refs/tags/v3.0.0^{}'` (dereferenced commit — `v3.0.0` is an annotated tag, see CONTRIBUTING.md for why `^{}` is required) |
| `codecov/codecov-action` | `e79a6962e0d4c0c17b229090214935d2e33f8354` | Already SHA-pinned; verified as dereferenced commit of `refs/tags/v6.0.1` via `git ls-remote` — the previous `# v5` comment was stale from before the v5→v6 bump |

## Verification

- [x] `grep -hE '^\s*-?\s*uses:' .github/workflows/*.yml | wc -l` returns **41**.
- [x] `grep -hEc 'uses:\s+[^@]+@[0-9a-f]{40}' .github/workflows/*.yml` sums to **40** SHA-pinned refs.
- [x] `grep -hE 'uses:\s+[^@]+@release/' .github/workflows/*.yml | wc -l` returns **1** (the documented PyPA exception).
- [x] All `azure/login@v3.0.0` references (`e2e-azure.yml` job `deploy_and_test` and job `cleanup`) resolve to the same commit (`532459ea...`) and preserve the existing OIDC `permissions: id-token: write` block.
- [x] `actions/upload-artifact` is pinned to the same SHA already in use by `sbom.yml`, so no double-version drift exists across workflows.
- [x] `pypa/gh-action-pypi-publish@release/v1` is intentionally preserved per upstream guidance; CI alone cannot enforce this exception, so the rationale is committed inline beside the call site for future maintainers and automated agents.
- [x] `CONTRIBUTING.md` describes how to resolve a new SHA (`git ls-remote ... 'refs/tags/<tag>^{}'`) with explicit annotated-vs-lightweight-tag handling, so future contributors do not need to ask.
- [x] No diagnostics on any changed `.yml` file.
- [x] All templates-smoke CI jobs (which directly exercise the newly-pinned SHAs) passed on the first run.

## Out of scope (tracked separately)

- Dependabot grouping (`groups:`) for `github-actions` — per-PR review is currently preferred so each upstream SHA change can be inspected independently. Will revisit if PR volume becomes painful.
- Other sibling repositories — `azure-functions-doctor#156` will follow the same pattern; `azure-functions-db#140` already landed as the canary.
