### PR TITLE
docs(stacks): restructure --profile examples for current CLI surface

### DIFF
--- a/docs/guide/stacks.md
+++ b/docs/guide/stacks.md
@@ -14,9 +14,10 @@ and the scaffold command to generate a matching project.
 | `azure-functions-openapi` | Swagger UI + OpenAPI 3.1 spec |
 | `azure-functions-validation` | Pydantic request/response validation |
 | `azure-functions-logging` | Structured JSON logging |
+| `azure-functions-doctor` | Pre-deploy diagnostic checks |
 
 ```bash
-afs new my-api --profile api
+afs new my-api
 ```
 
 ```text
@@ -28,7 +29,8 @@ azure-functions-logging
 ```
 
 **What you get:** validated HTTP endpoints with auto-generated API docs,
-structured logs, and request correlation IDs.
+structured logs, request correlation IDs, and pre-wired `azure-functions-doctor`
+health checks.
 
 ---
 
@@ -44,7 +46,7 @@ structured logs, and request correlation IDs.
 | `azure-functions-logging` | Structured JSON logging |
 
 ```bash
-afs new my-api --profile db-api
+afs new my-api
 ```
 
 ```text
@@ -58,6 +60,10 @@ azure-functions-logging
 
 **What you get:** everything in the API Stack plus declarative database
 read/write bindings via `@db.input()` and `@db.output()`.
+
+> **Manual step:** `afs new` does not yet ship a `--with-db` flag. After
+> scaffolding, add `azure-functions-db[postgres]` (or another supported
+> engine) to `requirements.txt` and wire up your bindings under `app/`.
 
 ---
 
@@ -103,7 +109,7 @@ database access, health diagnostics, and observability.
 | `azure-functions-doctor` | Pre-deploy diagnostic checks |
 
 ```bash
-afs new my-api --profile db-api
+afs new my-api
 ```
 
 ```text
@@ -117,7 +123,11 @@ azure-functions-doctor
 ```
 
 **What you get:** a fully instrumented API with validation, database access,
-API docs, structured logging, and pre-deploy health diagnostics.
+API docs, structured logging, and pre-wired health diagnostics.
+
+> **Manual step:** `afs new` does not yet ship a `--with-db` flag. After
+> scaffolding, add `azure-functions-db[postgres]` (or another supported
+> engine) to `requirements.txt` and wire up your bindings under `app/`.
 
 ---
 
@@ -125,10 +135,10 @@ API docs, structured logging, and pre-deploy health diagnostics.
 
 | Stack | Scaffold Command | Packages | Use Case |
 |-------|-----------------|----------|----------|
-| API | `afs new my-api --profile api` | 3 | REST APIs, webhooks |
-| DB API | `afs new my-api --profile db-api` | 4 | CRUD with database |
+| API | `afs new my-api` | 4 | REST APIs, webhooks |
+| DB API | `afs new my-api` + `pip install azure-functions-db[<engine>]` | 5 | CRUD with database |
 | AI Agent | `afs ai agent my-agent` | 3 | LangGraph agents |
-| Full | `afs new my-api --profile db-api` | 5 | Production services |
+| Full | `afs new my-api` + `pip install azure-functions-db[<engine>]` | 5 | Production services |
 
 Start with the smallest stack that covers your needs.
 Add packages incrementally — the toolkit is designed for zero coupling between packages.


### PR DESCRIPTION
## Summary

- API Stack now uses \`afs new my-api\` (the current shortcut for \`afs api new\`, which pre-wires OpenAPI, validation, doctor, and logging).
- DB API Stack and Full Stack use \`afs new my-api\` with a new "Manual step" callout for adding \`azure-functions-db[<engine>]\` to \`requirements.txt\` until \`--with-db\` ships.
- API Stack package table now includes \`azure-functions-doctor\` to match what \`afs new my-api\` actually generates (package count 3 → 4).
- "Choosing a Stack" matrix rewritten to match the new invocations.
- AI Agent Stack (\`afs ai agent my-agent\`) already correct and is untouched.

## Context

PR #127 (issue #112) left \`docs/guide/stacks.md\` untouched per Oracle iteration 1 review because the page needed editorial restructure rather than a mechanical example swap. Every example advertised \`afs new my-api --profile <name>\`, but no such \`--profile\` flag exists on any current \`afs\` subcommand.

Verified against \`afs new --help\`, \`afs api new --help\`, and \`afs advanced new --help\`: there is no \`--profile\` flag. \`afs new\` is the shortcut for \`afs api new\`, which creates a REST API project with OpenAPI, validation, doctor, and logging pre-wired.

## Restructure decisions

1. **Use \`afs new my-api\` for HTTP stacks.** Simpler than \`afs advanced new --template http --preset standard --with-openapi --with-validation --with-doctor my-api\` and matches the current top-level CLI shape.
2. **Call out the manual db install step.** \`afs new\` does not yet ship a \`--with-db\` flag (README lists it as *planned — not yet available in CLI*). The stacks that need database bindings now include a blockquote noting the post-scaffold \`pip install\` step.
3. **Leave section structure intact.** The four sections (API, DB API, AI Agent, Full) remain distinct so users landing on any one section still get a clear stack description.

## Verification

- \`hatch run pytest tests/test_docs_cli_examples.py --no-cov -q\` — **68 passed, 2 skipped** (allowlist).
- \`hatch run mkdocs build --strict\` — warnings diff (before vs after): **zero new warnings introduced**. The 3 pre-existing warnings on \`main\` (broken links in \`release_process.md\` and \`getting-started.md\`) are unrelated.
- No \`--profile\` references remain in \`docs/guide/stacks.md\`.

## Out of scope (tracked separately)

- \`docs/reference/cli.md\` stale \`--interactive\` references — #128 (PR #139).
- Broadening the smoke test alias — #130 (PR #140).
- \`docs/reference/cli.md\` \`new\` options table lists \`--template/--preset/--with-*\` even though the top-level \`afs new\` no longer accepts them — separate follow-up.

Closes #129