### PR TITLE
refactor(cli): generate worker commands from INTENT_SPECS table (#163)

### DIFF
--- a/src/azure_functions_scaffold/cli_worker.py
+++ b/src/azure_functions_scaffold/cli_worker.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from typing import Callable
 
 import typer
 
@@ -24,136 +25,47 @@ worker_app = typer.Typer(
 )
 
 
-@worker_app.command("timer")
-def worker_timer(
-    project_name: str = typer.Argument(..., help="Directory name for the new project."),
-    destination: DestinationOption = Path("."),
-    python_version: PythonVersionOption = "3.10",
-    include_github_actions: GithubActionsOption = False,
-    initialize_git: GitOption = False,
-    include_azd: AzdOption = False,
-    dry_run: DryRunOption = False,
-    overwrite: OverwriteOption = False,
-    yes: YesOption = False,
-) -> None:
-    """Create a timer-trigger worker project."""
-    run_intent(
-        "worker/timer",
-        project_name,
-        destination=destination,
-        python_version=python_version,
-        include_github_actions=include_github_actions,
-        initialize_git=initialize_git,
-        include_azd=include_azd,
-        dry_run=dry_run,
-        overwrite=overwrite,
-        yes=yes,
-    )
+# (command name, intent id, help text). The worker commands are otherwise
+# identical — same option surface, same ``run_intent`` dispatch — so they are
+# generated from this single spec table instead of hand-duplicated.
+_WORKER_INTENTS: tuple[tuple[str, str, str], ...] = (
+    ("timer", "worker/timer", "Create a timer-trigger worker project."),
+    ("queue", "worker/queue", "Create a queue-trigger worker project."),
+    ("blob", "worker/blob", "Create a blob-trigger worker project."),
+    ("servicebus", "worker/servicebus", "Create a Service Bus-trigger worker project."),
+    ("eventhub", "worker/eventhub", "Create an EventHub-trigger worker project."),
+)
 
 
-@worker_app.command("queue")
-def worker_queue(
-    project_name: str = typer.Argument(..., help="Directory name for the new project."),
-    destination: DestinationOption = Path("."),
-    python_version: PythonVersionOption = "3.10",
-    include_github_actions: GithubActionsOption = False,
-    initialize_git: GitOption = False,
-    include_azd: AzdOption = False,
-    dry_run: DryRunOption = False,
-    overwrite: OverwriteOption = False,
-    yes: YesOption = False,
-) -> None:
-    """Create a queue-trigger worker project."""
-    run_intent(
-        "worker/queue",
-        project_name,
-        destination=destination,
-        python_version=python_version,
-        include_github_actions=include_github_actions,
-        initialize_git=initialize_git,
-        include_azd=include_azd,
-        dry_run=dry_run,
-        overwrite=overwrite,
-        yes=yes,
-    )
+def _make_worker_command(intent: str) -> Callable[..., None]:
+    """Build a Typer command callable that dispatches ``intent`` via ``run_intent``."""
+
+    def command(
+        project_name: str = typer.Argument(..., help="Directory name for the new project."),
+        destination: DestinationOption = Path("."),
+        python_version: PythonVersionOption = "3.10",
+        include_github_actions: GithubActionsOption = False,
+        initialize_git: GitOption = False,
+        include_azd: AzdOption = False,
+        dry_run: DryRunOption = False,
+        overwrite: OverwriteOption = False,
+        yes: YesOption = False,
+    ) -> None:
+        run_intent(
+            intent,
+            project_name,
+            destination=destination,
+            python_version=python_version,
+            include_github_actions=include_github_actions,
+            initialize_git=initialize_git,
+            include_azd=include_azd,
+            dry_run=dry_run,
+            overwrite=overwrite,
+            yes=yes,
+        )
+
+    return command
 
 
-@worker_app.command("blob")
-def worker_blob(
-    project_name: str = typer.Argument(..., help="Directory name for the new project."),
-    destination: DestinationOption = Path("."),
-    python_version: PythonVersionOption = "3.10",
-    include_github_actions: GithubActionsOption = False,
-    initialize_git: GitOption = False,
-    include_azd: AzdOption = False,
-    dry_run: DryRunOption = False,
-    overwrite: OverwriteOption = False,
-    yes: YesOption = False,
-) -> None:
-    """Create a blob-trigger worker project."""
-    run_intent(
-        "worker/blob",
-        project_name,
-        destination=destination,
-        python_version=python_version,
-        include_github_actions=include_github_actions,
-        initialize_git=initialize_git,
-        include_azd=include_azd,
-        dry_run=dry_run,
-        overwrite=overwrite,
-        yes=yes,
-    )
-
-
-@worker_app.command("servicebus")
-def worker_servicebus(
-    project_name: str = typer.Argument(..., help="Directory name for the new project."),
-    destination: DestinationOption = Path("."),
-    python_version: PythonVersionOption = "3.10",
-    include_github_actions: GithubActionsOption = False,
-    initialize_git: GitOption = False,
-    include_azd: AzdOption = False,
-    dry_run: DryRunOption = False,
-    overwrite: OverwriteOption = False,
-    yes: YesOption = False,
-) -> None:
-    """Create a Service Bus-trigger worker project."""
-    run_intent(
-        "worker/servicebus",
-        project_name,
-        destination=destination,
-        python_version=python_version,
-        include_github_actions=include_github_actions,
-        initialize_git=initialize_git,
-        include_azd=include_azd,
-        dry_run=dry_run,
-        overwrite=overwrite,
-        yes=yes,
-    )
-
-
-@worker_app.command("eventhub")
-def worker_eventhub(
-    project_name: str = typer.Argument(..., help="Directory name for the new project."),
-    destination: DestinationOption = Path("."),
-    python_version: PythonVersionOption = "3.10",
-    include_github_actions: GithubActionsOption = False,
-    initialize_git: GitOption = False,
-    include_azd: AzdOption = False,
-    dry_run: DryRunOption = False,
-    overwrite: OverwriteOption = False,
-    yes: YesOption = False,
-) -> None:
-    """Create an EventHub-trigger worker project."""
-    run_intent(
-        "worker/eventhub",
-        project_name,
-        destination=destination,
-        python_version=python_version,
-        include_github_actions=include_github_actions,
-        initialize_git=initialize_git,
-        include_azd=include_azd,
-        dry_run=dry_run,
-        overwrite=overwrite,
-        yes=yes,
-    )
+for _name, _intent, _help in _WORKER_INTENTS:
+    worker_app.command(_name, help=_help)(_make_worker_command(_intent))


### PR DESCRIPTION
## Context
Part of #163, checklist item 4: "Generate the worker CLI commands (and overlapping `add-*` commands) from a single `INTENT_SPECS` loop."

The five `afs worker` commands (`timer`/`queue`/`blob`/`servicebus`/`eventhub`) were byte-for-byte identical apart from their intent id and help string — 159 lines of copy-paste.

## Changes
- Replace the five hand-written command functions with a `_WORKER_INTENTS` spec table + a `_make_worker_command(intent)` factory registered in a loop. `cli_worker.py` drops from 159 → 71 lines.
- CLI surface is unchanged: identical command names, option set, defaults, and per-command help text.

## Scope note
This delivers the **worker** half of item 4. The `add-*` commands carry per-command dry-run/return handling and are left for a separate focused PR, so item 4 stays open.

## Verification
- ruff: clean · mypy: clean (24 files)
- `tests/test_cli_intents.py -k worker` passes; full suite green, coverage 97.88% (≥95%).

Part of #163