### PR TITLE
test: correct Codecov version comment and bound generated-project smoke tests

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.python-version == '3.10' && github.actor != 'dependabot[bot]'
-        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.xml

--- a/tests/test_template_smoke.py
+++ b/tests/test_template_smoke.py
@@ -164,6 +164,13 @@ def test_scaffolded_pyproject_sdist_includes_do_not_use_leading_slashes(
 _SMOKE_SUBPROCESS_TIMEOUT_SECONDS = 300
 
 
+def _as_text(value: str | bytes | None) -> str:
+    """Normalize captured subprocess output to text for failure messages."""
+    if isinstance(value, bytes):
+        return value.decode("utf-8", "replace")
+    return value or ""
+
+
 def _run_generated_project_tests(project_root: Path) -> subprocess.CompletedProcess[str]:
     """Run a scaffolded project's own pytest suite in a bounded subprocess."""
     try:
@@ -182,12 +189,8 @@ def _run_generated_project_tests(project_root: Path) -> subprocess.CompletedProc
             },
         )
     except subprocess.TimeoutExpired as exc:  # pragma: no cover - safety bound
-        stdout = exc.stdout
-        stderr = exc.stderr
-        if isinstance(stdout, bytes):
-            stdout = stdout.decode("utf-8", "replace")
-        if isinstance(stderr, bytes):
-            stderr = stderr.decode("utf-8", "replace")
+        stdout = _as_text(exc.stdout)
+        stderr = _as_text(exc.stderr)
         pytest.fail(
             f"Generated project tests exceeded "
             f"{_SMOKE_SUBPROCESS_TIMEOUT_SECONDS}s and were terminated: {exc}\n"

--- a/tests/test_template_smoke.py
+++ b/tests/test_template_smoke.py
@@ -158,6 +158,36 @@ def test_scaffolded_pyproject_sdist_includes_do_not_use_leading_slashes(
     assert all(not path.startswith("/") for path in sdist_includes)
 
 
+# Upper bound (seconds) for a generated project's own test run. Keeps the smoke
+# tests deterministic: a hung subprocess fails fast instead of stalling CI on
+# every Python version in the matrix.
+_SMOKE_SUBPROCESS_TIMEOUT_SECONDS = 300
+
+
+def _run_generated_project_tests(project_root: Path) -> subprocess.CompletedProcess[str]:
+    """Run a scaffolded project's own pytest suite in a bounded subprocess."""
+    try:
+        return subprocess.run(
+            [sys.executable, "-m", "pytest", "-x", "-q", str(project_root / "tests")],
+            cwd=str(project_root),
+            capture_output=True,
+            text=True,
+            timeout=_SMOKE_SUBPROCESS_TIMEOUT_SECONDS,
+            env={
+                **os.environ,
+                "WEBHOOK_SECRET": "test-secret-key",
+                "PYTHONPATH": os.pathsep.join(
+                    filter(None, [str(project_root), os.environ.get("PYTHONPATH", "")])
+                ),
+            },
+        )
+    except subprocess.TimeoutExpired as exc:  # pragma: no cover - safety bound
+        pytest.fail(
+            f"Generated project tests exceeded "
+            f"{_SMOKE_SUBPROCESS_TIMEOUT_SECONDS}s and were terminated: {exc}"
+        )
+
+
 @pytest.mark.slow
 def test_rendered_strict_http_project_tests_pass(tmp_path: Path) -> None:
     """Scaffold a strict HTTP project and run its generated tests."""
@@ -177,21 +207,7 @@ def test_rendered_strict_http_project_tests_pass(tmp_path: Path) -> None:
         options=options,
     )
 
-    # Run the generated project's own tests using the current interpreter.
-    # All runtime deps (azure-functions, pydantic, etc.) are already installed.
-    result = subprocess.run(
-        [sys.executable, "-m", "pytest", "-x", "-q", str(project_root / "tests")],
-        cwd=str(project_root),
-        capture_output=True,
-        text=True,
-        env={
-            **os.environ,
-            "WEBHOOK_SECRET": "test-secret-key",
-            "PYTHONPATH": os.pathsep.join(
-                filter(None, [str(project_root), os.environ.get("PYTHONPATH", "")])
-            ),
-        },
-    )
+    result = _run_generated_project_tests(project_root)
     assert result.returncode == 0, (
         f"Generated project tests failed (rc={result.returncode}):\n"
         f"stdout:\n{result.stdout}\n"
@@ -218,19 +234,7 @@ def test_rendered_standard_http_project_tests_pass(tmp_path: Path) -> None:
         options=options,
     )
 
-    result = subprocess.run(
-        [sys.executable, "-m", "pytest", "-x", "-q", str(project_root / "tests")],
-        cwd=str(project_root),
-        capture_output=True,
-        text=True,
-        env={
-            **os.environ,
-            "WEBHOOK_SECRET": "test-secret-key",
-            "PYTHONPATH": os.pathsep.join(
-                filter(None, [str(project_root), os.environ.get("PYTHONPATH", "")])
-            ),
-        },
-    )
+    result = _run_generated_project_tests(project_root)
     assert result.returncode == 0, (
         f"Generated project tests failed (rc={result.returncode}):\n"
         f"stdout:\n{result.stdout}\n"

--- a/tests/test_template_smoke.py
+++ b/tests/test_template_smoke.py
@@ -182,9 +182,17 @@ def _run_generated_project_tests(project_root: Path) -> subprocess.CompletedProc
             },
         )
     except subprocess.TimeoutExpired as exc:  # pragma: no cover - safety bound
+        stdout = exc.stdout
+        stderr = exc.stderr
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode("utf-8", "replace")
+        if isinstance(stderr, bytes):
+            stderr = stderr.decode("utf-8", "replace")
         pytest.fail(
             f"Generated project tests exceeded "
-            f"{_SMOKE_SUBPROCESS_TIMEOUT_SECONDS}s and were terminated: {exc}"
+            f"{_SMOKE_SUBPROCESS_TIMEOUT_SECONDS}s and were terminated: {exc}\n"
+            f"--- captured stdout ---\n{stdout or '<empty>'}\n"
+            f"--- captured stderr ---\n{stderr or '<empty>'}"
         )
 
 


### PR DESCRIPTION
## Summary

Test-suite hardening for the scaffold repo (issue #158).

- **Codecov version comment fixed** — `.github/workflows/ci-test.yml` pinned
  `codecov/codecov-action@fb8b3582…` with a trailing `# v7.0.0` comment, but that SHA is the **v5**
  release (7 sibling repos comment it `# v5`). Corrected the comment to match the pinned SHA.
- **Generated-project smoke tests bounded** — the two `@pytest.mark.slow` tests in
  `tests/test_template_smoke.py` spawn a subprocess to run a scaffolded project's own pytest suite.
  They now run through a shared `_run_generated_project_tests` helper with a **300s timeout**, so a
  hung subprocess fails fast and deterministically instead of stalling `make check-all` on every
  Python version in the matrix. The helper also de-duplicates the subprocess/env setup.

## Verification

- `hatch run pytest` — 442 passed, 5 skipped; coverage 97.48% (gate 95%).
- `hatch run ruff check` and `hatch run mypy tests/test_template_smoke.py` — clean.

Closes #158
