### PR TITLE
docs(cli): align CLI reference with implemented commands and fix changelog/migration drift

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,68 +1,19 @@
+<!--
+  This page is generated at build time from the canonical CHANGELOG.md at the repository root
+  (see docs_hooks/changelog.py, registered under `hooks:` in mkdocs.yml). Do not edit here —
+  update CHANGELOG.md instead. When viewed on the published docs site, this placeholder is
+  replaced by the full canonical changelog.
+-->
+
 # Changelog
 
-All notable changes to the `azure-functions-scaffold` project are documented on this page. This project adheres to Semantic Versioning and maintains a structured history of updates, features, and bug fixes.
+The complete, canonical changelog lives in
+[`CHANGELOG.md`](https://github.com/yeongseon/azure-functions-scaffold-python/blob/main/CHANGELOG.md)
+at the repository root and is rendered here automatically on the published documentation site.
 
-## Versioning Scheme
-
-This project follows [Semantic Versioning (SemVer)](https://semver.org/). Version numbers are assigned using the `MAJOR.MINOR.PATCH` format:
+It is generated from [Conventional Commits](https://www.conventionalcommits.org/) using
+`git-cliff` and follows [Semantic Versioning](https://semver.org/):
 
 - **MAJOR**: Breaking changes that require user intervention or migration.
-- **MINOR**: New features or significant enhancements that are backwards compatible.
-- **PATCH**: Backwards compatible bug fixes and maintenance updates.
-
-The changelog is generated from [Conventional Commits](https://www.conventionalcommits.org/) using `git-cliff`. Breaking changes are explicitly highlighted in the release notes.
-
-## Full Version History
-
-### v0.3.1 (2026-03-14)
-
-This release captures the tooling unification and documentation overhaul applied across the ecosystem.
-
-#### Added
-- Unified tooling: Ruff (lint + format), pre-commit hooks, standardized Makefile
-- Comprehensive documentation overhaul (MkDocs site with standardized nav)
-- Translated README files (Korean, Japanese, Chinese)
-- Standardized documentation quality across ecosystem
-
-### v0.3.0 (2026-03-12)
-
-This release introduces health check integration and enhanced structured logging capabilities across all project templates.
-
-#### Added
-- Introduced `--with-doctor` and `--no-doctor` flags for the `new` command to include `azure-functions-doctor` health checks in scaffolded projects.
-- Added an interactive prompt to choose whether to include the doctor health check tool during project setup.
-- Implemented a conditional `make doctor` target in the generated `Makefile` when the doctor flag is enabled.
-- Set `azure-functions-logging>=0.2.0` as a default dependency for all generated project templates.
-- Added structured JSON logging support via `setup_logging(format="json")` and `get_logger()` in the generated `logging.py` file.
-- Updated non-HTTP function templates to use `logging.info()` instead of `print()` for better production readiness.
-- Added a dry-run report status for the doctor tool, showing "Doctor: enabled" when requested.
-- Expanded test coverage to include the doctor flag, dry-run output verification, and logging dependency management.
-
-#### Changed
-- Refactored the generated `logging.py` to replace the basic `basicConfig` stub with full `azure-functions-logging` integration.
-- Updated Queue, Blob, and Service Bus function templates to use lazy `%s` format strings for more efficient logging.
-
-### v0.2.0 (2026-03-12)
-
-This update focuses on the HTTP template, adding optional support for OpenAPI documentation and automated request/target validation.
-
-#### Added
-- Added `--with-openapi` and `--no-openapi` flags for the `new` command, specifically for HTTP project templates.
-- Added `--with-validation` and `--no-validation` flags for the `new` command to enable request and response validation.
-- Included interactive prompts for both OpenAPI and validation features during the `new` command execution.
-- Implemented conditional Jinja2 templates to generate OpenAPI endpoints, validation decorators, and Pydantic models only when requested.
-- Updated dry-run output to report "OpenAPI: enabled" and "Validation: enabled" based on the provided flags.
-- Added comprehensive test coverage for all combinations of OpenAPI and validation flags.
-
-### v0.1.0 (2026-03-08)
-
-The initial release of the `azure-functions-scaffold` CLI, providing a robust foundation for building Azure Functions Python v2 projects.
-
-#### Added
-- Launched the interactive `new` command for bootstrapping Azure Functions Python v2 projects with ease.
-- Introduced project presets (`minimal`, `standard`, and `strict`) to cater to different project complexity needs.
-- Added optional tooling selection for `Ruff`, `mypy`, and `pytest` during the interactive setup process.
-- Implemented the `add` command with support for `http`, `timer`, `queue`, `blob`, and `servicebus` triggers.
-- Provided specialized trigger templates for Queue, Blob, and Service Bus functions.
-- Enabled template-driven generation for core project files, including `pyproject.toml`, `Makefile`, CI configurations, and `README.md`.
-- Established initial project documentation, release notes structure, and template specification guidance.
+- **MINOR**: New, backwards-compatible features or enhancements.
+- **PATCH**: Backwards-compatible bug fixes and maintenance updates.

--- a/docs/contributing/guidelines.md
+++ b/docs/contributing/guidelines.md
@@ -61,6 +61,22 @@ If you are modifying templates in `src/azure_functions_scaffold/templates/`, fol
 5. Verify the generated project can be initialized (e.g., `pip install -r requirements.txt`).
 6. Confirm the generated code is valid Python and follows Azure Functions best practices.
 
+## Documentation & i18n Sync
+
+The primary `README.md` is mirrored by localized translations: `README.ko.md` (한국어),
+`README.ja.md` (日本語), and `README.zh-CN.md` (简体中文). When a change alters user-facing
+**command examples, CLI flags, or the command surface**, keep documentation in lockstep:
+
+1. Update `docs/reference/cli.md` so the CLI reference matches the implemented command/flag surface.
+   The `tests/test_docs_cli_examples.py` regression guard fails the build if the reference drifts.
+2. If the change touches examples shown in the READMEs, update **all four** READMEs
+   (`README.md`, `README.ko.md`, `README.ja.md`, `README.zh-CN.md`) in the same PR — do not let the
+   localized copies fall behind the English original.
+3. If a change adds or renames a public symbol, update `docs/reference/api.md` accordingly.
+
+Reviewers should reject PRs that change command examples in `README.md` without matching updates to
+the localized READMEs.
+
 ## Pull Request Process
 
 - Provide a clear title and description of the change in your PR.

--- a/docs/migration/0.6.0.md
+++ b/docs/migration/0.6.0.md
@@ -1,6 +1,6 @@
 # Migration Guide: 0.5.0 → 0.6.0
 
-> **Status**: Released. This guide covers upgrading from 0.5.0 to the 0.6.x line (current: 0.6.1) and documents every breaking change introduced by PRs #81-#94, so 0.5.0 users can upgrade with a single read. If you are already on any 0.6.x release, no further migration is required — this guide is retained as a historical reference for the 0.5.0 → 0.6.0 jump.
+> **Status**: Released. This guide covers upgrading from 0.5.0 to the 0.6.x line and documents every breaking change introduced by PRs #81-#94, so 0.5.0 users can upgrade with a single read. If you are already on any 0.6.x release, no further migration is required — this guide is retained as a historical reference for the 0.5.0 → 0.6.0 jump.
 
 0.6.0 is a hardening release. It tightens default security posture, fixes a packaging mismatch that prevented install via the documented command, and ships several CLI quality-of-life improvements. There are several breaking changes; all are documented below with migration steps.
 

--- a/docs/migration/0.6.0.md
+++ b/docs/migration/0.6.0.md
@@ -1,6 +1,6 @@
 # Migration Guide: 0.5.0 → 0.6.0
 
-> **Status**: Draft. This guide accompanies the 0.6.0 release (planned). It documents every breaking change introduced by PRs #81-#94 so that 0.5.0 users can upgrade with a single read.
+> **Status**: Released. This guide covers upgrading from 0.5.0 to the 0.6.x line (current: 0.6.1) and documents every breaking change introduced by PRs #81-#94, so 0.5.0 users can upgrade with a single read. If you are already on any 0.6.x release, no further migration is required — this guide is retained as a historical reference for the 0.5.0 → 0.6.0 jump.
 
 0.6.0 is a hardening release. It tightens default security posture, fixes a packaging mismatch that prevented install via the documented command, and ships several CLI quality-of-life improvements. There are several breaking changes; all are documented below with migration steps.
 
@@ -324,7 +324,7 @@ A new workflow `templates-smoke.yml` scaffolds every template on every PR that t
 After upgrading:
 
 - [ ] `pip install azure-functions-scaffold` succeeds (use the new name).
-- [ ] `afs --version` prints `0.6.0`.
+- [ ] `afs --version` prints a `0.6.x` version (e.g. `0.6.1`).
 - [ ] If you use webhooks, `WEBHOOK_SECRET` is configured in `local.settings.json` and Azure app settings.
 - [ ] Existing scaffolded projects still respond to `afs api add` etc. (legacy marker shim).
 - [ ] Scripted `--overwrite` invocations include `--yes`.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2,76 +2,204 @@
 
 Technical specification for the `azure-functions-scaffold` (alias: `afs`) command-line interface.
 
-## Commands
+The CLI is organized into intent-centric subcommand groups (`api`, `worker`, `ai`, `advanced`)
+plus a few top-level shortcuts. The following diagram shows how a command flows from the CLI
+surface through the intent pipeline to the filesystem:
+
+```mermaid
+flowchart LR
+    Dev([Developer]) --> CLI["afs (cli)"]
+    CLI --> Intent["run_intent /<br/>build_project_options"]
+    Intent --> Scaffold["scaffold_project"]
+    Scaffold --> Render["Jinja2 render"]
+    Render --> FS[("Project files<br/>on disk")]
+```
+
+## Command Overview
+
+| Command | Kind | Purpose |
+| :--- | :--- | :--- |
+| `afs new` | shortcut | Alias for `afs api new` (HTTP REST API project). |
+| `afs api new` | group | Create a REST API project (OpenAPI + validation + doctor). |
+| `afs api add` | group | Add an HTTP function to an existing project. |
+| `afs api add-route` | group | Add a single HTTP route to an existing project. |
+| `afs api add-resource` | group | Add a full CRUD resource (blueprint, service, schema, test). |
+| `afs worker timer\|queue\|blob\|servicebus\|eventhub` | group | Create a background worker project for the given trigger. |
+| `afs ai agent` | group | Create a LangGraph agent project. |
+| `afs advanced new` | group | Power-user project creation with full option control. |
+| `afs advanced add` | group | Add a function of any trigger type to an existing project. |
+| `afs advanced add-route` / `add-resource` | group | Route/resource variants for power users. |
+| `afs advanced templates` / `presets` | group | List templates/presets (mirrors the top-level commands). |
+| `afs templates` | top-level | List available scaffold templates. |
+| `afs presets` | top-level | List available project presets and their tooling. |
+| `afs add` | deprecated | Shim forwarding to `afs api add` / `afs advanced add`. |
+| `afs profiles` | deprecated | Shim forwarding to `afs presets`. |
+| `afs --version` | top-level | Print the installed version and exit. |
+
+> **Note:** The top-level `afs new` is a **shortcut for `afs api new`** (HTTP template only). It
+> does **not** accept `--template`, `--preset`, or `--with-openapi/--with-validation/--with-doctor`.
+> Those flags live on `afs advanced new`. To scaffold a non-HTTP trigger use `afs worker <type>`,
+> `afs ai agent`, or `afs advanced new --template <name>`.
+
+## Shared Scaffold Options
+
+Every project-creation command (`afs new`, `afs api new`, `afs worker <type>`, `afs ai agent`)
+accepts the same option set:
+
+| Flag | Default | Values | Description |
+| :--- | :--- | :--- | :--- |
+| `--destination`, `-d` | `.` | Path | Base directory where the project folder is created. |
+| `--python-version` | `3.10` | `3.10`, `3.11`, `3.12`, `3.13`, `3.14 (Preview)` | Target Python version. `3.14` emits a Preview warning. |
+| `--github-actions` / `--no-github-actions` | `--no-github-actions` | Boolean | Include a basic GitHub Actions CI workflow. |
+| `--git` / `--no-git` | `--no-git` | Boolean | Initialize a git repository in the generated project. |
+| `--azd` / `--no-azd` | `--no-azd` | Boolean | Include Azure Developer CLI (`azd`) support files. |
+| `--dry-run` | `False` | Boolean | Preview the generated project without writing files. |
+| `--overwrite` | `False` | Boolean | Replace an existing target directory before generating. |
+| `--yes`, `-y` | `False` | Boolean | Skip confirmation prompts (required when `--overwrite` runs in a non-TTY session or against a directory containing `.git/`). |
+
+When `--overwrite` is used in an interactive TTY, the CLI prompts before deleting the target
+directory and defaults to No. In non-interactive sessions, `--overwrite` is refused unless `--yes`
+is also passed. As an extra safety guard, any target directory containing `.git/` also requires
+`--yes` before it can be deleted.
+
+## Top-Level Commands
 
 ### `new`
 
-Generates a new Azure Functions Python v2 project from scratch.
+Shortcut for `afs api new`: generates a new HTTP REST API project.
 
-- **Synopsis**: `azure-functions-scaffold new [PROJECT_NAME] [OPTIONS]`
-
-#### Arguments
-
-| Argument | Required | Description |
-| :--- | :--- | :--- |
-| `PROJECT_NAME` | Yes | Name of the project directory. Must start with an alphanumeric character and contain only letters, numbers, hyphens, or underscores. |
-
-#### Options
-
-| Flag | Default | Values | Description |
-| :--- | :--- | :--- | :--- |
-| `--destination`, `-d` | `.` | Path | Target parent directory for the project. |
-| `--template`, `-t` | `http` | `http`, `timer`, `queue`, `blob`, `servicebus` | Initial trigger template to include. |
-| `--preset` | `standard` | `minimal`, `standard`, `strict` | Tooling configuration (linting, types, tests). |
-| `--python-version` | `3.10` | `3.10`, `3.11`, `3.12`, `3.13`, `3.14 (Preview)` | Target Python version for the project. 3.14 is Preview on Azure Functions with limited regional/plan support. |
-| `--github-actions` / `--no-github-actions` | `--no-github-actions` | Boolean | Include GitHub Actions CI/CD workflows. |
-| `--git` / `--no-git` | `--no-git` | Boolean | Initialize a git repository. |
-| `--with-openapi` / `--no-openapi` | `--no-openapi` | Boolean | Include OpenAPI/Swagger documentation support. |
-| `--with-validation` / `--no-validation` | `--no-validation` | Boolean | Include Pydantic-based request validation. |
-| `--with-doctor` / `--no-doctor` | `--no-doctor` | Boolean | Include a `doctor.py` script for environment checks. |
-| `--dry-run` | False | Boolean | Show planned files without writing to disk. |
-| `--overwrite` | False | Boolean | Overwrite files if the destination directory exists. |
-| `--yes`, `-y` | False | Boolean | Skip overwrite confirmation prompts when deletion is intentional. |
-
-When `--overwrite` is used in an interactive TTY, the CLI prompts before deleting the target directory and defaults to No. In non-interactive sessions, `--overwrite` is refused unless `--yes` is also passed. As an extra safety guard, any target directory containing `.git/` also requires `--yes` before it can be deleted.
-
-### `add`
-
-Adds a new function to an existing project.
-
-- **Synopsis**: `azure-functions-scaffold add TRIGGER FUNCTION_NAME [OPTIONS]`
-
-#### Arguments
-
-| Argument | Required | Description |
-| :--- | :--- | :--- |
-| `TRIGGER` | Yes | Trigger type (e.g., `http`, `timer`, `queue`). |
-| `FUNCTION_NAME` | Yes | Name of the new function. |
-
-#### Options
-
-| Flag | Default | Values | Description |
-| :--- | :--- | :--- | :--- |
-| `--project-root` | `.` | Path | Path to the root of the existing project. |
-| `--dry-run` | False | Boolean | Show planned changes without writing to disk. |
+- **Synopsis**: `afs new PROJECT_NAME [OPTIONS]`
+- **Arguments**: `PROJECT_NAME` (required) — directory name for the new project. Must be a valid
+  project identifier (letters, numbers, hyphens, or underscores).
+- **Options**: the [Shared Scaffold Options](#shared-scaffold-options) above.
 
 ### `templates`
 
-Lists all available function templates.
+Lists all available scaffold templates.
 
-- **Synopsis**: `azure-functions-scaffold templates`
+- **Synopsis**: `afs templates`
 
 ### `presets`
 
-Lists all available project presets and their included tools.
+Lists all available project presets and their included tooling.
 
-- **Synopsis**: `azure-functions-scaffold presets`
+- **Synopsis**: `afs presets`
 
 ### `--version`
 
-Shows the current version of the CLI tool.
+Shows the installed version of the CLI tool.
 
-- **Synopsis**: `azure-functions-scaffold --version`
+- **Synopsis**: `afs --version`
+
+## `afs api` — REST API Scaffolding
+
+### `api new`
+
+Create a REST API project with OpenAPI, validation, and doctor enabled.
+
+- **Synopsis**: `afs api new PROJECT_NAME [OPTIONS]`
+- **Options**: the [Shared Scaffold Options](#shared-scaffold-options).
+
+### `api add`
+
+Add an HTTP function to an existing API project.
+
+- **Synopsis**: `afs api add FUNCTION_NAME [OPTIONS]`
+- **Options**: `--project-root` (default `.`), `--dry-run`.
+
+### `api add-route`
+
+Add a single HTTP route to an existing API project.
+
+- **Synopsis**: `afs api add-route ROUTE_NAME [OPTIONS]`
+- **Options**: `--project-root` (default `.`), `--dry-run`.
+
+### `api add-resource`
+
+Add a full CRUD resource (blueprint, service, schema, and test) to an existing API project.
+
+- **Synopsis**: `afs api add-resource RESOURCE_NAME [OPTIONS]`
+- **Options**: `--project-root` (default `.`), `--dry-run`.
+
+## `afs worker` — Background Worker Scaffolding
+
+Each subcommand creates a worker project for the named trigger and accepts the
+[Shared Scaffold Options](#shared-scaffold-options).
+
+| Command | Trigger |
+| :--- | :--- |
+| `afs worker timer PROJECT_NAME` | Timer trigger |
+| `afs worker queue PROJECT_NAME` | Queue trigger |
+| `afs worker blob PROJECT_NAME` | Blob trigger |
+| `afs worker servicebus PROJECT_NAME` | Service Bus trigger |
+| `afs worker eventhub PROJECT_NAME` | Event Hub trigger |
+
+## `afs ai` — AI Agent Scaffolding
+
+### `ai agent`
+
+Create a LangGraph agent project.
+
+- **Synopsis**: `afs ai agent PROJECT_NAME [OPTIONS]`
+- **Options**: the [Shared Scaffold Options](#shared-scaffold-options).
+
+## `afs advanced` — Power-User Scaffolding
+
+### `advanced new`
+
+Create a new project with full option control, including template and preset selection.
+
+- **Synopsis**: `afs advanced new PROJECT_NAME [OPTIONS]`
+
+| Flag | Default | Values | Description |
+| :--- | :--- | :--- | :--- |
+| `--destination`, `-d` | `.` | Path | Base directory for the project. |
+| `--template`, `-t` | `http` | `http`, `timer`, `queue`, `blob`, `servicebus`, `eventhub`, `cosmosdb`, `durable`, `ai`, `langgraph` | Template to render. |
+| `--preset` | `standard` | `minimal`, `standard`, `strict` | Project preset (tooling configuration). |
+| `--python-version` | `3.10` | `3.10`–`3.14 (Preview)` | Target Python version. |
+| `--github-actions` / `--no-github-actions` | `--no-github-actions` | Boolean | Include a GitHub Actions CI workflow. |
+| `--git` / `--no-git` | `--no-git` | Boolean | Initialize a git repository. |
+| `--with-openapi` / `--no-openapi` | `--no-openapi` | Boolean | Include OpenAPI support (HTTP template only). |
+| `--with-validation` / `--no-validation` | `--no-validation` | Boolean | Include request validation (HTTP template only). |
+| `--with-doctor` / `--no-doctor` | `--no-doctor` | Boolean | Include `azure-functions-doctor` health checks. |
+| `--azd` / `--no-azd` | `--no-azd` | Boolean | Include Azure Developer CLI (`azd`) support files. |
+| `--dry-run` | `False` | Boolean | Preview without writing files. |
+| `--overwrite` | `False` | Boolean | Replace an existing target directory. |
+| `--yes`, `-y` | `False` | Boolean | Skip confirmation prompts. |
+
+Feature flags are validated against the chosen template *before* any files are written. For
+example, `--with-openapi` against the `langgraph` template errors out cleanly. See the
+[template spec](template-spec.md) for the allowed feature set per template.
+
+### `advanced add`
+
+Add a function module of any trigger type to an existing project.
+
+- **Synopsis**: `afs advanced add TRIGGER FUNCTION_NAME [OPTIONS]`
+- **Arguments**: `TRIGGER` (one of the addable triggers), `FUNCTION_NAME`.
+- **Options**: `--project-root` (default `.`), `--dry-run`.
+
+### `advanced add-route` / `advanced add-resource`
+
+Route and resource variants mirroring `afs api add-route` / `afs api add-resource`.
+
+- **Synopsis**: `afs advanced add-route ROUTE_NAME [OPTIONS]` /
+  `afs advanced add-resource RESOURCE_NAME [OPTIONS]`
+- **Options**: `--project-root` (default `.`), `--dry-run`.
+
+### `advanced templates` / `advanced presets`
+
+List available templates/presets. Equivalent to the top-level `afs templates` / `afs presets`.
+
+## Deprecated Commands
+
+These commands still work but print a one-time stderr deprecation warning and will be removed in a
+future major release. See the [0.6.0 migration guide](../migration/0.6.0.md#7-cli-ergonomic-changes).
+
+| Deprecated | Replacement |
+| :--- | :--- |
+| `afs add TRIGGER FUNCTION_NAME` | `afs api add` (http) or `afs advanced add <trigger>` |
+| `afs profiles` | `afs presets` |
 
 ## Exit Codes
 
@@ -87,6 +215,7 @@ The CLI returns exit code `1` under the following conditions:
 - **Directory Conflict**: Destination directory is not empty and `--overwrite` is not set.
 - **Invalid Template**: Specified trigger template does not exist in the registry.
 - **Invalid Preset**: Specified preset name is not recognized.
+- **Unsupported Feature Flag**: A `--with-*` / `--azd` flag is not allowed for the chosen template.
 - **Python Version Mismatch**: Host Python version is lower than required by the tool.
-- **Missing Project Root**: `add` command executed outside a valid scaffolded project.
-- **Validation Failure**: Project name contains illegal characters for Azure resources.
+- **Missing Project Root**: an `add` command executed outside a valid scaffolded project.
+- **Validation Failure**: Project/function name contains illegal characters or is a Python keyword.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -215,7 +215,7 @@ The CLI returns exit code `1` under the following conditions:
 - **Directory Conflict**: Destination directory is not empty and `--overwrite` is not set.
 - **Invalid Template**: Specified trigger template does not exist in the registry.
 - **Invalid Preset**: Specified preset name is not recognized.
-- **Unsupported Feature Flag**: A `--with-*` / `--azd` flag is not allowed for the chosen template.
+- **Unsupported Feature Flag**: A `--with-*` flag (OpenAPI/validation/doctor) is not allowed for the chosen template. (`--azd` is allowed for every template.)
 - **Python Version Mismatch**: Host Python version is lower than required by the tool.
 - **Missing Project Root**: an `add` command executed outside a valid scaffolded project.
 - **Validation Failure**: Project/function name contains illegal characters or is a Python keyword.

--- a/docs_hooks/changelog.py
+++ b/docs_hooks/changelog.py
@@ -1,0 +1,33 @@
+"""MkDocs hook: render the changelog page from the canonical root ``CHANGELOG.md``.
+
+The docs site historically shipped a hand-maintained ``docs/changelog.md`` that drifted
+behind the canonical ``CHANGELOG.md`` (git-cliff generated) at the repository root. This hook
+overrides the source of the ``changelog.md`` page at build time so the published changelog is
+always the canonical one, eliminating the drift by construction.
+
+Registered via the ``hooks:`` key in ``mkdocs.yml``; requires no extra dependency.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+# The nav slug (relative to ``docs/``) whose content is replaced with canonical CHANGELOG.md.
+_CHANGELOG_PAGE = "changelog.md"
+
+
+def on_page_read_source(page: Any, config: Any, **_kwargs: Any) -> str | None:
+    """Return canonical changelog text for the changelog page, else defer to disk.
+
+    MkDocs calls this for every page; returning ``None`` lets MkDocs read the on-disk
+    source as usual. For the changelog page we return the root ``CHANGELOG.md`` content.
+    """
+    if page.file.src_uri != _CHANGELOG_PAGE:
+        return None
+
+    repo_root = Path(config["docs_dir"]).resolve().parent
+    canonical = repo_root / "CHANGELOG.md"
+    if not canonical.is_file():
+        return None
+    return canonical.read_text(encoding="utf-8")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -78,6 +78,9 @@ plugins:
             show_root_full_path: false
             merge_init_into_class: true
 
+hooks:
+  - docs_hooks/changelog.py
+
 extra:
   social:
     - icon: fontawesome/brands/github

--- a/tests/test_docs_cli_examples.py
+++ b/tests/test_docs_cli_examples.py
@@ -140,3 +140,77 @@ class TestTopLevelAfsNewRegex:
             "azure-functions-scaffold new my-api"
         ) is None
 
+
+CLI_REFERENCE = DOCS_ROOT / "reference" / "cli.md"
+
+
+def _cli_reference_text() -> str:
+    return CLI_REFERENCE.read_text(encoding="utf-8")
+
+
+def _iter_command_paths() -> list[str]:
+    """Return every implemented command path from the live Typer app tree.
+
+    Walks the top-level app plus every registered sub-group so the set reflects
+    the real command surface (``api new``, ``worker timer``, ``advanced add`` ...).
+    Deprecated shims are excluded — they are documented separately.
+    """
+    from azure_functions_scaffold.cli import app
+
+    paths: list[str] = []
+
+    def _walk(typer_app: object, prefix: str) -> None:
+        for command in getattr(typer_app, "registered_commands", []):
+            if getattr(command, "deprecated", False):
+                continue
+            name = command.name or command.callback.__name__.replace("_", "-")
+            paths.append(f"{prefix}{name}".strip())
+        for group in getattr(typer_app, "registered_groups", []):
+            _walk(group.typer_instance, f"{prefix}{group.name} ")
+
+    _walk(app, "")
+    return sorted(set(paths))
+
+
+# Flags that the CLI reference must document (implemented across the command groups).
+REQUIRED_FLAGS: frozenset[str] = frozenset(
+    {
+        "--destination",
+        "--python-version",
+        "--github-actions",
+        "--git",
+        "--azd",
+        "--dry-run",
+        "--overwrite",
+        "--yes",
+        "--template",
+        "--preset",
+        "--with-openapi",
+        "--with-validation",
+        "--with-doctor",
+        "--project-root",
+        "--version",
+    }
+)
+
+
+class TestCliReferenceCoverage:
+    """Guard: ``docs/reference/cli.md`` must cover the implemented command surface."""
+
+    @pytest.mark.parametrize("command_path", _iter_command_paths())
+    def test_every_command_group_is_documented(self, command_path: str) -> None:
+        """Each non-deprecated command (e.g. ``api new``) must appear in the reference."""
+        text = _cli_reference_text()
+        assert command_path in text, (
+            f"docs/reference/cli.md does not document the `afs {command_path}` command. "
+            "Update the CLI reference when the command surface changes."
+        )
+
+    @pytest.mark.parametrize("flag", sorted(REQUIRED_FLAGS))
+    def test_every_implemented_flag_is_documented(self, flag: str) -> None:
+        """Each implemented CLI flag must be documented in the reference."""
+        text = _cli_reference_text()
+        assert flag in text, (
+            f"docs/reference/cli.md does not document the `{flag}` flag. "
+            "Update the CLI reference when flags change."
+        )

--- a/tests/test_docs_cli_examples.py
+++ b/tests/test_docs_cli_examples.py
@@ -172,27 +172,63 @@ def _iter_command_paths() -> list[str]:
     return sorted(set(paths))
 
 
-# Flags that the CLI reference must document (implemented across the command groups).
-REQUIRED_FLAGS: frozenset[str] = frozenset(
+# Completion/help machinery that Typer/Click injects automatically. These are not
+# part of the scaffold's documented CLI surface, so exclude them from the guard.
+_IGNORED_FLAGS: frozenset[str] = frozenset(
     {
-        "--destination",
-        "--python-version",
-        "--github-actions",
-        "--git",
-        "--azd",
-        "--dry-run",
-        "--overwrite",
-        "--yes",
-        "--template",
-        "--preset",
-        "--with-openapi",
-        "--with-validation",
-        "--with-doctor",
-        "--project-root",
-        "--version",
+        "--help",
+        "--install-completion",
+        "--show-completion",
     }
 )
 
+
+def _iter_command_flags() -> list[str]:
+    """Return every long option flag from the live Typer/Click command tree.
+
+    Derives the flag set directly from the command surface so newly added
+    options are caught automatically, rather than a hand-curated list.
+
+    Uses duck-typing rather than ``isinstance`` checks: Typer vendors its own
+    click fork (``typer._click``), so its commands/params are not instances of
+    the public ``click.Group`` / ``click.Option`` classes.
+    """
+    import typer.main
+
+    from azure_functions_scaffold.cli import app
+
+    root = typer.main.get_command(app)
+    flags: set[str] = set()
+    seen: set[int] = set()
+
+    def _walk(command: object) -> None:
+        if id(command) in seen:
+            return
+        seen.add(id(command))
+        for param in getattr(command, "params", []):
+            for opt in list(getattr(param, "opts", [])) + list(
+                getattr(param, "secondary_opts", [])
+            ):
+                if isinstance(opt, str) and opt.startswith("--"):
+                    flags.add(opt)
+        list_commands = getattr(command, "list_commands", None)
+        get_command = getattr(command, "get_command", None)
+        if callable(list_commands) and callable(get_command):
+            import click
+
+            ctx = click.Context(command)  # type: ignore[arg-type]
+            for name in list_commands(ctx):
+                sub = get_command(ctx, name)
+                if sub is not None:
+                    _walk(sub)
+
+    _walk(root)
+    return sorted(flags - _IGNORED_FLAGS)
+
+
+# Every long option flag implemented across the command groups, derived from the
+# live Click command tree so newly-added flags are caught automatically.
+IMPLEMENTED_FLAGS: list[str] = _iter_command_flags()
 
 class TestCliReferenceCoverage:
     """Guard: ``docs/reference/cli.md`` must cover the implemented command surface."""
@@ -206,9 +242,14 @@ class TestCliReferenceCoverage:
             "Update the CLI reference when the command surface changes."
         )
 
-    @pytest.mark.parametrize("flag", sorted(REQUIRED_FLAGS))
+    @pytest.mark.parametrize("flag", IMPLEMENTED_FLAGS)
     def test_every_implemented_flag_is_documented(self, flag: str) -> None:
-        """Each implemented CLI flag must be documented in the reference."""
+        """Every long option flag on the live command tree must be documented.
+
+        The flag set is derived from the Typer/Click command tree (see
+        ``_iter_command_flags``), so newly-added options — including ``--no-*``
+        negations — are caught automatically without updating a curated list.
+        """
         text = _cli_reference_text()
         assert flag in text, (
             f"docs/reference/cli.md does not document the `{flag}` flag. "


### PR DESCRIPTION
## Summary

Aligns the docs with the implemented CLI and removes the sharpest command-doc drift for the
scaffolding CLI. Addresses most of the #156 acceptance checklist.

- **CLI reference rewrite (`docs/reference/cli.md`)** — top-level `new` is now documented as a
  shortcut for `afs api new` (HTTP only; no `--template`/`--preset`/`--with-*`), with accurate
  group-level sections for `api`, `worker`, `ai`, and `advanced` and flags exactly as implemented
  (incl. `--azd` and the `advanced new` `--with-openapi/--with-validation/--with-doctor` flags).
  Adds a command-overview table and a Mermaid command-flow diagram.
- **Changelog drift fixed** — a native mkdocs `hooks:` file (`docs_hooks/changelog.py`) renders the
  changelog page from the canonical root `CHANGELOG.md`, so `docs/changelog.md` can no longer lag
  behind (it was stuck at v0.3.1 vs canonical v0.6.1). No new dependency.
- **Migration guide** — relabeled from "Draft/planned" to "Released" with reader guidance; fixed the
  `afs --version` verification item.
- **Drift prevention** — `tests/test_docs_cli_examples.py` now introspects the live Typer app tree
  and asserts every non-deprecated command and implemented flag is documented in the CLI reference.
- **i18n propagation** — added a Documentation & i18n sync checklist to the contributing guidelines.

## Deferred

- **Generated-output examples** (per-template project trees + `function_app.py`/`host.json`
  snippets) is additive/larger and is tracked as a follow-up in #159.

## Verification

- `hatch run pytest` — 97.48% coverage (gate 95%), all tests pass.
- `hatch run ruff check` — clean. `hatch run mypy src` — clean.
- `hatch run mkdocs build --strict` — changelog hook + CLI reference render cleanly; the 3
  remaining strict warnings are pre-existing (`release_process.md`, `getting-started.md` links,
  unrelated to this PR).

Part of #156
