### PR TITLE
refactor(scaffold): fix cosmosdb template at source, drop normalize patch

### DIFF
--- a/src/azure_functions_scaffold/generator.py
+++ b/src/azure_functions_scaffold/generator.py
@@ -633,11 +633,11 @@ import azure.functions as func
 
 @{function_name}_blueprint.cosmos_db_trigger_v3(
     arg_name="documents",
-    container_name="my-container",
+    collection_name="my-container",
     database_name="my-database",
-    connection="CosmosDBConnection",
-    lease_container_name="leases",
-    create_lease_container_if_not_exists=True,
+    connection_string_setting="CosmosDBConnection",
+    lease_collection_name="leases",
+    create_lease_collection_if_not_exists=True,
 )
 def {function_name}(documents: func.DocumentList) -> None:
     logging.info("CosmosDB trigger '{function_name}' processed %s document(s).", len(documents))

--- a/src/azure_functions_scaffold/scaffolder.py
+++ b/src/azure_functions_scaffold/scaffolder.py
@@ -89,11 +89,6 @@ def scaffold_project(
             include_doctor=context.include_doctor,
             include_azd=context.include_azd,
         )
-        rendered_content = _normalize_rendered_content(
-            template_name=template.name,
-            rendered_path=rendered_path,
-            rendered_content=rendered_content,
-        )
         logger.debug("Rendering template: %s -> %s", template_rel_name, output_path)
         output_path.write_text(rendered_content, encoding="utf-8")
 
@@ -251,45 +246,6 @@ def _render_path(relative_path: Path, context: TemplateContext) -> Path:
             rendered = rendered[:-3]
         rendered_parts.append(rendered)
     return Path(*rendered_parts)
-
-
-def _normalize_rendered_content(
-    *, template_name: str, rendered_path: Path, rendered_content: str
-) -> str:
-    normalized_path = rendered_path.as_posix()
-
-    if template_name == "cosmosdb" and normalized_path == "app/functions/cosmosdb.py":
-        return (
-            rendered_content.replace(
-                'container_name="my-container"', 'collection_name="my-container"'
-            )
-            .replace(
-                'connection="CosmosDBConnection"', 'connection_string_setting="CosmosDBConnection"'
-            )
-            .replace('lease_container_name="leases"', 'lease_collection_name="leases"')
-            .replace(
-                "create_lease_container_if_not_exists=True",
-                "create_lease_collection_if_not_exists=True",
-            )
-        )
-
-    if template_name == "durable" and normalized_path == "app/functions/durable.py":
-        return (
-            rendered_content.replace(
-                'results.append(yield context.call_activity("say_hello", "Tokyo"))',
-                'results.append((yield context.call_activity("say_hello", "Tokyo")))',
-            )
-            .replace(
-                'results.append(yield context.call_activity("say_hello", "Seattle"))',
-                'results.append((yield context.call_activity("say_hello", "Seattle")))',
-            )
-            .replace(
-                'results.append(yield context.call_activity("say_hello", "London"))',
-                'results.append((yield context.call_activity("say_hello", "London")))',
-            )
-        )
-
-    return rendered_content
 
 
 def _slugify(value: str) -> str:

--- a/src/azure_functions_scaffold/templates/cosmosdb/app/functions/cosmosdb.py.j2
+++ b/src/azure_functions_scaffold/templates/cosmosdb/app/functions/cosmosdb.py.j2
@@ -11,11 +11,11 @@ cosmosdb_blueprint = func.Blueprint()  # type: ignore[no-untyped-call]
 
 @cosmosdb_blueprint.cosmos_db_trigger_v3(
     arg_name="documents",
-    container_name="my-container",
+    collection_name="my-container",
     database_name="my-database",
-    connection="CosmosDBConnection",
-    lease_container_name="leases",
-    create_lease_container_if_not_exists=True,
+    connection_string_setting="CosmosDBConnection",
+    lease_collection_name="leases",
+    create_lease_collection_if_not_exists=True,
 )
 def process_cosmos_changes(documents: func.DocumentList) -> None:
     count = describe_documents(documents)

--- a/tests/test_generator.py
+++ b/tests/test_generator.py
@@ -562,6 +562,27 @@ app.register_functions(my_blueprint)"""
     assert "app = FunctionApp()\nnew_line_here" in result
 
 
+def test_render_cosmosdb_module_uses_v3_trigger_param_names() -> None:
+    """The generator's cosmosdb path must emit legacy v3 Cosmos DB param names.
+
+    ``cosmos_db_trigger_v3`` requires the legacy ``collection_name`` /
+    ``connection_string_setting`` / ``lease_collection_name`` /
+    ``create_lease_collection_if_not_exists`` names, not the newer
+    ``container_name`` / ``connection`` names used by non-v3 ``cosmos_db_trigger``.
+    """
+    module = _render_function_module(trigger="cosmosdb", function_name="on_change")
+    assert "cosmos_db_trigger_v3(" in module
+    assert "collection_name=" in module
+    assert "connection_string_setting=" in module
+    assert "lease_collection_name=" in module
+    assert "create_lease_collection_if_not_exists=" in module
+    # The v4 (non-v3) parameter names must not appear with the v3 decorator.
+    assert "container_name=" not in module
+    assert "connection=" not in module
+    assert "lease_container_name=" not in module
+    assert "create_lease_container_if_not_exists=" not in module
+
+
 def test_render_function_module_raises_for_unknown_trigger() -> None:
     """Test that _render_function_module raises error for unknown trigger."""
     with pytest.raises(ScaffoldError, match="No function module template for trigger"):

--- a/tests/test_scaffolder.py
+++ b/tests/test_scaffolder.py
@@ -393,6 +393,24 @@ def test_durable_template_uses_correct_durable_module_path(tmp_path: Path) -> No
     assert "Generator[Any, Any, list[str]]" in durable_text
 
 
+def test_cosmosdb_template_uses_v3_trigger_param_names(tmp_path: Path) -> None:
+    project_path = scaffold_project(
+        "cosmosdb-sample",
+        tmp_path,
+        template_name="cosmosdb",
+    )
+
+    cosmosdb_text = (project_path / "app/functions/cosmosdb.py").read_text(encoding="utf-8")
+    # The `cosmos_db_trigger_v3` decorator requires the legacy Cosmos DB param
+    # names (collection_name / connection_string_setting), NOT the newer
+    # container_name / connection names used by the non-v3 `cosmos_db_trigger`.
+    assert 'collection_name="my-container"' in cosmosdb_text
+    assert 'connection_string_setting="CosmosDBConnection"' in cosmosdb_text
+    assert 'lease_collection_name="leases"' in cosmosdb_text
+    assert "create_lease_collection_if_not_exists=True" in cosmosdb_text
+    assert "container_name" not in cosmosdb_text
+
+
 @pytest.mark.parametrize("template_name", ["queue", "blob", "servicebus", "eventhub", "cosmosdb"])
 def test_binding_templates_include_extension_bundle(tmp_path: Path, template_name: str) -> None:
     project_path = scaffold_project(


### PR DESCRIPTION
## Summary
Delivers one self-contained, behavior-preserving item from the #163 tracker: *"Fix the cosmosdb/durable `.j2` templates at source and delete the compensating `_normalize_rendered_content` post-render patch."*

## Root cause
The `templates/cosmosdb/app/functions/cosmosdb.py.j2` template used the **newer `cosmos_db_trigger` (v4) parameter names** (`container_name`, `connection`, `lease_container_name`, `create_lease_container_if_not_exists`) on a **`cosmos_db_trigger_v3` decorator** — which actually requires the **legacy** names (`collection_name`, `connection_string_setting`, `lease_collection_name`, `create_lease_collection_if_not_exists`).

Two rendering paths handled this differently:
- `scaffolder.py` compensated at runtime via a `_normalize_rendered_content` string-rewrite → correct output.
- `generator.py` (the `add-*` path) rendered the raw template → **latent bug**, emitting invalid v3 code.

Verified against the SDK source: [`cosmos_db_trigger_v3`](https://github.com/Azure/azure-functions-python-library/blob/8199f47e836d5d459784f188e7fa2516dbdeb7f4/azure/functions/decorators/function_app.py#L911-L1017) uses the legacy param names; the newer `container_name`/`connection` belong to the non-v3 `cosmos_db_trigger`.

## Changes
- Bake the correct `cosmos_db_trigger_v3` (legacy) param names into the `.j2` template source, so **both** the scaffolder and generator paths now produce valid code.
- Delete `_normalize_rendered_content` and its call site in `scaffolder.py`. Its `durable` branch was already a no-op (the `durable.py.j2` source already used the parenthesized `((yield ...))` form).
- Add `test_cosmosdb_template_uses_v3_trigger_param_names` pinning the exact param names on the scaffold path (previously only a weak `"CosmosDBConnection" in output` substring assertion existed).

## Verification
- Behavior-preserving for the scaffold path (byte-identical to the prior normalized output); fixes the latent bug on the generator path.
- `make lint`, `make typecheck` clean.
- `make test`: 484 passed, coverage **97.47%** (gate 95%). Includes the `test_simple_trigger_templates_pass_generated_checks[cosmosdb-standard]` case that scaffolds a project and runs `make check-all` inside it.

Part of #163
Part of #155