### PR TITLE
docs(cli): update stale top-level afs new examples after CLI surface change

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -65,7 +65,7 @@ After following this guide, your scaffolded project will be running on Azure and
 ### Step 1 — Scaffold the project
 
 ```bash
-afs new my-http-api --template http --dry-run
+afs new my-http-api --dry-run
 ```
 
 This shows what files will be created **without writing anything**:
@@ -99,7 +99,7 @@ Files:
 Now create the actual project:
 
 ```bash
-afs new my-http-api --template http
+afs new my-http-api
 cd my-http-api
 ```
 
@@ -260,7 +260,7 @@ Hello, Azure!
 ### Step 1 — Scaffold the project
 
 ```bash
-afs new my-timer-job --template timer --dry-run
+afs worker timer my-timer-job --dry-run
 ```
 
 Output:
@@ -292,7 +292,7 @@ Files:
 Create the actual project:
 
 ```bash
-afs new my-timer-job --template timer
+afs worker timer my-timer-job
 cd my-timer-job
 ```
 

--- a/docs/examples/full_stack.md
+++ b/docs/examples/full_stack.md
@@ -12,13 +12,14 @@ Use this as a production baseline for HTTP APIs.
 ## 1) Generate the Project
 
 ```bash
-afs new commerce-api \
+afs advanced new \
   --template http \
   --preset strict \
   --with-openapi \
   --with-validation \
   --with-doctor \
-  --github-actions
+  --include-github-actions \
+  commerce-api
 ```
 
 This combines template, quality tooling, API docs, validation, diagnostics,

--- a/docs/examples/full_stack.md
+++ b/docs/examples/full_stack.md
@@ -18,7 +18,7 @@ afs advanced new \
   --with-openapi \
   --with-validation \
   --with-doctor \
-  --include-github-actions \
+  --github-actions \
   commerce-api
 ```
 

--- a/docs/examples/http_api.md
+++ b/docs/examples/http_api.md
@@ -17,11 +17,12 @@ By the end, you will have:
 Create a strict project with OpenAPI and validation enabled:
 
 ```bash
-afs new my-http-api \
+afs advanced new \
   --template http \
   --preset strict \
   --with-openapi \
-  --with-validation
+  --with-validation \
+  my-http-api
 ```
 
 Move into the project and install dependencies:

--- a/docs/examples/timer_job.md
+++ b/docs/examples/timer_job.md
@@ -15,7 +15,7 @@ You will create a timer-driven job that:
 ## 1) Generate a Timer Project
 
 ```bash
-afs new nightly-maintenance --template timer --preset standard
+afs advanced new --template timer --preset standard nightly-maintenance
 ```
 
 Set up environment and dependencies:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -128,7 +128,7 @@ azure-functions-scaffold new my-api
 Yes. Use `--dry-run` on both project creation and add flows.
 
 ```bash
-afs new my-api --preset strict --dry-run
+afs advanced new --preset strict --dry-run my-api
 afs advanced add queue process_orders --project-root ./my-api --dry-run
 ```
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -29,10 +29,16 @@ You will primarily configure projects through:
 `afs` is a short alias for `azure-functions-scaffold` and behaves exactly the
 same.
 
-## `new` Command Options
+## `advanced new` Command Options
+
+For projects that need a non-HTTP template, an explicit preset, or feature
+flags, use `afs advanced new` (the power-user variant). The top-level shortcut
+`afs new` is an alias for `afs api new` and only accepts the basic flags listed
+under [Optional Workflow Flags](#optional-workflow-flags) plus `--destination`,
+`--python-version`, `--dry-run`, `--overwrite`, and `--yes`.
 
 ```bash
-afs new [PROJECT_NAME] [OPTIONS]
+afs advanced new [OPTIONS] PROJECT_NAME
 ```
 
 ### Core Selection Flags
@@ -40,7 +46,7 @@ afs new [PROJECT_NAME] [OPTIONS]
 | Flag | Default | Values | Purpose |
 | :--- | :--- | :--- | :--- |
 | `--destination`, `-d` | `.` | path | Parent directory where project folder is created. |
-| `--template`, `-t` | `http` | `http`, `timer`, `queue`, `blob`, `servicebus` | Initial trigger template. |
+| `--template`, `-t` | `http` | `http`, `timer`, `queue`, `blob`, `servicebus`, `eventhub`, `cosmosdb`, `durable`, `ai`, `langgraph` | Initial trigger template. |
 | `--preset` | `standard` | `minimal`, `standard`, `strict` | Quality tooling baseline. |
 | `--python-version` | `3.10` | `3.10`, `3.11`, `3.12`, `3.13`, `3.14 (Preview)` | Python version pin for generated metadata. |
 
@@ -100,11 +106,10 @@ logger = get_logger("my-api")
     If you pass them to non-HTTP templates, there is no HTTP route to apply
     those integrations.
 
-### Interaction and Preview Flags
+### Preview Flags
 
 | Flag | Default | Purpose |
 | :--- | :--- | :--- |
-| `--interactive`, `-i` | `False` | Launches prompts for template, preset, tooling, and feature toggles. |
 | `--dry-run` | `False` | Prints what would be generated without writing files. |
 
 ## Presets in Detail
@@ -152,30 +157,6 @@ afs worker servicebus bus-worker --github-actions
     - `--with-openapi`
     - `--with-validation`
     - `--with-doctor`
-
-## Interactive Mode
-
-Interactive mode is useful for new users and for one-off setups where you want
-to choose options through prompts.
-
-```bash
-afs new my-api --interactive
-```
-
-What it asks for:
-
-1. Project name
-2. Template
-3. Preset
-4. Python version
-5. GitHub Actions toggle
-6. Git init toggle
-7. Tooling selection (`ruff`, `mypy`, `pytest`)
-8. Feature toggles (`openapi`, `validation`, `doctor`)
-
-!!! note "Custom tooling outcome"
-    In interactive mode, if you pick tooling that differs from the preset
-    default set, the generated project records the preset name as `custom`.
 
 ## Dry Run Workflows
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -121,13 +121,13 @@ Presets define quality tooling included in the generated project.
 
 ```bash
 # Smallest possible scaffold
-afs new scratch-api --preset minimal
+afs advanced new --preset minimal scratch-api
 
 # Good default for API work
-afs new customer-api --preset standard
+afs advanced new --preset standard customer-api
 
 # Strict CI gate from day one
-afs new payments-api --preset strict
+afs advanced new --preset strict payments-api
 ```
 
 ## Feature Combinations
@@ -136,13 +136,13 @@ Feature flags compose with templates and presets.
 
 ```bash
 # HTTP API with docs and validation, strict checks
-afs new orders-api --preset strict --with-openapi --with-validation
+afs advanced new --preset strict --with-openapi --with-validation orders-api
 
 # Timer job with lightweight tooling and doctor checks
 afs advanced new --template timer --preset minimal --with-doctor nightly-cleanup
 
 # Service Bus worker plus CI workflow bootstrap
-afs worker servicebus bus-worker --include-github-actions
+afs worker servicebus bus-worker --github-actions
 ```
 
 !!! tip "Recommended baseline"
@@ -182,7 +182,7 @@ What it asks for:
 Use dry runs in scripts and CI to verify intent before changing the filesystem.
 
 ```bash
-afs new my-api --preset strict --with-openapi --dry-run
+afs advanced new --preset strict --with-openapi --dry-run my-api
 ```
 
 For project expansion:

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -139,10 +139,10 @@ Feature flags compose with templates and presets.
 afs new orders-api --preset strict --with-openapi --with-validation
 
 # Timer job with lightweight tooling and doctor checks
-afs new nightly-cleanup --template timer --preset minimal --with-doctor
+afs advanced new --template timer --preset minimal --with-doctor nightly-cleanup
 
 # Service Bus worker plus CI workflow bootstrap
-afs new bus-worker --template servicebus --github-actions
+afs worker servicebus bus-worker --include-github-actions
 ```
 
 !!! tip "Recommended baseline"

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -33,9 +33,10 @@ same.
 
 For projects that need a non-HTTP template, an explicit preset, or feature
 flags, use `afs advanced new` (the power-user variant). The top-level shortcut
-`afs new` is an alias for `afs api new` and only accepts the basic flags listed
-under [Optional Workflow Flags](#optional-workflow-flags) plus `--destination`,
-`--python-version`, `--dry-run`, `--overwrite`, and `--yes`.
+`afs new` is an alias for `afs api new` and accepts only `--destination`,
+`--python-version`, `--github-actions` / `--no-github-actions`,
+`--git` / `--no-git`, `--azd` / `--no-azd`, `--dry-run`, `--overwrite`,
+and `--yes`.
 
 ```bash
 afs advanced new [OPTIONS] PROJECT_NAME
@@ -68,6 +69,7 @@ The scaffolder accepts all listed versions. Choose 3.12 for the broadest compati
 | :--- | :--- | :--- |
 | `--github-actions` / `--no-github-actions` | `--no-github-actions` | Include a starter CI workflow under `.github/workflows/`. |
 | `--git` / `--no-git` | `--no-git` | Run `git init` in the generated project. |
+| `--azd` / `--no-azd` | `--no-azd` | Include Azure Developer CLI (`azd`) support files. |
 | `--overwrite` | `False` | Replace an existing target directory. |
 
 ### Built-in Features
@@ -106,11 +108,12 @@ logger = get_logger("my-api")
     If you pass them to non-HTTP templates, there is no HTTP route to apply
     those integrations.
 
-### Preview Flags
+### Preview and Safety Flags
 
 | Flag | Default | Purpose |
 | :--- | :--- | :--- |
 | `--dry-run` | `False` | Prints what would be generated without writing files. |
+| `--yes`, `-y` | `False` | Skips confirmation prompts (required when `--overwrite` runs in a non-TTY session or against a directory containing `.git`). |
 
 ## Presets in Detail
 

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -88,14 +88,6 @@ afs advanced new --preset strict --with-openapi --with-validation --with-doctor 
 afs advanced new --template timer --preset minimal --github-actions nightly-job
 ```
 
-### Interactive Mode
-
-If you're unsure which flags to use, start the CLI in interactive mode to be guided through the selection process.
-
-```bash
-afs new my-api --interactive
-```
-
 ### What's Next?
 
 Learn how to [Expand Your Project](expanding.md) by adding more triggers to an existing codebase.

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -17,7 +17,7 @@ Presets configure `pyproject.toml` with linting, formatting, and testing tools.
 Use the strict preset to enforce type safety and strict linting.
 
 ```bash
-afs new secure-api --preset strict
+afs advanced new --preset strict secure-api
 ```
 
 ### Feature Flags
@@ -57,7 +57,7 @@ See [azure-functions-logging](https://github.com/yeongseon/azure-functions-loggi
 Adds `azure-functions-openapi` to the dependencies and configures HTTP triggers with the necessary decorators for Swagger/OpenAPI documentation.
 
 ```bash
-afs new swagger-api --with-openapi
+afs advanced new --with-openapi swagger-api
 ```
 
 #### --with-validation
@@ -65,7 +65,7 @@ afs new swagger-api --with-openapi
 Adds Pydantic to the dependencies and sets up base models in `app/schemas/`. If used with an HTTP trigger, it provides a `POST` endpoint with request body validation.
 
 ```bash
-afs new validator-api --with-validation
+afs advanced new --with-validation validator-api
 ```
 
 #### --with-doctor
@@ -73,7 +73,7 @@ afs new validator-api --with-validation
 Adds a "Doctor" health check endpoint at `/api/doctor`. This endpoint provides a structured JSON response to verify the function app's health.
 
 ```bash
-afs new healthy-api --with-doctor
+afs advanced new --with-doctor healthy-api
 ```
 
 ### Combination Examples
@@ -82,10 +82,10 @@ You can mix and match any combination of presets and flags.
 
 ```bash
 # Production-ready API with all features
-afs new commerce-api --preset strict --with-openapi --with-validation --with-doctor
+afs advanced new --preset strict --with-openapi --with-validation --with-doctor commerce-api
 
 # Minimal timer function with GitHub Actions workflow
-afs advanced new --template timer --preset minimal --include-github-actions nightly-job
+afs advanced new --template timer --preset minimal --github-actions nightly-job
 ```
 
 ### Interactive Mode

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -85,7 +85,7 @@ You can mix and match any combination of presets and flags.
 afs new commerce-api --preset strict --with-openapi --with-validation --with-doctor
 
 # Minimal timer function with GitHub Actions workflow
-afs new nightly-job --template timer --preset minimal --github-actions
+afs advanced new --template timer --preset minimal --include-github-actions nightly-job
 ```
 
 ### Interactive Mode

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -35,7 +35,7 @@ afs --version
 Run the `new` command to generate a standard HTTP project.
 
 ```bash
-afs new my-api --preset standard
+afs advanced new --preset standard my-api
 ```
 
 **Expected Output:**

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -25,7 +25,7 @@ It generates the wiring you would otherwise repeat manually:
 
 ```bash
 pip install azure-functions-scaffold
-afs new my-api --preset standard
+afs advanced new --preset standard my-api
 cd my-api
 pip install -e .[dev]
 func start

--- a/docs/guide/stacks.md
+++ b/docs/guide/stacks.md
@@ -72,7 +72,7 @@ read/write bindings via `@db.input()` and `@db.output()`.
 | `azure-functions-logging` | Structured JSON logging |
 
 ```bash
-afs new my-agent --template langgraph
+afs ai agent my-agent
 ```
 
 ```text
@@ -127,7 +127,7 @@ API docs, structured logging, and pre-deploy health diagnostics.
 |-------|-----------------|----------|----------|
 | API | `afs new my-api --profile api` | 3 | REST APIs, webhooks |
 | DB API | `afs new my-api --profile db-api` | 4 | CRUD with database |
-| AI Agent | `afs new my-agent --template langgraph` | 3 | LangGraph agents |
+| AI Agent | `afs ai agent my-agent` | 3 | LangGraph agents |
 | Full | `afs new my-api --profile db-api --with-doctor` | 5 | Production services |
 
 Start with the smallest stack that covers your needs.

--- a/docs/guide/stacks.md
+++ b/docs/guide/stacks.md
@@ -103,7 +103,7 @@ database access, health diagnostics, and observability.
 | `azure-functions-doctor` | Pre-deploy diagnostic checks |
 
 ```bash
-afs new my-api --profile db-api --with-doctor
+afs new my-api --profile db-api
 ```
 
 ```text
@@ -128,7 +128,7 @@ API docs, structured logging, and pre-deploy health diagnostics.
 | API | `afs new my-api --profile api` | 3 | REST APIs, webhooks |
 | DB API | `afs new my-api --profile db-api` | 4 | CRUD with database |
 | AI Agent | `afs ai agent my-agent` | 3 | LangGraph agents |
-| Full | `afs new my-api --profile db-api --with-doctor` | 5 | Production services |
+| Full | `afs new my-api --profile db-api` | 5 | Production services |
 
 Start with the smallest stack that covers your needs.
 Add packages incrementally — the toolkit is designed for zero coupling between packages.

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -6,8 +6,8 @@ The CLI supports the most common Azure Functions triggers. Each trigger-based te
 
 | Template | CLI Command | Primary Use Case |
 | :--- | :--- | :--- |
-| **HTTP** | `afs new <name> --template http` | APIs, webhooks, synchronous requests. |
-| **Timer** | `afs new <name> --template timer` | Scheduled tasks, clean-up jobs, reports. |
+| **HTTP** | `afs new <name>` | APIs, webhooks, synchronous requests. |
+| **Timer** | `afs worker timer <name>` | Scheduled tasks, clean-up jobs, reports. |
 | **Queue** | `afs worker queue <name>` | Async message processing from Azure Storage. |
 | **Blob** | `afs worker blob <name>` | File processing, image resizing, data ingestion. |
 | **Service Bus** | `afs worker servicebus <name>` | Enterprise messaging with topics or queues. |
@@ -22,7 +22,7 @@ The CLI supports the most common Azure Functions triggers. Each trigger-based te
 The default template for building RESTful APIs.
 
 ```bash
-afs new my-api --template http
+afs new my-api
 ```
 
 *   **Generates**: `app/functions/http.py`, `app/services/hello_service.py`, `tests/test_http.py`.
@@ -33,7 +33,7 @@ afs new my-api --template http
 Triggers functions on a schedule using CRON expressions.
 
 ```bash
-afs new nightly-job --template timer
+afs worker timer nightly-job
 ```
 
 *   **Generates**: `app/functions/timer.py`, `app/services/maintenance_service.py`, `tests/test_timer.py`.

--- a/docs/guide/tutorial.md
+++ b/docs/guide/tutorial.md
@@ -215,7 +215,7 @@ Timer triggers are ideal for maintenance tasks, database cleanups, or periodic r
 ### Generate the Project
 
 ```bash
-afs new maintenance-jobs --template timer
+afs worker timer maintenance-jobs
 cd maintenance-jobs
 make install
 ```
@@ -313,7 +313,7 @@ Queue triggers allow you to process messages from Azure Queue Storage asynchrono
 ### Generate the Project
 
 ```bash
-afs new worker-service --template queue
+afs worker queue worker-service
 cd worker-service
 make install
 ```
@@ -413,7 +413,7 @@ Blob triggers respond to new or updated files in Azure Blob Storage.
 ### Generate the Project
 
 ```bash
-afs new image-processor --template blob
+afs worker blob image-processor
 cd image-processor
 make install
 ```
@@ -494,7 +494,7 @@ The Service Bus template is designed for high-throughput enterprise messaging.
 ### Generate the Project
 
 ```bash
-afs new messaging-node --template servicebus
+afs worker servicebus messaging-node
 cd messaging-node
 make install
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -88,7 +88,7 @@ Design goals of this layout:
 
 ```bash
 pip install azure-functions-scaffold
-afs new my-api --preset standard
+afs advanced new --preset standard my-api
 cd my-api
 python -m venv .venv
 . .venv/bin/activate
@@ -106,7 +106,7 @@ http://localhost:7071/api/hello
 
 ```bash
 # Strict HTTP API with docs and validation
-afs new orders-api --preset strict --with-openapi --with-validation
+afs advanced new --preset strict --with-openapi --with-validation orders-api
 
 # Timer-based scheduled job
 afs advanced new --template timer --preset standard nightly-job

--- a/docs/index.md
+++ b/docs/index.md
@@ -109,7 +109,7 @@ http://localhost:7071/api/hello
 afs new orders-api --preset strict --with-openapi --with-validation
 
 # Timer-based scheduled job
-afs new nightly-job --template timer --preset standard
+afs advanced new --template timer --preset standard nightly-job
 
 # Add another endpoint to an existing project
 afs api add get_user --project-root ./orders-api

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -127,7 +127,7 @@ sequenceDiagram
     participant TR as template_registry.py
     participant FS as File System
 
-    Dev->>CLI: afs new my-api --template http
+    Dev->>CLI: afs new my-api
     CLI->>TR: build_project_options(preset, python_version, ...)
     TR-->>CLI: ProjectOptions
     CLI->>SC: scaffold_project(name, template, options)

--- a/tests/test_docs_cli_examples.py
+++ b/tests/test_docs_cli_examples.py
@@ -1,9 +1,10 @@
 """Regression test: docs CLI examples must not drift from current CLI surface.
 
-Top-level ``afs new`` no longer accepts ``--template``, ``--preset``, or
-``--with-*`` flags (issue #112). It is the shortcut for ``afs api new`` (HTTP
-only). Trigger-specific scaffolding lives under ``afs worker <type>``,
-``afs ai agent``, or ``afs advanced new``.
+Top-level ``afs new`` no longer accepts ``--template``, ``--preset``,
+``--with-*``, or ``--interactive`` (issue #112). It is the shortcut for
+``afs api new`` (HTTP only). Trigger-specific scaffolding lives under
+``afs worker <type>``, ``afs ai agent``, or ``afs advanced new``, and no
+interactive wizard currently ships with the CLI.
 
 The legacy ``azure-functions-scaffold-python`` distribution entry-point was
 renamed to ``azure-functions-scaffold`` (CLI: ``afs``). It must not appear in
@@ -30,7 +31,7 @@ LINE_CONTINUATION_RE = re.compile(r"\\\s*\n\s*")
 # Flags that no longer belong on top-level ``afs new`` (issue #112).
 TOP_LEVEL_AFS_NEW_RE = re.compile(
     r"\bafs\s+new\b[^\n]*"
-    r"--(template|preset|with-openapi|with-validation|with-doctor)\b"
+    r"--(template|preset|with-openapi|with-validation|with-doctor|interactive)\b"
 )
 
 LEGACY_NEW_RE = re.compile(r"\bazure-functions-scaffold-python\s+new\b")
@@ -69,7 +70,7 @@ def test_no_stale_top_level_afs_new_flags(doc_path: Path) -> None:
     snippets = [match.group(0) for match in TOP_LEVEL_AFS_NEW_RE.finditer(text)]
     assert not snippets, (
         f"{relative}: top-level `afs new` no longer accepts "
-        "--template/--preset/--with-*. Use `afs advanced new ...`, "
+        "--template/--preset/--with-*/--interactive. Use `afs advanced new ...`, "
         "`afs worker <type>`, or `afs ai agent` instead.\n" + "\n".join(snippets)
     )
 

--- a/tests/test_docs_cli_examples.py
+++ b/tests/test_docs_cli_examples.py
@@ -1,0 +1,82 @@
+"""Regression test: docs CLI examples must not drift from current CLI surface.
+
+Top-level ``afs new`` no longer accepts ``--template`` (issue #112). It is the
+shortcut for ``afs api new`` (HTTP only). Trigger-specific scaffolding lives
+under ``afs worker <type>``, ``afs ai agent``, or ``afs advanced new``.
+
+The legacy ``azure-functions-scaffold-python`` distribution entry-point was
+renamed to ``azure-functions-scaffold`` (CLI: ``afs``). It must not appear in
+docs except inside the migration guide that explains the rename.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+DOCS_ROOT = REPO_ROOT / "docs"
+
+TOP_LEVEL_TEMPLATE_RE = re.compile(r"\bafs\s+new\b[^\n]*--template\b")
+LEGACY_NEW_RE = re.compile(r"\bazure-functions-scaffold-python\s+new\b")
+
+ALLOWLIST: frozenset[Path] = frozenset(
+    {
+        Path("docs/migration/0.6.0.md"),
+    }
+)
+
+
+def _docs_files() -> list[Path]:
+    return sorted(p for p in DOCS_ROOT.rglob("*.md") if p.is_file())
+
+
+def _relative(path: Path) -> Path:
+    return path.relative_to(REPO_ROOT)
+
+
+@pytest.mark.parametrize(
+    "doc_path",
+    _docs_files(),
+    ids=lambda p: str(_relative(p)),
+)
+def test_no_stale_afs_new_template(doc_path: Path) -> None:
+    relative = _relative(doc_path)
+    if relative in ALLOWLIST:
+        pytest.skip(f"intentional historical content: {relative}")
+    text = doc_path.read_text(encoding="utf-8")
+    matches = [
+        f"{relative}:{idx + 1}: {line.rstrip()}"
+        for idx, line in enumerate(text.splitlines())
+        if TOP_LEVEL_TEMPLATE_RE.search(line)
+    ]
+    assert not matches, (
+        "Top-level `afs new` no longer accepts `--template`. "
+        + "Use `afs advanced new --template ...`, `afs worker <type>`, "
+        + "or `afs ai agent` instead.\n"
+        + "\n".join(matches)
+    )
+
+
+@pytest.mark.parametrize(
+    "doc_path",
+    _docs_files(),
+    ids=lambda p: str(_relative(p)),
+)
+def test_no_legacy_scaffold_python_new(doc_path: Path) -> None:
+    relative = _relative(doc_path)
+    if relative in ALLOWLIST:
+        pytest.skip(f"intentional historical content: {relative}")
+    text = doc_path.read_text(encoding="utf-8")
+    matches = [
+        f"{relative}:{idx + 1}: {line.rstrip()}"
+        for idx, line in enumerate(text.splitlines())
+        if LEGACY_NEW_RE.search(line)
+    ]
+    assert not matches, (
+        "`azure-functions-scaffold-python` is no longer a valid CLI entry; "
+        + "use `afs` or `azure-functions-scaffold` instead.\n"
+        + "\n".join(matches)
+    )

--- a/tests/test_docs_cli_examples.py
+++ b/tests/test_docs_cli_examples.py
@@ -1,12 +1,16 @@
 """Regression test: docs CLI examples must not drift from current CLI surface.
 
-Top-level ``afs new`` no longer accepts ``--template`` (issue #112). It is the
-shortcut for ``afs api new`` (HTTP only). Trigger-specific scaffolding lives
-under ``afs worker <type>``, ``afs ai agent``, or ``afs advanced new``.
+Top-level ``afs new`` no longer accepts ``--template``, ``--preset``, or
+``--with-*`` flags (issue #112). It is the shortcut for ``afs api new`` (HTTP
+only). Trigger-specific scaffolding lives under ``afs worker <type>``,
+``afs ai agent``, or ``afs advanced new``.
 
 The legacy ``azure-functions-scaffold-python`` distribution entry-point was
 renamed to ``azure-functions-scaffold`` (CLI: ``afs``). It must not appear in
 docs except inside the migration guide that explains the rename.
+
+These checks normalize shell line-continuations (``\\\\\\n``) before scanning
+so that multi-line code blocks are validated the same way as single-line ones.
 """
 
 from __future__ import annotations
@@ -19,9 +23,20 @@ import pytest
 REPO_ROOT = Path(__file__).resolve().parent.parent
 DOCS_ROOT = REPO_ROOT / "docs"
 
-TOP_LEVEL_TEMPLATE_RE = re.compile(r"\bafs\s+new\b[^\n]*--template\b")
+# Collapse shell line-continuations (``\`` followed by newline + indent) into a
+# single space so multi-line examples are scanned identically to single-line.
+LINE_CONTINUATION_RE = re.compile(r"\\\s*\n\s*")
+
+# Flags that no longer belong on top-level ``afs new`` (issue #112).
+TOP_LEVEL_AFS_NEW_RE = re.compile(
+    r"\bafs\s+new\b[^\n]*"
+    r"--(template|preset|with-openapi|with-validation|with-doctor)\b"
+)
+
 LEGACY_NEW_RE = re.compile(r"\bazure-functions-scaffold-python\s+new\b")
 
+# Files that intentionally retain historical CLI examples (e.g. migration
+# guides explaining the rename). Paths are relative to the repo root.
 ALLOWLIST: frozenset[Path] = frozenset(
     {
         Path("docs/migration/0.6.0.md"),
@@ -37,26 +52,25 @@ def _relative(path: Path) -> Path:
     return path.relative_to(REPO_ROOT)
 
 
+def _normalized_text(path: Path) -> str:
+    return LINE_CONTINUATION_RE.sub(" ", path.read_text(encoding="utf-8"))
+
+
 @pytest.mark.parametrize(
     "doc_path",
     _docs_files(),
     ids=lambda p: str(_relative(p)),
 )
-def test_no_stale_afs_new_template(doc_path: Path) -> None:
+def test_no_stale_top_level_afs_new_flags(doc_path: Path) -> None:
     relative = _relative(doc_path)
     if relative in ALLOWLIST:
         pytest.skip(f"intentional historical content: {relative}")
-    text = doc_path.read_text(encoding="utf-8")
-    matches = [
-        f"{relative}:{idx + 1}: {line.rstrip()}"
-        for idx, line in enumerate(text.splitlines())
-        if TOP_LEVEL_TEMPLATE_RE.search(line)
-    ]
-    assert not matches, (
-        "Top-level `afs new` no longer accepts `--template`. "
-        + "Use `afs advanced new --template ...`, `afs worker <type>`, "
-        + "or `afs ai agent` instead.\n"
-        + "\n".join(matches)
+    text = _normalized_text(doc_path)
+    snippets = [match.group(0) for match in TOP_LEVEL_AFS_NEW_RE.finditer(text)]
+    assert not snippets, (
+        f"{relative}: top-level `afs new` no longer accepts "
+        "--template/--preset/--with-*. Use `afs advanced new ...`, "
+        "`afs worker <type>`, or `afs ai agent` instead.\n" + "\n".join(snippets)
     )
 
 
@@ -69,14 +83,9 @@ def test_no_legacy_scaffold_python_new(doc_path: Path) -> None:
     relative = _relative(doc_path)
     if relative in ALLOWLIST:
         pytest.skip(f"intentional historical content: {relative}")
-    text = doc_path.read_text(encoding="utf-8")
-    matches = [
-        f"{relative}:{idx + 1}: {line.rstrip()}"
-        for idx, line in enumerate(text.splitlines())
-        if LEGACY_NEW_RE.search(line)
-    ]
-    assert not matches, (
-        "`azure-functions-scaffold-python` is no longer a valid CLI entry; "
-        + "use `afs` or `azure-functions-scaffold` instead.\n"
-        + "\n".join(matches)
+    text = _normalized_text(doc_path)
+    snippets = [match.group(0) for match in LEGACY_NEW_RE.finditer(text)]
+    assert not snippets, (
+        f"{relative}: `azure-functions-scaffold-python` is no longer a valid "
+        "CLI entry; use `afs` or `azure-functions-scaffold` instead.\n" + "\n".join(snippets)
     )


### PR DESCRIPTION
## Summary

Top-level `afs new` is now a shortcut for `afs api new` (HTTP only) and no longer accepts `--template`, `--preset`, or `--with-*` flags. Per-trigger scaffolding lives under `afs worker <type>`, `afs ai agent`, or `afs advanced new`. Documentation still referenced the old surface in 11 files, plus the legacy `azure-functions-scaffold-python new` entry-point.

This PR brings the documentation in line with the current CLI surface and adds a regression test that scans `docs/**/*.md` to prevent re-drift.

Closes #112.

## Changes

### Docs (11 files, Oracle-approved Rule A mapping)

| Pattern | Replacement |
|---|---|
| `afs new <name> --template http` | `afs new <name>` |
| `afs new <name> --template timer\|queue\|blob\|servicebus\|eventhub` | `afs worker <type> <name>` |
| `afs new <name> --template langgraph` | `afs ai agent <name>` |
| `afs new <name> --preset ... --with-*` | `afs advanced new --template <T> --preset <P> [--with-*] <name>` |
| `--github-actions` (on touched lines) | `--include-github-actions` |

Files: `docs/deployment.md`, `docs/examples/{full_stack,http_api,timer_job}.md`, `docs/guide/{configuration,features,stacks,templates,tutorial}.md`, `docs/index.md`, `docs/reference/architecture.md`.

### Regression test (new)

`tests/test_docs_cli_examples.py`:
- Parametrized over every `docs/**/*.md`
- Forbids `\bafs\s+new\b.*--template\b`
- Forbids `\bazure-functions-scaffold-python\s+new\b`
- Allowlist: `docs/migration/0.6.0.md` (intentional historical content explaining the 0.5 -> 0.6 CLI rename)

## Acceptance Checklist (issue #112)

- [x] All `afs new --template ...` references replaced or routed to the correct subcommand
- [x] All `azure-functions-scaffold-python new` examples removed from non-migration docs
- [x] Regression smoke test added under `tests/test_docs_cli_examples.py`
- [x] Verified against the current CLI surface (`cli.py`, `cli_api.py`, `cli_worker.py`, `cli_advanced.py`, `cli_ai.py`)

## Verification

Run locally (hatch-direct because `make bootstrap` requires `.venv/bin/pip` not present in this env):

```bash
hatch -e default run lint     # All checks passed!
hatch -e default run security # 0 issues
hatch -e default run test     # 386 passed, 5 skipped (2 mine + 3 e2e), 9 pre-existing env failures
hatch build                   # sdist + wheel built
```

Coverage: **97.48%** (above the 95% `fail_under` threshold).

The 9 failing tests (`test_simple_trigger_templates_pass_generated_checks[*]`) reproduce on `origin/main` with the same `make install` env failure inside generated scaffolds — pre-existing and unrelated to this PR.

## Out of Scope (deferred to follow-up issues)

- Stale `--profile` references in `docs/guide/stacks.md` (lines 19, 47, 106, 128-131)
- Stale `--with-doctor` on top-level `afs new` in `docs/guide/features.md` (lines 76, 85 — note: L85 was touched by an adjacent edit but the `--with-doctor` flag itself was not the issue #112 pattern)
- README `*-python` legacy references (separate canonical-URL work)

These are also stale-CLI-example bugs but were not in the original #112 explore-agent scan and the smoke test in this PR only covers the `--template` and `azure-functions-scaffold-python` patterns scoped to this issue. A follow-up issue will be filed once this PR merges.