### PR TITLE
refactor(cli): dedupe overlapping add-* commands via shared helpers

### DIFF
--- a/src/azure_functions_scaffold/cli_advanced.py
+++ b/src/azure_functions_scaffold/cli_advanced.py
@@ -8,24 +8,19 @@ from typing import Annotated
 import typer
 
 from azure_functions_scaffold.cli_common import (
-    PYTHON_VERSION_HELP,
-    AzdOption,
-    DestinationOption,
-    DryRunOption,
-    OverwriteOption,
+PYTHON_VERSION_HELP,
+AzdOption,
+DestinationOption,
+DryRunOption,
+OverwriteOption,
     YesOption,
-    run_scaffold,
+    run_add_function,
+    run_add_resource,
+    run_add_route,
+run_scaffold,
 )
 from azure_functions_scaffold.errors import ScaffoldError
-from azure_functions_scaffold.generator import (
-    ADDABLE_TRIGGERS,
-    add_function,
-    add_resource,
-    add_route,
-    describe_add_function,
-    describe_add_resource,
-    describe_add_route,
-)
+from azure_functions_scaffold.generator import ADDABLE_TRIGGERS
 from azure_functions_scaffold.template_registry import (
     build_project_options,
     list_presets,
@@ -209,25 +204,12 @@ def advanced_add(
     dry_run: DryRunOption = False,
 ) -> None:
     """Add a function module to an existing project (any trigger type)."""
-    try:
-        if dry_run:
-            for line in describe_add_function(
-                project_root=project_root,
-                trigger=trigger,
-                function_name=function_name,
-            ):
-                typer.echo(line)
-            return
-        function_path = add_function(
-            project_root=project_root,
-            trigger=trigger,
-            function_name=function_name,
-        )
-    except ScaffoldError as exc:
-        typer.secho(str(exc), fg=typer.colors.RED)
-        raise typer.Exit(code=1) from exc
-
-    typer.echo(f"Created function at {function_path}")
+    run_add_function(
+        project_root=project_root,
+        trigger=trigger,
+        function_name=function_name,
+        dry_run=dry_run,
+    )
 
 
 @advanced_app.command("templates")
@@ -262,23 +244,11 @@ def advanced_add_route(
     dry_run: DryRunOption = False,
 ) -> None:
     """Add a simple HTTP route to an existing project."""
-    try:
-        if dry_run:
-            for line in describe_add_route(
-                project_root=project_root,
-                route_name=route_name,
-            ):
-                typer.echo(line)
-            return
-        route_path = add_route(
-            project_root=project_root,
-            route_name=route_name,
-        )
-    except ScaffoldError as exc:
-        typer.secho(str(exc), fg=typer.colors.RED)
-        raise typer.Exit(code=1) from exc
-
-    typer.echo(f"Created route at {route_path}")
+    run_add_route(
+        project_root=project_root,
+        route_name=route_name,
+        dry_run=dry_run,
+    )
 
 
 @advanced_app.command("add-resource")
@@ -298,21 +268,8 @@ def advanced_add_resource(
     dry_run: DryRunOption = False,
 ) -> None:
     """Add a full CRUD resource (blueprint, service, schema, test) to an existing project."""
-    try:
-        if dry_run:
-            for line in describe_add_resource(
-                project_root=project_root,
-                resource_name=resource_name,
-            ):
-                typer.echo(line)
-            return
-        created = add_resource(
-            project_root=project_root,
-            resource_name=resource_name,
-        )
-    except ScaffoldError as exc:
-        typer.secho(str(exc), fg=typer.colors.RED)
-        raise typer.Exit(code=1) from exc
-
-    for path in created:
-        typer.echo(f"Created {path}")
+    run_add_resource(
+        project_root=project_root,
+        resource_name=resource_name,
+        dry_run=dry_run,
+    )

--- a/src/azure_functions_scaffold/cli_api.py
+++ b/src/azure_functions_scaffold/cli_api.py
@@ -15,16 +15,10 @@ from azure_functions_scaffold.cli_common import (
     OverwriteOption,
     PythonVersionOption,
     YesOption,
+    run_add_function,
+    run_add_resource,
+    run_add_route,
     run_intent,
-)
-from azure_functions_scaffold.errors import ScaffoldError
-from azure_functions_scaffold.generator import (
-    add_function,
-    add_resource,
-    add_route,
-    describe_add_function,
-    describe_add_resource,
-    describe_add_route,
 )
 
 api_app = typer.Typer(
@@ -71,25 +65,12 @@ def api_add(
     dry_run: DryRunOption = False,
 ) -> None:
     """Add an HTTP function to an existing API project."""
-    try:
-        if dry_run:
-            for line in describe_add_function(
-                project_root=project_root,
-                trigger="http",
-                function_name=function_name,
-            ):
-                typer.echo(line)
-            return
-        function_path = add_function(
-            project_root=project_root,
-            trigger="http",
-            function_name=function_name,
-        )
-    except ScaffoldError as exc:
-        typer.secho(str(exc), fg=typer.colors.RED)
-        raise typer.Exit(code=1) from exc
-
-    typer.echo(f"Created function at {function_path}")
+    run_add_function(
+        project_root=project_root,
+        trigger="http",
+        function_name=function_name,
+        dry_run=dry_run,
+    )
 
 
 @api_app.command("add-route")
@@ -103,23 +84,11 @@ def api_add_route(
     dry_run: DryRunOption = False,
 ) -> None:
     """Add a simple HTTP route to an existing API project."""
-    try:
-        if dry_run:
-            for line in describe_add_route(
-                project_root=project_root,
-                route_name=route_name,
-            ):
-                typer.echo(line)
-            return
-        route_path = add_route(
-            project_root=project_root,
-            route_name=route_name,
-        )
-    except ScaffoldError as exc:
-        typer.secho(str(exc), fg=typer.colors.RED)
-        raise typer.Exit(code=1) from exc
-
-    typer.echo(f"Created route at {route_path}")
+    run_add_route(
+        project_root=project_root,
+        route_name=route_name,
+        dry_run=dry_run,
+    )
 
 
 @api_app.command("add-resource")
@@ -133,21 +102,8 @@ def api_add_resource(
     dry_run: DryRunOption = False,
 ) -> None:
     """Add a full CRUD resource (blueprint, service, schema, test) to an existing API project."""
-    try:
-        if dry_run:
-            for line in describe_add_resource(
-                project_root=project_root,
-                resource_name=resource_name,
-            ):
-                typer.echo(line)
-            return
-        created = add_resource(
-            project_root=project_root,
-            resource_name=resource_name,
-        )
-    except ScaffoldError as exc:
-        typer.secho(str(exc), fg=typer.colors.RED)
-        raise typer.Exit(code=1) from exc
-
-    for path in created:
-        typer.echo(f"Created {path}")
+    run_add_resource(
+        project_root=project_root,
+        resource_name=resource_name,
+        dry_run=dry_run,
+    )

--- a/src/azure_functions_scaffold/cli_common.py
+++ b/src/azure_functions_scaffold/cli_common.py
@@ -9,6 +9,14 @@ from typing import Annotated
 import typer
 
 from azure_functions_scaffold.errors import ScaffoldError
+from azure_functions_scaffold.generator import (
+    add_function,
+    add_resource,
+    add_route,
+    describe_add_function,
+    describe_add_resource,
+    describe_add_route,
+)
 from azure_functions_scaffold.models import ProjectOptions
 from azure_functions_scaffold.scaffolder import describe_scaffold_project, scaffold_project
 from azure_functions_scaffold.template_registry import (
@@ -262,3 +270,90 @@ def _print_success_message(
         typer.secho("  API docs:", bold=True)
         typer.echo("    http://localhost:7071/api/docs")
     typer.echo("")
+
+
+# ---------------------------------------------------------------------------
+# Shared add-* intent execution (used by both `api` and `advanced` groups)
+# ---------------------------------------------------------------------------
+
+
+def run_add_function(
+    *,
+    project_root: Path,
+    trigger: str,
+    function_name: str,
+    dry_run: bool = False,
+) -> None:
+    """Add a function module (or preview via *dry_run*) with unified error handling."""
+    try:
+        if dry_run:
+            for line in describe_add_function(
+                project_root=project_root,
+                trigger=trigger,
+                function_name=function_name,
+            ):
+                typer.echo(line)
+            return
+        function_path = add_function(
+            project_root=project_root,
+            trigger=trigger,
+            function_name=function_name,
+        )
+    except ScaffoldError as exc:
+        typer.secho(str(exc), fg=typer.colors.RED)
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(f"Created function at {function_path}")
+
+
+def run_add_route(
+    *,
+    project_root: Path,
+    route_name: str,
+    dry_run: bool = False,
+) -> None:
+    """Add an HTTP route (or preview via *dry_run*) with unified error handling."""
+    try:
+        if dry_run:
+            for line in describe_add_route(
+                project_root=project_root,
+                route_name=route_name,
+            ):
+                typer.echo(line)
+            return
+        route_path = add_route(
+            project_root=project_root,
+            route_name=route_name,
+        )
+    except ScaffoldError as exc:
+        typer.secho(str(exc), fg=typer.colors.RED)
+        raise typer.Exit(code=1) from exc
+
+    typer.echo(f"Created route at {route_path}")
+
+
+def run_add_resource(
+    *,
+    project_root: Path,
+    resource_name: str,
+    dry_run: bool = False,
+) -> None:
+    """Add a CRUD resource (or preview via *dry_run*) with unified error handling."""
+    try:
+        if dry_run:
+            for line in describe_add_resource(
+                project_root=project_root,
+                resource_name=resource_name,
+            ):
+                typer.echo(line)
+            return
+        created = add_resource(
+            project_root=project_root,
+            resource_name=resource_name,
+        )
+    except ScaffoldError as exc:
+        typer.secho(str(exc), fg=typer.colors.RED)
+        raise typer.Exit(code=1) from exc
+
+    for path in created:
+        typer.echo(f"Created {path}")


### PR DESCRIPTION
## Context
Part of #163 (item 4, remaining `add-*` portion). The `add` / `add-route` / `add-resource` command bodies were duplicated verbatim between the `api` (`cli_api.py`) and `advanced` (`cli_advanced.py`) groups — same try / dry-run-describe / add / `ScaffoldError` handling / echo logic.

## Changes
- Added `run_add_function`, `run_add_route`, `run_add_resource` to `cli_common.py` encapsulating the shared execution + error handling.
- Rewrote all six command bodies in `cli_api.py` and `cli_advanced.py` to delegate to these helpers.
- Trimmed now-unused `generator` / `ScaffoldError` imports from `cli_api.py`; narrowed `cli_advanced.py`'s `generator` import to just `ADDABLE_TRIGGERS`.

## Verification
- CLI surface unchanged (command names, arguments, options, echoed output identical) — existing `test_cli.py` / `test_cli_intents.py` pass unchanged.
- `hatch run lint` ✅  `hatch run typecheck` ✅  `hatch run pytest --cov` ✅ (coverage 97.70%, gate 95%).

## Out of scope
- Remaining #163 items: 5 (decompose `generator.py`), 6 (dry-run unification — needs a behavior decision).

Part of #163