### PR TITLE
docs(readme): document all 9 ADDABLE_TRIGGERS across en/ko/ja/zh-CN

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -51,7 +51,7 @@ Python バージョンサポート: Azure Functions では 3.10-3.13 は GA、3.
 - Azure Functions Python **v2 プログラミングモデル**
 - デコレータベースの `func.FunctionApp()` アプリケーション
 - CLI 駆動のプロジェクト生成と拡張
-- HTTP、Timer、Queue、Blob、Service Bus、LangGraph トリガー用テンプレート
+- HTTP、Timer、Queue、Blob、Service Bus、Event Hub、Cosmos DB、Durable Functions、AI (Azure OpenAI)、LangGraph トリガー用テンプレート
 
 このツールはプロジェクトスキャフォールドを生成します。ランタイムライブラリは提供**しません**。
 
@@ -145,6 +145,10 @@ my-api/
 | queue | `afs worker queue my-worker` | メッセージ処理 (Azurite) |
 | blob | `afs worker blob my-blob` | ファイル処理 (Azurite) |
 | servicebus | `afs worker servicebus my-bus` | エンタープライズメッセージング |
+| eventhub | `afs worker eventhub my-hub` | 高スループットイベントストリーム取り込み |
+| cosmosdb | `afs advanced new --template cosmosdb my-processor` | Cosmos DB 変更フィード処理 |
+| durable | `afs advanced new --template durable my-workflow` | オーケストレーションワークフロー |
+| ai | `afs advanced new --template ai my-ai-api` | Azure OpenAI チャット完了エンドポイント |
 
 注: `afs` は `azure-functions-scaffold` の短縮形です。どちらも利用できます。
 
@@ -155,6 +159,10 @@ my-api/
 - `queue`: ローカル Azurite 開発向けに準備された Storage Queue トリガー。
 - `blob`: ファイル取り込みパイプライン向け Blob トリガースキャフォールド。
 - `servicebus`: 開発用プレースホルダー付きの Service Bus トリガースキャフォールド。
+- `eventhub`: 高スループットのイベントストリーム用に `EventHubConnection` を使用する Event Hub トリガースキャフォールド。
+- `cosmosdb`: `CosmosDBConnection` とリースコンテナを使用する Cosmos DB 変更フィードプロセッサー。
+- `durable`: HTTP スターター、オーケストレーター、アクティビティ例を含む Durable Functions スキャフォールド (Azurite 必須)。
+- `ai`: `AZURE_OPENAI_ENDPOINT`、`AZURE_OPENAI_API_KEY`、`AZURE_OPENAI_DEPLOYMENT` 設定が必要な Azure OpenAI チャットエンドポイント。
 
 ## オプション機能
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -51,7 +51,7 @@ Python 버전 지원: Azure Functions에서 3.10-3.13은 GA이며, 3.14는 **Pre
 - Azure Functions Python **v2 프로그래밍 모델**
 - 데코레이터 기반 `func.FunctionApp()` 애플리케이션
 - CLI 기반 프로젝트 생성 및 확장
-- HTTP, Timer, Queue, Blob, Service Bus, LangGraph 트리거 템플릿
+- HTTP, Timer, Queue, Blob, Service Bus, Event Hub, Cosmos DB, Durable Functions, AI (Azure OpenAI), LangGraph 트리거 템플릿
 
 이 도구는 프로젝트 스캐폴드를 생성합니다. 런타임 라이브러리를 제공하지는 **않습니다**.
 
@@ -145,6 +145,10 @@ my-api/
 | queue | `afs worker queue my-worker` | 메시지 처리 (Azurite) |
 | blob | `afs worker blob my-blob` | 파일 처리 (Azurite) |
 | servicebus | `afs worker servicebus my-bus` | 엔터프라이즈 메시징 |
+| eventhub | `afs worker eventhub my-hub` | 고처리량 이벤트 스트림 수집 |
+| cosmosdb | `afs advanced new --template cosmosdb my-processor` | Cosmos DB 변경 피드 처리 |
+| durable | `afs advanced new --template durable my-workflow` | 오케스트레이션 워크플로우 |
+| ai | `afs advanced new --template ai my-ai-api` | Azure OpenAI 채팅 완성 엔드포인트 |
 
 참고: `afs`는 `azure-functions-scaffold`의 줄임말입니다. 둘 다 동작합니다.
 
@@ -155,6 +159,10 @@ my-api/
 - `queue`: 로컬 Azurite 개발에 바로 사용할 수 있는 Storage Queue 트리거.
 - `blob`: 파일 수집 파이프라인을 위한 Blob 트리거 스캐폴드.
 - `servicebus`: 개발용 자리표시자가 포함된 Service Bus 트리거 스캐폴드.
+- `eventhub`: 고처리량 이벤트 스트림을 위한 `EventHubConnection` 사용 Event Hub 트리거 스캐폴드.
+- `cosmosdb`: `CosmosDBConnection`과 리스 컨테이너를 사용하는 Cosmos DB 변경 피드 프로세서.
+- `durable`: HTTP 시작기, 오케스트레이터, 활동 예제가 포함된 Durable Functions 스캐폴드 (Azurite 필요).
+- `ai`: `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_API_KEY`, `AZURE_OPENAI_DEPLOYMENT` 설정이 필요한 Azure OpenAI 채팅 엔드포인트.
 
 ## 선택 기능
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ flowchart LR
 - Azure Functions Python **v2 programming model**
 - Decorator-based `func.FunctionApp()` applications
 - CLI-driven project generation and expansion
-- Templates for HTTP, Timer, Queue, Blob, Service Bus triggers, and LangGraph agents
+- Templates for HTTP, Timer, Queue, Blob, Service Bus, Event Hub, Cosmos DB, Durable Functions, AI (Azure OpenAI), and LangGraph agents
 
 This tool generates project scaffolds. It does **not** provide runtime libraries.
 
@@ -174,6 +174,10 @@ Why this layout works:
 | queue | `afs worker queue my-worker` | Message processing (Azurite) |
 | blob | `afs worker blob my-blob` | File processing (Azurite) |
 | servicebus | `afs worker servicebus my-bus` | Enterprise messaging |
+| eventhub | `afs worker eventhub my-hub` | High-throughput event stream ingestion |
+| cosmosdb | `afs advanced new --template cosmosdb my-processor` | Cosmos DB change feed processing |
+| durable | `afs advanced new --template durable my-workflow` | Orchestrated workflows with fan-out |
+| ai | `afs advanced new --template ai my-ai-api` | Azure OpenAI chat completion endpoint |
 | langgraph | `afs ai agent my-agent` | LangGraph AI agent deployment |
 
 Note: `afs` is short for `azure-functions-scaffold`. Both work.
@@ -185,6 +189,10 @@ Template defaults:
 - `queue`: Storage Queue trigger ready for local Azurite development.
 - `blob`: Blob trigger scaffold for file-ingestion pipelines.
 - `servicebus`: Service Bus trigger scaffold with development placeholders.
+- `eventhub`: Event Hub trigger scaffold using `EventHubConnection` for high-throughput event streams.
+- `cosmosdb`: Cosmos DB change feed processor with `CosmosDBConnection` and lease container.
+- `durable`: Durable Functions orchestrator with HTTP starter, orchestrator, and activity example (requires Azurite).
+- `ai`: Azure OpenAI chat endpoint requiring `AZURE_OPENAI_ENDPOINT`, `AZURE_OPENAI_API_KEY`, and `AZURE_OPENAI_DEPLOYMENT` settings.
 
 ## Optional Features
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -51,7 +51,7 @@ Python 版本支持: Azure Functions 上 3.10-3.13 为 GA，3.14 为 **Preview**
 - Azure Functions Python **v2 编程模型**
 - 基于装饰器的 `func.FunctionApp()` 应用
 - CLI 驱动的项目生成与扩展
-- HTTP、Timer、Queue、Blob、Service Bus 和 LangGraph 触发器模板
+- HTTP、Timer、Queue、Blob、Service Bus、Event Hub、Cosmos DB、Durable Functions、AI (Azure OpenAI) 和 LangGraph 触发器模板
 
 此工具用于生成项目脚手架，**不**提供运行时库。
 
@@ -145,6 +145,10 @@ my-api/
 | queue | `afs worker queue my-worker` | 消息处理 (Azurite) |
 | blob | `afs worker blob my-blob` | 文件处理 (Azurite) |
 | servicebus | `afs worker servicebus my-bus` | 企业消息传递 |
+| eventhub | `afs worker eventhub my-hub` | 高吞吐量事件流摄取 |
+| cosmosdb | `afs advanced new --template cosmosdb my-processor` | Cosmos DB 变更源处理 |
+| durable | `afs advanced new --template durable my-workflow` | 编排工作流 |
+| ai | `afs advanced new --template ai my-ai-api` | Azure OpenAI 聊天完成端点 |
 
 注意: `afs` 是 `azure-functions-scaffold` 的简称。两者都可用。
 
@@ -155,6 +159,10 @@ my-api/
 - `queue`: 为本地 Azurite 开发准备好的 Storage Queue 触发器。
 - `blob`: 用于文件摄取流水线的 Blob 触发器脚手架。
 - `servicebus`: 带开发占位符的 Service Bus 触发器脚手架。
+- `eventhub`: 使用 `EventHubConnection` 的 Event Hub 触发器脚手架，适用于高吞吐量事件流。
+- `cosmosdb`: 使用 `CosmosDBConnection` 和租约容器的 Cosmos DB 变更源处理器。
+- `durable`: 包含 HTTP 启动器、编排器和活动示例的 Durable Functions 脚手架 (需要 Azurite)。
+- `ai`: 需要 `AZURE_OPENAI_ENDPOINT`、`AZURE_OPENAI_API_KEY` 和 `AZURE_OPENAI_DEPLOYMENT` 设置的 Azure OpenAI 聊天端点。
 
 ## 可选功能
 

--- a/tests/test_readme_triggers.py
+++ b/tests/test_readme_triggers.py
@@ -1,0 +1,56 @@
+"""Guard against README trigger-list drift from generator.ADDABLE_TRIGGERS.
+
+Regression tests for issue #138: the top-level README (and its translations)
+must document every trigger exposed by ``generator.ADDABLE_TRIGGERS`` so users
+discover the full CLI surface. The ``docs/guide/templates.md`` matrix carries
+the per-trigger detail; these tests only assert coverage in the READMEs.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from azure_functions_scaffold.generator import ADDABLE_TRIGGERS
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+README_FILES: tuple[str, ...] = (
+    "README.md",
+    "README.ko.md",
+    "README.ja.md",
+    "README.zh-CN.md",
+)
+
+
+class TestReadmeTriggerCoverage:
+    """Every ADDABLE_TRIGGERS entry must appear in every README variant."""
+
+    @pytest.mark.parametrize("readme_name", README_FILES)
+    @pytest.mark.parametrize("trigger", ADDABLE_TRIGGERS)
+    def test_trigger_documented_in_readme(self, readme_name: str, trigger: str) -> None:
+        readme_path = REPO_ROOT / readme_name
+        assert readme_path.exists(), f"Missing README file: {readme_name}"
+
+        content = readme_path.read_text(encoding="utf-8")
+        # Trigger name must appear as a backtick-fenced token in the templates
+        # table (e.g. `| eventhub |`). We accept either backtick or plain
+        # occurrences to stay tolerant of translated section headers, but the
+        # trigger name itself must be present verbatim.
+        assert trigger in content, (
+            f"{readme_name} does not mention ADDABLE_TRIGGERS entry '{trigger}'. "
+            f"Update the ## Templates table (and Scope bullet) to keep the CLI "
+            f"surface discoverable."
+        )
+
+    @pytest.mark.parametrize("readme_name", README_FILES)
+    def test_readme_has_templates_section(self, readme_name: str) -> None:
+        readme_path = REPO_ROOT / readme_name
+        content = readme_path.read_text(encoding="utf-8")
+        # English uses '## Templates'; translations use '## 템플릿', '## テンプレート',
+        # or '## 模板'. We only require SOME level-2 heading whose body then
+        # contains all ADDABLE_TRIGGERS entries — enforced by the sibling test.
+        heading_candidates = ("## Templates", "## 템플릿", "## テンプレート", "## 模板")
+        assert any(h in content for h in heading_candidates), (
+            f"{readme_name} is missing a templates heading. Expected one of {heading_candidates}."
+        )


### PR DESCRIPTION
## Summary

Aligns all four README variants with `generator.ADDABLE_TRIGGERS` so users can discover the full trigger surface from the top-level docs. Adds a regression test that asserts every `ADDABLE_TRIGGERS` entry appears in every README.

## Changes

**READMEs** (`README.md`, `README.ko.md`, `README.ja.md`, `README.zh-CN.md`):
- **Scope bullet**: expanded from `HTTP, Timer, Queue, Blob, Service Bus, LangGraph` to include `Event Hub, Cosmos DB, Durable Functions, AI (Azure OpenAI)`
- **## Templates table**: added 4 new rows (eventhub, cosmosdb, durable, ai) with the correct CLI invocation per trigger
- **Template defaults list**: added 4 new bullets describing what each trigger scaffold generates and its runtime dependencies (EventHubConnection, CosmosDBConnection + lease container, Azurite for durable, AZURE_OPENAI_* env vars for ai)

**Tests** (`tests/test_readme_triggers.py`):
- New file, 40 parametrized tests: 9 triggers × 4 READMEs = 36 coverage tests + 4 templates-heading tests
- Reads `ADDABLE_TRIGGERS` from `generator` directly, so adding a new trigger to the tuple immediately requires README updates (CI will fail otherwise)

## Trigger audit summary (via background agent)

Verified all 9 addable triggers are production-quality with full templates, code branches in `generator.py`, and test coverage. **No experimental badges warranted.**

| Trigger    | Template files | Test files | CLI exposure                         |
| ---------- | -------------: | ---------: | ------------------------------------ |
| http       |             26 |          6 | `api new/add`, `advanced add`        |
| timer      |             18 |          5 | `worker timer`, `advanced add`       |
| queue      |             18 |          4 | `worker queue`, `advanced add`       |
| blob       |             18 |          4 | `worker blob`, `advanced add`        |
| servicebus |             18 |          4 | `worker servicebus`, `advanced add`  |
| eventhub   |             18 |          4 | `worker eventhub`, `advanced add`    |
| cosmosdb   |             18 |          3 | `advanced add` only                  |
| durable    |             18 |          3 | `advanced add` only                  |
| ai         |             18 |          5 | `ai agent` (via langgraph), `advanced add` |

Every trigger has non-trivial template implementations (200-1000+ template lines, multiple files per trigger). No `TODO`/`FIXME`/`experimental`/`alpha`/`beta` markers found in any trigger template beyond the intentional "TODO: implement" placeholder text in generated function bodies (normal for skeleton code).

CLI help coverage is already asserted by the pre-existing `test_templates_command_lists_available_templates` in `tests/test_cli.py:19-32`, which verifies `afs templates` output contains every trigger by name.

## Verification

- `hatch run pytest tests/test_readme_triggers.py --no-cov -v` → **40 passed** in 0.11s
- `hatch run pytest --cov -q` → **all pass, coverage 97.48%** (above 95% threshold)
- `hatch run mkdocs build --strict` → 3 pre-existing warnings (unchanged from `main` baseline; unrelated to this PR — they concern `release_process.md` broken links and a broken README anchor in `getting-started.md`)

## Out of scope (follow-ups filed / to be filed)

- Translated READMEs (ko/ja/zh-CN) still lack the `langgraph` row that English has (line 181). This is a pre-existing translation gap, separate from `ADDABLE_TRIGGERS` coverage. Not blocking.
- README badge drift `release.yml` → `publish-pypi.yml` tracked in #143
- `docs/reference/cli.md` documents advanced-only flags on top-level `afs new` tracked in #144

Closes #138
