### PR TITLE
docs: add discoverability metadata (pepy badge + llms.txt)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -1,6 +1,7 @@
 # Azure Functions Scaffold
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-scaffold.svg)](https://pypi.org/project/azure-functions-scaffold/)
+[![Downloads](https://static.pepy.tech/badge/azure-functions-scaffold/month)](https://pepy.tech/project/azure-functions-scaffold)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-scaffold/)
 [![CI](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/release.yml/badge.svg)](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/release.yml)

--- a/README.ko.md
+++ b/README.ko.md
@@ -1,6 +1,7 @@
 # Azure Functions Scaffold
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-scaffold.svg)](https://pypi.org/project/azure-functions-scaffold/)
+[![Downloads](https://static.pepy.tech/badge/azure-functions-scaffold/month)](https://pepy.tech/project/azure-functions-scaffold)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-scaffold/)
 [![CI](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/release.yml/badge.svg)](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/release.yml)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-scaffold.svg)](https://pypi.org/project/azure-functions-scaffold/)
+[![Downloads](https://static.pepy.tech/badge/azure-functions-scaffold/month)](https://pepy.tech/project/azure-functions-scaffold)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-scaffold/)
 [![CI](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/release.yml/badge.svg)](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/release.yml)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,7 @@
 # Azure Functions Scaffold
 
 [![PyPI](https://img.shields.io/pypi/v/azure-functions-scaffold.svg)](https://pypi.org/project/azure-functions-scaffold/)
+[![Downloads](https://static.pepy.tech/badge/azure-functions-scaffold/month)](https://pepy.tech/project/azure-functions-scaffold)
 [![Python Version](https://img.shields.io/badge/python-3.10%20%7C%203.11%20%7C%203.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/azure-functions-scaffold/)
 [![CI](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/ci-test.yml/badge.svg)](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/ci-test.yml)
 [![Release](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/release.yml/badge.svg)](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/release.yml)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,0 +1,26 @@
+# Azure Functions Scaffold
+
+> Scaffolding CLI for Azure Functions Python v2 projects.
+
+Part of the **Azure Functions Python DX Toolkit**. Generate production-ready Azure Functions Python v2 projects from templates and presets — wiring up structure, tooling, and recommended stacks so you start from a working baseline. Install from PyPI with `pip install azure-functions-scaffold`.
+
+## Getting Started
+- [Introduction](https://yeongseon.github.io/azure-functions-scaffold-python/guide/): Overview.
+- [Getting Started](https://yeongseon.github.io/azure-functions-scaffold-python/guide/getting-started/): Create your first project.
+- [Configuration](https://yeongseon.github.io/azure-functions-scaffold-python/guide/configuration/): Configure generation.
+
+## User Guide
+- [Templates](https://yeongseon.github.io/azure-functions-scaffold-python/guide/templates/): Available templates.
+- [Features & Presets](https://yeongseon.github.io/azure-functions-scaffold-python/guide/features/): Opt-in features.
+- [Recommended Stacks](https://yeongseon.github.io/azure-functions-scaffold-python/guide/stacks/): Curated stacks.
+- [Project Structure](https://yeongseon.github.io/azure-functions-scaffold-python/guide/project-structure/): What gets generated.
+
+## Reference
+- [CLI Reference](https://yeongseon.github.io/azure-functions-scaffold-python/reference/cli/): Command reference.
+- [Template Specification](https://yeongseon.github.io/azure-functions-scaffold-python/reference/template-spec/): Template spec.
+- [Architecture](https://yeongseon.github.io/azure-functions-scaffold-python/reference/architecture/): How the generator works.
+- [API Reference](https://yeongseon.github.io/azure-functions-scaffold-python/reference/api/): Public API surface.
+
+## Optional
+- [Troubleshooting](https://yeongseon.github.io/azure-functions-scaffold-python/guide/troubleshooting/): Common issues and fixes.
+- [Changelog](https://yeongseon.github.io/azure-functions-scaffold-python/changelog/): Release history.


### PR DESCRIPTION
## Summary

Discoverability improvements (no code changes):

- **pepy monthly-downloads badge** added to `README.md`, `README.ko.md`, `README.ja.md`, `README.zh-CN.md`.
- **`docs/llms.txt`** added — an llmstxt.org-style summary served at the gh-pages site root (`/llms.txt`) with curated links to key docs.

## Verification
- `mkdocs build` succeeds; `llms.txt` present at site root.
- Note: `mkdocs build --strict` has 3 **pre-existing** broken-link warnings on `main` (`release_process.md`, `guide/getting-started.md`) unrelated to this change; this PR adds no new internal links.

Closes #165
