### PR TITLE
docs(reference): remove stale --interactive flag from cli.md

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -14,7 +14,7 @@ Generates a new Azure Functions Python v2 project from scratch.
 
 | Argument | Required | Description |
 | :--- | :--- | :--- |
-| `PROJECT_NAME` | No | Name of the project directory. If omitted, the tool enters interactive mode. |
+| `PROJECT_NAME` | Yes | Name of the project directory. Must start with an alphanumeric character and contain only letters, numbers, hyphens, or underscores. |
 
 #### Options
 
@@ -29,7 +29,6 @@ Generates a new Azure Functions Python v2 project from scratch.
 | `--with-openapi` / `--no-openapi` | `--no-openapi` | Boolean | Include OpenAPI/Swagger documentation support. |
 | `--with-validation` / `--no-validation` | `--no-validation` | Boolean | Include Pydantic-based request validation. |
 | `--with-doctor` / `--no-doctor` | `--no-doctor` | Boolean | Include a `doctor.py` script for environment checks. |
-| `--interactive`, `-i` | False | Boolean | Force interactive wizard. |
 | `--dry-run` | False | Boolean | Show planned files without writing to disk. |
 | `--overwrite` | False | Boolean | Overwrite files if the destination directory exists. |
 | `--yes`, `-y` | False | Boolean | Skip overwrite confirmation prompts when deletion is intentional. |


### PR DESCRIPTION
## Summary

- `docs/reference/cli.md:17` — `PROJECT_NAME` marked as required; dropped the "If omitted, the tool enters interactive mode" fallback prose.
- `docs/reference/cli.md:32` — removed the `--interactive, -i` row entirely.
- The one remaining "interactive" mention (line 36) describes TTY-mode overwrite confirmation prompts, not the removed wizard, and is left intact per acceptance interpretation.

## Context

PR #127 (issue #112) cleaned up stale `--interactive` references in `docs/guide/configuration.md` and `docs/guide/features.md` but explicitly excluded `docs/reference/cli.md` from scope per Oracle iteration 2 + 4 review deferrals. This PR closes that deferral.

Verified against current CLI help:
- `afs new --help` has no `--interactive` / `-i` flag.
- `afs advanced new --help` has no `--interactive` / `-i` flag.
- The CLI no longer ships any interactive wizard.

## Verification

- \`hatch run pytest tests/test_docs_cli_examples.py --no-cov\` — **70 passed, 2 skipped** (both intentional allowlist entries: \`docs/migration/0.6.0.md\`).
- \`hatch run mkdocs build --strict\` — warnings diff (before vs after this change): **zero new warnings introduced**. The 3 pre-existing warnings on \`main\` are unrelated (\`release_process.md\` → broken links, \`getting-started.md\` → broken README anchor).

## Out of scope (tracked separately)

- \`docs/reference/cli.md\` \`new\` options table lists \`--template/--preset/--with-*\` even though the top-level \`afs new\` no longer accepts them — this is a broader table drift that deserves its own issue.
- \`docs/guide/stacks.md\` \`--profile\` editorial restructure — #129.
- Broadening the smoke test alias to \`(?:afs|azure-functions-scaffold)\` — #130.

Closes #128