### PR TITLE
fix(ci): replace fragile apt install of Core Tools with pinned npm

### DIFF
--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -95,10 +95,17 @@ jobs:
       # in Microsoft's own CI (e.g. microsoft/agent-framework,
       # Azure/azure-functions-durable-extension). Version is pinned via the
       # FUNCTIONS_CORE_TOOLS_VERSION env var declared at the workflow level.
+      # Node is pinned explicitly so the install path stays reproducible across
+      # GitHub-hosted runner image updates (the npm package requires Node >= 20).
+      - name: Set up Node.js 22
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+
       - name: Install Azure Functions Core Tools
         run: |
           npm install -g "azure-functions-core-tools@${FUNCTIONS_CORE_TOOLS_VERSION}"
-          FUNC_VERSION="$(func --version | head -n 1)"
+          FUNC_VERSION="$(func --version)"
           echo "Installed func: ${FUNC_VERSION}"
           test "${FUNC_VERSION}" = "${FUNCTIONS_CORE_TOOLS_VERSION}"
 

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -13,6 +13,9 @@ permissions:
 env:
   AZURE_LOCATION: ${{ vars.AZURE_LOCATION || 'koreacentral' }}
   REPO_SHORT: scaffold
+  # Azure Functions Core Tools version (installed via npm in the install step below).
+  # Pin exactly; bump only after a verified end-to-end run on a tag or workflow_dispatch.
+  FUNCTIONS_CORE_TOOLS_VERSION: "4.12.0"
 
 jobs:
   deploy_and_test:
@@ -83,13 +86,21 @@ jobs:
                 storageName="${{ steps.names.outputs.st }}" \
                 enableAppInsights=false
 
+      # Install Azure Functions Core Tools via npm.
+      # We previously installed from packages.microsoft.com via apt, but that feed
+      # has hit stale-index 404s during Core Tools 4.x package transitions
+      # (Azure/azure-functions-core-tools#4796) and there is no Microsoft-maintained
+      # GitHub Action for Core Tools. npm is Microsoft's documented v4 install path
+      # (see Azure/azure-functions-core-tools README) and is the same approach used
+      # in Microsoft's own CI (e.g. microsoft/agent-framework,
+      # Azure/azure-functions-durable-extension). Version is pinned via the
+      # FUNCTIONS_CORE_TOOLS_VERSION env var declared at the workflow level.
       - name: Install Azure Functions Core Tools
         run: |
-          curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /tmp/microsoft.gpg
-          sudo install -o root -g root -m 644 /tmp/microsoft.gpg /etc/apt/trusted.gpg.d/
-          sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-$(lsb_release -cs)-prod $(lsb_release -cs) main" > /etc/apt/sources.list.d/dotnetdev.list'
-          sudo apt-get update
-          sudo apt-get install -y azure-functions-core-tools-4
+          npm install -g "azure-functions-core-tools@${FUNCTIONS_CORE_TOOLS_VERSION}"
+          FUNC_VERSION="$(func --version | head -n 1)"
+          echo "Installed func: ${FUNC_VERSION}"
+          test "${FUNC_VERSION}" = "${FUNCTIONS_CORE_TOOLS_VERSION}"
 
       - name: Publish scaffolded app
         run: |


### PR DESCRIPTION
## Summary

- Replace the `packages.microsoft.com` apt install of Azure Functions Core Tools in `.github/workflows/e2e-azure.yml` with a **pinned `npm install`** of `azure-functions-core-tools@4.12.0`.
- Add a workflow-level `FUNCTIONS_CORE_TOOLS_VERSION` env var (exact pin) so the version lives in one place and is easy to bump after a verified e2e run.
- Provision **Node 22 explicitly** via `actions/setup-node@v6.4.0` (SHA-pinned per the repo's GitHub Actions Pinning policy) before the npm install so the new install path is reproducible across GitHub-hosted runner image updates instead of depending on the runner's bundled Node version.
- Assert `func --version` matches the pinned value so a silent install drift fails fast at the install step instead of at publish time.
- Document the rationale and the upstream bug reference inline so future maintainers do not accidentally revert to apt.

Closes #115.

## Why

The previous install step (lines 87-94, pre-PR) drove three commands through the `packages.microsoft.com` apt feed:

```yaml
- name: Install Azure Functions Core Tools
  run: |
    curl https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > /tmp/microsoft.gpg
    sudo install -o root -g root -m 644 /tmp/microsoft.gpg /etc/apt/trusted.gpg.d/
    sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-$(lsb_release -cs)-prod $(lsb_release -cs) main" > /etc/apt/sources.list.d/dotnetdev.list'
    sudo apt-get update
    sudo apt-get install -y azure-functions-core-tools-4
```

This pattern has three concrete problems:

1. **Stale-index 404s during Core Tools 4.x package transitions.** [`Azure/azure-functions-core-tools#4796`](https://github.com/Azure/azure-functions-core-tools/issues/4796) confirms (with Microsoft's `@liliankasem` responding) that the apt feed intermittently returns `404 Not Found` when Microsoft cuts a new `4.X` patch and the index file is briefly out of sync with the package directory. The advertised workaround is "run `apt-get update` first" — which this workflow already does — and the workflow still hits the bug.
2. **Unpinned major (`azure-functions-core-tools-4`).** Acceptance criterion 2 calls for an explicit version. The apt package name only constrains the major.
3. **No Microsoft-maintained Action exists.** A search across public GitHub workflows (`grep_app` for `setup-azure-functions-core-tools`) returns zero hits. There is no `Azure/setup-azure-functions-core-tools` equivalent to `Azure/setup-helm` or `actions/setup-node`.

**Microsoft's own CI uses npm:**
- [`microsoft/agent-framework`](https://github.com/microsoft/agent-framework/blob/main/.github/actions/azure-functions-integration-setup/action.yml) — `npm install -g azure-functions-core-tools@4`
- [`Azure/azure-functions-durable-extension`](https://github.com/Azure/azure-functions-durable-extension) — same pattern
- [`Azure/azure-functions-openapi-extension`](https://github.com/Azure/azure-functions-openapi-extension) — same pattern

`npm install -g azure-functions-core-tools@4` is also the **first install option in the upstream README** ([`Azure/azure-functions-core-tools` README — Installing](https://github.com/Azure/azure-functions-core-tools#installing)) and is the documented v4 install path on Linux runners.

Switching to npm with an exact pin gets us completely off the broken substrate, keeps the version explicit, and matches Microsoft's own conventions.

## What changed

| File | Change |
|------|--------|
| `.github/workflows/e2e-azure.yml` | (1) Add workflow-level `FUNCTIONS_CORE_TOOLS_VERSION: "4.12.0"` env var with a comment about the bump policy. (2) Add `actions/setup-node@v6.4.0` step pinning Node 22 (SHA-pinned per the repo's GitHub Actions Pinning policy). (3) Replace the 5-line apt install block with `npm install -g azure-functions-core-tools@${FUNCTIONS_CORE_TOOLS_VERSION}` plus a `func --version` assertion against the pinned value. (4) Add a 10-line rationale comment above the install steps citing `#4796`, the absence of a Microsoft Action, the Microsoft CI precedent, and the reason Node is pinned explicitly. |

Net diff: **+24 / -6** (one file, two commits in this PR; squash-merge will collapse to a single change).

## Node pinning rationale

The `azure-functions-core-tools@4.12.0` npm package declares `engines.node >= 20`. GitHub-hosted `ubuntu-latest` currently bundles Node 20+, but that default has changed historically and is not part of any stability contract from GitHub. Adding `actions/setup-node@v6.4.0` with `node-version: "22"`:

- Pins the Node major to the **current LTS line** (Node 22 is in active LTS through 2027), independent of the runner image's default.
- Keeps the install path reproducible across future runner image bumps. A change to the runner's bundled Node version cannot silently break the npm install (e.g. by dropping below the Core Tools engine requirement).
- Matches the explicit-toolchain pattern already used in this workflow for Python (`actions/setup-python@v6` pinning `python-version: "3.10"`).
- Follows scaffold's GitHub Actions Pinning policy (canonized in #114 / #125): `actions/setup-node` is pinned by full 40-character commit SHA with a trailing `# v6.4.0` version comment.

## Version pinning rationale

- **Latest stable npm version:** `4.12.0`, published by Microsoft on 2026-05-28. Verified via the registry: `https://registry.npmjs.org/azure-functions-core-tools/4.12.0` returns `version: "4.12.0"` with Microsoft's npm signature.
- **Pin strategy:** Exact patch (`4.12.0`), not `@4` or `@4.x`. Acceptance criterion 2 of #115 ("keep version explicit") rules out floating tags.
- **Bump policy:** Manual, only after a verified `workflow_dispatch` or tag-triggered e2e run. Dependabot cannot bump versions embedded in shell strings, and adding Renovate just for this would be more machinery than this toolkit warrants. The env var keeps the bump diff small (single line) for cross-repo consistency.

## Version assertion rationale

The assertion is:

```bash
FUNC_VERSION="$(func --version)"
echo "Installed func: ${FUNC_VERSION}"
test "${FUNC_VERSION}" = "${FUNCTIONS_CORE_TOOLS_VERSION}"
```

- **Fail-fast:** If npm ever resolves the pin to a different actual version (e.g. yanked release, registry desync), the install step fails immediately rather than letting `func azure functionapp publish` fail later with a confusing error.
- **Single-line output is guaranteed by upstream:** [`Azure/azure-functions-core-tools` `Program.cs`](https://github.com/Azure/azure-functions-core-tools) prints only `Constants.CliVersion` (single line) when `--version` is passed, then exits early — no banner, no host runtime detail. The assertion can therefore rely on plain string equality.
- **Diagnostic echo:** The installed value is logged before the assertion so a mismatch failure shows both expected and actual in the runner output.

## Why we did NOT update CONTRIBUTING.md or AGENTS.md

This is a narrow workflow implementation choice, not yet a repo-wide engineering policy like the SHA pinning canonicalized in #114 / #125. Canonization is appropriate only after the pattern has been validated by at least one real `workflow_dispatch` run. Per-workflow comments are the right scope for now; if this pattern survives propagation to the four sibling repos (db, doctor, validation, logging — see below), it can be promoted into `CONTRIBUTING.md` in a follow-up.

## Sibling repo follow-ups

The identical fragile apt block exists in four sibling repos:

| Repo | Workflow | Lines |
|------|----------|-------|
| `azure-functions-db-python` | `.github/workflows/e2e-azure.yml` | 89-95 |
| `azure-functions-doctor-python` | `.github/workflows/e2e-azure.yml` | 78-84 |
| `azure-functions-validation-python` | `.github/workflows/e2e-azure.yml` | 84-90 |
| `azure-functions-logging-python` | `.github/workflows/e2e-azure.yml` | 73-79 |

Tracking issues will be filed in those repos referencing this PR as the canonical pattern. Propagation PRs are intentionally **deferred** until this scaffold workflow has been validated by one real `workflow_dispatch` or tag-triggered run, so any npm-specific surprise surfaces in one repo first instead of all five at once.

## Testing

- **`python3 -c "import yaml; yaml.safe_load(...)"`** — passes (YAML well-formed).
- **No Python source changes** — `make lint`, `make typecheck`, `make test` are not affected; the workflow file is the only modification.
- **All PR CI checks pass** on the previous commit (12/12 green: Analyze, CodeQL, bandit, semgrep, stale-issues, stale-branches, branch-naming-validation, test 3.10–3.14). The new commit re-runs these.
- **`e2e-azure.yml` cannot run in PR CI** because the workflow only triggers on `push.tags: ['v*']` and `workflow_dispatch`. End-to-end validation of the new install path will happen on:
  1. A maintainer-initiated `workflow_dispatch` after this PR merges, **or**
  2. The next `v*` tag push.

  If that run surfaces a problem with npm install on the GitHub-hosted Ubuntu runner, the fallback per the Oracle design review is **Strategy D** (pinned release zip from the GitHub release artifacts), not a return to apt.

## Acceptance criteria from #115

- [x] Replace manual `curl`/`apt` install with a maintainable Microsoft-supported path → npm via upstream-documented command, with Node toolchain pinned explicitly.
- [x] Keep the Core Tools version explicit → `FUNCTIONS_CORE_TOOLS_VERSION: "4.12.0"` workflow env var, asserted at install time.
- [ ] Verify the e2e workflow still reaches the publish/test steps successfully → deferred to first post-merge `workflow_dispatch` run (PR CI cannot exercise this workflow).
- [x] Document the chosen strategy in workflow comments → 10-line rationale comment above the install steps plus a 2-line comment beside the env var.

Acceptance criterion 3 is the only one that cannot be verified inside this PR; everything else is done in the diff.

## Out of scope

- OIDC / Azure auth changes.
- Scaffold generation behavior changes (the install step is for the *scaffolded app's* publish step, not for the scaffold tool itself).
- Propagation to sibling repos (tracked separately, deferred until this workflow proves out under a real run).
- Promoting the pattern into `CONTRIBUTING.md` (deferred until cross-repo adoption).

## References

- Issue: #115
- Upstream bug: [`Azure/azure-functions-core-tools#4796`](https://github.com/Azure/azure-functions-core-tools/issues/4796) (stale-index 404 in apt feed)
- Upstream install docs: [`Azure/azure-functions-core-tools` README](https://github.com/Azure/azure-functions-core-tools#installing)
- Release notes for 4.12.0: [`Azure/azure-functions-core-tools/releases/tag/4.12.0`](https://github.com/Azure/azure-functions-core-tools/releases/tag/4.12.0) (2026-05-28)
- npm metadata: [`registry.npmjs.org/azure-functions-core-tools/4.12.0`](https://registry.npmjs.org/azure-functions-core-tools/4.12.0)
- Microsoft CI precedent: [`microsoft/agent-framework` integration action](https://github.com/microsoft/agent-framework/blob/main/.github/actions/azure-functions-integration-setup/action.yml)
- Node 22 LTS schedule: [`nodejs/release` README](https://github.com/nodejs/release#release-schedule) (active LTS through October 2027)
- Sibling toolkit PRs:
  - #125 (SHA pinning canary, merged)
  - [`yeongseon/azure-functions-db-python#146`](https://github.com/yeongseon/azure-functions-db-python/pull/146) (SHA pinning, merged)
  - [`yeongseon/azure-functions-doctor-python#162`](https://github.com/yeongseon/azure-functions-doctor-python/pull/162) (SHA pinning, merged)
