### PR TITLE
test(docs): broaden cli-example smoke test to accept azure-functions-scaffold alias

### DIFF
--- a/tests/test_docs_cli_examples.py
+++ b/tests/test_docs_cli_examples.py
@@ -30,7 +30,7 @@ LINE_CONTINUATION_RE = re.compile(r"\\\s*\n\s*")
 
 # Flags that no longer belong on top-level ``afs new`` (issue #112).
 TOP_LEVEL_AFS_NEW_RE = re.compile(
-    r"\bafs\s+new\b[^\n]*"
+    r"\b(?:afs|azure-functions-scaffold)\s+new\b[^\n]*"
     r"--(template|preset|with-openapi|with-validation|with-doctor|interactive)\b"
 )
 
@@ -90,3 +90,53 @@ def test_no_legacy_scaffold_python_new(doc_path: Path) -> None:
         f"{relative}: `azure-functions-scaffold-python` is no longer a valid "
         "CLI entry; use `afs` or `azure-functions-scaffold` instead.\n" + "\n".join(snippets)
     )
+
+
+class TestTopLevelAfsNewRegex:
+    """Unit tests for :data:`TOP_LEVEL_AFS_NEW_RE` covering both CLI aliases."""
+
+    def test_matches_short_alias_with_drifted_flag(self) -> None:
+        """``afs new`` + a drifted flag still triggers the regex."""
+        assert TOP_LEVEL_AFS_NEW_RE.search(
+            "afs new my-api --template http"
+        ) is not None
+
+    def test_matches_long_alias_with_drifted_flag(self) -> None:
+        """``azure-functions-scaffold new`` + a drifted flag also triggers."""
+        assert TOP_LEVEL_AFS_NEW_RE.search(
+            "azure-functions-scaffold new my-api --template http"
+        ) is not None
+
+    def test_matches_long_alias_with_interactive_flag(self) -> None:
+        """``--interactive`` on the long alias also triggers."""
+        assert TOP_LEVEL_AFS_NEW_RE.search(
+            "azure-functions-scaffold new my-api --interactive"
+        ) is not None
+
+    def test_ignores_short_alias_advanced_new(self) -> None:
+        """``afs advanced new`` with drifted flag is a valid, current CLI shape."""
+        assert TOP_LEVEL_AFS_NEW_RE.search(
+            "afs advanced new my-api --template http"
+        ) is None
+
+    def test_ignores_long_alias_advanced_new(self) -> None:
+        """``azure-functions-scaffold advanced new`` is a valid, current CLI shape."""
+        assert TOP_LEVEL_AFS_NEW_RE.search(
+            "azure-functions-scaffold advanced new my-api --template http"
+        ) is None
+
+    def test_ignores_legacy_scaffold_python_distribution(self) -> None:
+        """``azure-functions-scaffold-python new`` must be caught by LEGACY_NEW_RE,
+        not TOP_LEVEL_AFS_NEW_RE. The two regexes must remain distinct.
+        """
+        text = "azure-functions-scaffold-python new my-api --template http"
+        assert TOP_LEVEL_AFS_NEW_RE.search(text) is None
+        assert LEGACY_NEW_RE.search(text) is not None
+
+    def test_ignores_bare_afs_new_without_drifted_flags(self) -> None:
+        """Current, correct ``afs new`` invocations must not trip the regex."""
+        assert TOP_LEVEL_AFS_NEW_RE.search("afs new my-api") is None
+        assert TOP_LEVEL_AFS_NEW_RE.search(
+            "azure-functions-scaffold new my-api"
+        ) is None
+


### PR DESCRIPTION
## Summary

- \`TOP_LEVEL_AFS_NEW_RE\` broadened from \`\bafs\b\` to \`\b(?:afs|azure-functions-scaffold)\b\`, so drifted examples written with the long-form CLI alias no longer slip past the smoke test.
- \`LEGACY_NEW_RE\` (targets the renamed \`azure-functions-scaffold-python\` distribution) is unchanged and remains the exclusive matcher for that pattern.
- New \`TestTopLevelAfsNewRegex\` class adds 7 unit tests covering both aliases and the boundary between top-level and legacy regexes.

## Context

Oracle iteration 1 review on PR #127 flagged this as a non-blocking "watch out for" item. Both \`afs\` and \`azure-functions-scaffold\` are valid CLI entry points that ship with the distribution — previously the smoke test only anchored to the short form.

## Regex distinctness (documented in test)

The two regexes remain properly separated:

- \`TOP_LEVEL_AFS_NEW_RE\` matches \`\\s+new\\b\` after either alias. In \`azure-functions-scaffold-python new ...\`, the character after \`scaffold\` is \`-\` (not whitespace), so \`\\s+\` fails and the top-level regex does not match.
- \`LEGACY_NEW_RE\` continues to be the sole matcher for the renamed distribution pattern.

Explicit test asserts this: \`test_ignores_legacy_scaffold_python_distribution\` verifies that \`azure-functions-scaffold-python new my-api --template http\` is caught by \`LEGACY_NEW_RE\` but not by \`TOP_LEVEL_AFS_NEW_RE\`.

## Verification

- \`hatch run pytest tests/test_docs_cli_examples.py --no-cov -q\` — **75 passed** (68 existing parametrized + 7 new unit tests), 2 skipped (allowlist).
- \`hatch run pytest --cov -q\` — **97.48% total coverage**, above the 95% \`fail_under\` threshold.
- The 7 new unit tests all pass:
  - Positive: \`afs new --template\`, \`azure-functions-scaffold new --template\`, \`azure-functions-scaffold new --interactive\`
  - Negative: \`afs advanced new --template\`, \`azure-functions-scaffold advanced new --template\`, bare \`afs new my-api\`, bare \`azure-functions-scaffold new my-api\`
  - Boundary: \`azure-functions-scaffold-python new --template\` matches only \`LEGACY_NEW_RE\`

## Out of scope (tracked separately)

- \`docs/reference/cli.md\` stale \`--interactive\` references — #128 (PR #139).
- \`docs/guide/stacks.md\` \`--profile\` editorial restructure — #129.

Closes #130