### PR TITLE
docs(diagram): portable classDiagram notation and i18n README flowchart parity

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -46,6 +46,21 @@ Python バージョンサポート: Azure Functions では 3.10-3.13 は GA、3.
 
 新しい Azure Functions プロジェクトを始めるには、ボイラープレートの設定が必要です: `host.json`、`function_app.py`、ディレクトリ構造、ツール設定、テスト。`azure-functions-scaffold` は一つのコマンドでプロダクションレベルのプロジェクトレイアウトを生成し、最初からビジネスロジックに集中できるようにします。
 
+```mermaid
+flowchart LR
+    Dev(["開発者"])
+    CLI["afs new my-api"]
+    T["テンプレート"]
+    P["生成されたプロジェクト"]
+    VAL["azure-functions-validation"]
+
+    Dev --> CLI
+    CLI --> T
+    T --> P
+    CLI --> VAL
+    VAL --> P
+```
+
 ## スコープ
 
 - Azure Functions Python **v2 プログラミングモデル**

--- a/README.ko.md
+++ b/README.ko.md
@@ -46,6 +46,21 @@ Python 버전 지원: Azure Functions에서 3.10-3.13은 GA이며, 3.14는 **Pre
 
 새로운 Azure Functions 프로젝트를 시작하려면 보일러플레이트 설정이 필요합니다: `host.json`, `function_app.py`, 디렉터리 구조, 도구 설정, 테스트. `azure-functions-scaffold`는 한 번의 명령으로 프로덕션 수준의 프로젝트 레이아웃을 생성하여, 처음부터 비즈니스 로직에 집중할 수 있게 합니다.
 
+```mermaid
+flowchart LR
+    Dev(["개발자"])
+    CLI["afs new my-api"]
+    T["템플릿"]
+    P["생성된 프로젝트"]
+    VAL["azure-functions-validation"]
+
+    Dev --> CLI
+    CLI --> T
+    T --> P
+    CLI --> VAL
+    VAL --> P
+```
+
 ## 범위
 
 - Azure Functions Python **v2 프로그래밍 모델**

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -46,6 +46,21 @@ Python 版本支持: Azure Functions 上 3.10-3.13 为 GA，3.14 为 **Preview**
 
 启动新的 Azure Functions 项目意味着设置样板文件：`host.json`、`function_app.py`、目录结构、工具配置和测试。`azure-functions-scaffold` 通过一个命令生成生产级项目布局，让你从一开始就专注于业务逻辑。
 
+```mermaid
+flowchart LR
+    Dev(["开发者"])
+    CLI["afs new my-api"]
+    T["模板"]
+    P["生成的项目"]
+    VAL["azure-functions-validation"]
+
+    Dev --> CLI
+    CLI --> T
+    T --> P
+    CLI --> VAL
+    VAL --> P
+```
+
 ## 范围
 
 - Azure Functions Python **v2 编程模型**

--- a/docs/reference/architecture.md
+++ b/docs/reference/architecture.md
@@ -163,7 +163,7 @@ classDiagram
     class ProjectOptions {
         +str preset_name
         +str python_version
-        +tuple~str~ tooling
+        +tuple[str] tooling
         +bool include_github_actions
         +bool initialize_git
         +bool include_openapi
@@ -193,7 +193,7 @@ classDiagram
     class PresetSpec {
         +str name
         +str description
-        +tuple~str~ tooling
+        +tuple[str] tooling
     }
     class ScaffoldError {
     }


### PR DESCRIPTION
## Summary

Diagram-review fixes for the scaffold docs (issue #157).

- **Portable classDiagram notation** — `docs/reference/architecture.md` used Mermaid tilde-generics
  (`tuple~str~ tooling`) in both `ProjectOptions` class diagrams, which render inconsistently across
  Mermaid versions. Replaced with portable `tuple[str]`.
- **i18n README flowchart parity** — the high-level `flowchart LR` in `README.md` was missing from
  the localized READMEs. Mirrored it into `README.ko.md`, `README.ja.md`, and `README.zh-CN.md`
  with localized node labels.

## Note on checklist item 3

The third checklist item (a command-flow diagram for the CLI reference) was delivered as part of
the CLI-reference rewrite in #160, which adds a compact
`Developer → afs (cli) → run_intent/build_project_options → scaffold_project → render → filesystem`
Mermaid diagram to `docs/reference/cli.md`. Kept out of this PR to avoid a conflict on that file.

## Verification

- `hatch run pytest` — 442 passed, 5 skipped (incl. the README-triggers parity test).
- `hatch run mkdocs build --strict` — diagrams render; only the 3 pre-existing, unrelated link
  warnings remain (no new warnings introduced).

Part of #157
