### PR TITLE
chore(generator): decompose generator into focused package

### DIFF
--- a/src/azure_functions_scaffold/generator/__init__.py
+++ b/src/azure_functions_scaffold/generator/__init__.py
@@ -1,7 +1,20 @@
+"""Add functions, routes, and CRUD resources to an existing scaffolded project.
+
+This package is split into focused modules:
+
+* :mod:`~azure_functions_scaffold.generator.writer` — the atomic multi-file
+  write path with rollback.
+* :mod:`~azure_functions_scaffold.generator.function_app` — marker-based
+  ``function_app.py`` registration updates.
+* :mod:`~azure_functions_scaffold.generator.json_mutators` — idempotent
+  ``host.json`` / ``local.settings.json.example`` mutations.
+
+The public ``add_*`` / ``describe_*`` orchestration, name normalization, and
+Jinja rendering live in this module and compose the helpers above.
+"""
+
 from __future__ import annotations
 
-from dataclasses import dataclass
-import json
 import keyword
 import logging
 from pathlib import Path
@@ -10,12 +23,44 @@ import re
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from azure_functions_scaffold.errors import ScaffoldError
+from azure_functions_scaffold.generator.function_app import (
+    FUNCTION_IMPORT_MARKER,
+    FUNCTION_REGISTRATION_MARKER,
+    _compute_updated_function_app,
+    _insert_near_marker,
+    _sort_app_functions_imports,
+    _validate_function_app_updatable,
+)
+from azure_functions_scaffold.generator.json_mutators import (
+    HOST_JSON_TRIGGERS,
+    _compute_updated_host_json,
+    _compute_updated_local_settings,
+)
+from azure_functions_scaffold.generator.writer import (
+    _commit_pending_writes,
+    _PendingWrite,
+)
 from azure_functions_scaffold.template_registry import list_templates
 
-FUNCTION_IMPORT_MARKER = "# azure-functions-scaffold: function imports"
-FUNCTION_REGISTRATION_MARKER = "# azure-functions-scaffold: function registrations"
-LEGACY_FUNCTION_IMPORT_MARKER = "# azure-functions-scaffold-python: function imports"
-LEGACY_FUNCTION_REGISTRATION_MARKER = "# azure-functions-scaffold-python: function registrations"
+__all__ = [
+    "ADDABLE_TRIGGERS",
+    "FUNCTION_IMPORT_MARKER",
+    "FUNCTION_REGISTRATION_MARKER",
+    "HOST_JSON_TRIGGERS",
+    "SUPPORTED_TRIGGERS",
+    "_compute_updated_function_app",
+    "_compute_updated_host_json",
+    "_compute_updated_local_settings",
+    "_insert_near_marker",
+    "_sort_app_functions_imports",
+    "add_function",
+    "add_resource",
+    "add_route",
+    "describe_add_function",
+    "describe_add_resource",
+    "describe_add_route",
+]
+
 SUPPORTED_TRIGGERS = tuple(template.name for template in list_templates())
 ADDABLE_TRIGGERS: tuple[str, ...] = (
     "http",
@@ -28,171 +73,8 @@ ADDABLE_TRIGGERS: tuple[str, ...] = (
     "durable",
     "ai",
 )
-PARTIALS_ROOT = Path(__file__).parent / "templates" / "partials"
-HOST_JSON_TRIGGERS = frozenset({"queue", "blob", "servicebus", "eventhub", "cosmosdb"})
+PARTIALS_ROOT = Path(__file__).parent.parent / "templates" / "partials"
 logger = logging.getLogger(__name__)
-
-
-@dataclass
-class _PendingWrite:
-    path: Path
-    new_content: str
-    original_content: str | None
-    created_parent: Path | None = None
-
-
-def _commit_pending_writes(writes: list[_PendingWrite]) -> None:
-    written: list[_PendingWrite] = []
-    try:
-        for write in writes:
-            write.path.parent.mkdir(parents=True, exist_ok=True)
-            write.path.write_text(write.new_content, encoding="utf-8")
-            written.append(write)
-    except Exception as exc:
-        for write in reversed(written):
-            try:
-                if write.original_content is None:
-                    if write.path.exists():
-                        write.path.unlink()
-                    if (
-                        write.created_parent is not None
-                        and write.created_parent.exists()
-                        and not any(write.created_parent.iterdir())
-                    ):
-                        write.created_parent.rmdir()
-                else:
-                    write.path.write_text(write.original_content, encoding="utf-8")
-            except OSError:
-                logger.exception("Rollback failed for %s", write.path)
-        raise ScaffoldError(
-            f"Atomic write failed; rolled back {len(written)} file(s): {exc}"
-        ) from exc
-
-
-def _validate_function_app_updatable(
-    function_app_path: Path,
-    *,
-    import_stmt: str,
-    registration_stmt: str,
-) -> None:
-    """Pre-validate that function_app.py can be updated before writing files.
-
-    Raises ScaffoldError if markers/anchors are missing or the function is
-    already registered.  This must be called **before** creating any files so
-    that a failure never leaves the project in a half-applied state.
-    """
-    content = function_app_path.read_text(encoding="utf-8")
-
-    if import_stmt in content or registration_stmt in content:
-        raise ScaffoldError("Function is already registered in function_app.py.")
-
-    has_import_target = (
-        FUNCTION_IMPORT_MARKER in content
-        or LEGACY_FUNCTION_IMPORT_MARKER in content
-        or "configure_logging()" in content
-    )
-    has_registration_target = (
-        FUNCTION_REGISTRATION_MARKER in content
-        or LEGACY_FUNCTION_REGISTRATION_MARKER in content
-        or "app = func.FunctionApp()" in content
-    )
-
-    if not has_import_target:
-        raise ScaffoldError(
-            "Cannot update function_app.py: neither the import marker nor "
-            "'configure_logging()' was found."
-        )
-    if not has_registration_target:
-        raise ScaffoldError(
-            "Cannot update function_app.py: neither the registration marker nor "
-            "'app = func.FunctionApp()' was found."
-        )
-
-
-def _compute_updated_function_app(
-    content: str,
-    *,
-    import_stmt: str,
-    registration_stmt: str,
-) -> str:
-    if import_stmt in content or registration_stmt in content:
-        raise ScaffoldError("Function is already registered in function_app.py.")
-
-    updated = _insert_near_marker(
-        content,
-        marker=FUNCTION_IMPORT_MARKER,
-        line=import_stmt,
-        fallback_anchor="configure_logging()",
-    )
-    return _insert_near_marker(
-        updated,
-        marker=FUNCTION_REGISTRATION_MARKER,
-        line=registration_stmt,
-        fallback_anchor="app = func.FunctionApp()",
-        after_anchor=True,
-    )
-
-
-def _compute_updated_host_json(content: str, trigger: str) -> str | None:
-    if trigger not in HOST_JSON_TRIGGERS:
-        return None
-
-    try:
-        host_config = json.loads(content)
-    except json.JSONDecodeError as exc:
-        raise ScaffoldError(f"Invalid JSON in host.json: {exc}") from exc
-    if not isinstance(host_config, dict):
-        raise ScaffoldError("Expected host.json to contain a JSON object.")
-    if "extensionBundle" in host_config:
-        return None
-
-    host_config["extensionBundle"] = {
-        "id": "Microsoft.Azure.Functions.ExtensionBundle",
-        "version": "[4.*, 5.0.0)",
-    }
-    return f"{json.dumps(host_config, indent=2)}\n"
-
-
-def _compute_updated_local_settings(content: str, trigger: str) -> str | None:
-    connection_keys: dict[str, tuple[str, str]] = {
-        "servicebus": (
-            "ServiceBusConnection",
-            "Endpoint=sb://localhost/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=replace-me",
-        ),
-        "eventhub": (
-            "EventHubConnection",
-            "Endpoint=sb://localhost/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=replace-me",
-        ),
-        "cosmosdb": (
-            "CosmosDBConnection",
-            "AccountEndpoint=https://localhost:8081/;AccountKey=replace-me",
-        ),
-    }
-    if trigger not in connection_keys:
-        return None
-
-    try:
-        local_settings = json.loads(content)
-    except json.JSONDecodeError as exc:
-        raise ScaffoldError(f"Invalid JSON in local.settings.json.example: {exc}") from exc
-    if not isinstance(local_settings, dict):
-        raise ScaffoldError("Expected local.settings.json.example to contain a JSON object.")
-
-    existing_values = local_settings.get("Values")
-    if existing_values is None:
-        values: dict[str, object] = {}
-        local_settings["Values"] = values
-    elif isinstance(existing_values, dict):
-        values = existing_values
-    else:
-        raise ScaffoldError("Expected local.settings.json.example Values to be a JSON object.")
-
-    key, default = connection_keys[trigger]
-    if key in values:
-        return None
-
-    values[key] = default
-    return f"{json.dumps(local_settings, indent=2)}\n"
 
 
 def add_function(
@@ -396,84 +278,6 @@ def _validate_project_root(project_root: Path) -> None:
     missing = [path for path in required_paths if not path.exists()]
     if missing:
         raise ScaffoldError("Project root does not look like a scaffolded Azure Functions project.")
-
-
-def _insert_near_marker(
-    content: str,
-    *,
-    marker: str,
-    line: str,
-    fallback_anchor: str,
-    after_anchor: bool = False,
-) -> str:
-    legacy_marker = _legacy_marker_for(marker)
-    target_marker = marker
-
-    if target_marker not in content and legacy_marker is not None and legacy_marker in content:
-        target_marker = legacy_marker
-
-    if target_marker in content:
-        # Insert new import before the blank line that separates imports from
-        # the marker comment, keeping all imports in one contiguous block.
-        blank_then_marker = f"\n\n{target_marker}"
-        if blank_then_marker in content:
-            updated = content.replace(blank_then_marker, f"\n{line}\n\n{target_marker}", 1)
-        else:
-            updated = content.replace(target_marker, f"{line}\n{target_marker}", 1)
-        if marker == FUNCTION_IMPORT_MARKER or marker == LEGACY_FUNCTION_IMPORT_MARKER:
-            updated = _sort_app_functions_imports(updated, target_marker)
-        return updated
-
-    if fallback_anchor not in content:
-        raise ScaffoldError(
-            f"Could not update function_app.py because '{fallback_anchor}' was not found."
-        )
-
-    if after_anchor:
-        return content.replace(fallback_anchor, f"{fallback_anchor}\n{line}", 1)
-
-    return content.replace(fallback_anchor, f"{line}\n\n{fallback_anchor}", 1)
-
-
-def _sort_app_functions_imports(content: str, marker: str) -> str:
-    """Sort the contiguous ``from app.functions.* import ...`` block alphabetically.
-
-    Ruff's ``I001`` rule requires imports within the same isort section to be
-    sorted. New entries are appended in insertion order, so we re-sort the
-    contiguous run that ends just before the import marker. Only ``app.functions.*``
-    lines are reordered; surrounding imports keep their original positions.
-    """
-
-    lines = content.split("\n")
-    marker_index = next((i for i, ln in enumerate(lines) if ln.strip() == marker), -1)
-    if marker_index <= 0:
-        return content
-
-    # Walk backwards from the marker, skipping the blank line that separates
-    # imports from the marker, then collect the contiguous app.functions.* run.
-    end = marker_index
-    while end > 0 and lines[end - 1].strip() == "":
-        end -= 1
-    start = end
-    while start > 0 and lines[start - 1].startswith("from app.functions."):
-        start -= 1
-    if end - start < 2:
-        return content
-
-    block = lines[start:end]
-    sorted_block = sorted(block)
-    if block == sorted_block:
-        return content
-    lines[start:end] = sorted_block
-    return "\n".join(lines)
-
-
-def _legacy_marker_for(marker: str) -> str | None:
-    if marker == FUNCTION_IMPORT_MARKER:
-        return LEGACY_FUNCTION_IMPORT_MARKER
-    if marker == FUNCTION_REGISTRATION_MARKER:
-        return LEGACY_FUNCTION_REGISTRATION_MARKER
-    return None
 
 
 _FUNCTION_MODULE_TEMPLATES: dict[str, str] = {

--- a/src/azure_functions_scaffold/generator/function_app.py
+++ b/src/azure_functions_scaffold/generator/function_app.py
@@ -1,0 +1,154 @@
+"""Marker-based ``function_app.py`` registration updates."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from azure_functions_scaffold.errors import ScaffoldError
+
+FUNCTION_IMPORT_MARKER = "# azure-functions-scaffold: function imports"
+FUNCTION_REGISTRATION_MARKER = "# azure-functions-scaffold: function registrations"
+LEGACY_FUNCTION_IMPORT_MARKER = "# azure-functions-scaffold-python: function imports"
+LEGACY_FUNCTION_REGISTRATION_MARKER = "# azure-functions-scaffold-python: function registrations"
+
+
+def _validate_function_app_updatable(
+    function_app_path: Path,
+    *,
+    import_stmt: str,
+    registration_stmt: str,
+) -> None:
+    """Pre-validate that function_app.py can be updated before writing files.
+
+    Raises ScaffoldError if markers/anchors are missing or the function is
+    already registered.  This must be called **before** creating any files so
+    that a failure never leaves the project in a half-applied state.
+    """
+    content = function_app_path.read_text(encoding="utf-8")
+
+    if import_stmt in content or registration_stmt in content:
+        raise ScaffoldError("Function is already registered in function_app.py.")
+
+    has_import_target = (
+        FUNCTION_IMPORT_MARKER in content
+        or LEGACY_FUNCTION_IMPORT_MARKER in content
+        or "configure_logging()" in content
+    )
+    has_registration_target = (
+        FUNCTION_REGISTRATION_MARKER in content
+        or LEGACY_FUNCTION_REGISTRATION_MARKER in content
+        or "app = func.FunctionApp()" in content
+    )
+
+    if not has_import_target:
+        raise ScaffoldError(
+            "Cannot update function_app.py: neither the import marker nor "
+            "'configure_logging()' was found."
+        )
+    if not has_registration_target:
+        raise ScaffoldError(
+            "Cannot update function_app.py: neither the registration marker nor "
+            "'app = func.FunctionApp()' was found."
+        )
+
+
+def _compute_updated_function_app(
+    content: str,
+    *,
+    import_stmt: str,
+    registration_stmt: str,
+) -> str:
+    if import_stmt in content or registration_stmt in content:
+        raise ScaffoldError("Function is already registered in function_app.py.")
+
+    updated = _insert_near_marker(
+        content,
+        marker=FUNCTION_IMPORT_MARKER,
+        line=import_stmt,
+        fallback_anchor="configure_logging()",
+    )
+    return _insert_near_marker(
+        updated,
+        marker=FUNCTION_REGISTRATION_MARKER,
+        line=registration_stmt,
+        fallback_anchor="app = func.FunctionApp()",
+        after_anchor=True,
+    )
+
+
+def _insert_near_marker(
+    content: str,
+    *,
+    marker: str,
+    line: str,
+    fallback_anchor: str,
+    after_anchor: bool = False,
+) -> str:
+    legacy_marker = _legacy_marker_for(marker)
+    target_marker = marker
+
+    if target_marker not in content and legacy_marker is not None and legacy_marker in content:
+        target_marker = legacy_marker
+
+    if target_marker in content:
+        # Insert new import before the blank line that separates imports from
+        # the marker comment, keeping all imports in one contiguous block.
+        blank_then_marker = f"\n\n{target_marker}"
+        if blank_then_marker in content:
+            updated = content.replace(blank_then_marker, f"\n{line}\n\n{target_marker}", 1)
+        else:
+            updated = content.replace(target_marker, f"{line}\n{target_marker}", 1)
+        if marker == FUNCTION_IMPORT_MARKER or marker == LEGACY_FUNCTION_IMPORT_MARKER:
+            updated = _sort_app_functions_imports(updated, target_marker)
+        return updated
+
+    if fallback_anchor not in content:
+        raise ScaffoldError(
+            f"Could not update function_app.py because '{fallback_anchor}' was not found."
+        )
+
+    if after_anchor:
+        return content.replace(fallback_anchor, f"{fallback_anchor}\n{line}", 1)
+
+    return content.replace(fallback_anchor, f"{line}\n\n{fallback_anchor}", 1)
+
+
+def _sort_app_functions_imports(content: str, marker: str) -> str:
+    """Sort the contiguous ``from app.functions.* import ...`` block alphabetically.
+
+    Ruff's ``I001`` rule requires imports within the same isort section to be
+    sorted. New entries are appended in insertion order, so we re-sort the
+    contiguous run that ends just before the import marker. Only ``app.functions.*``
+    lines are reordered; surrounding imports keep their original positions.
+    """
+
+    lines = content.split("\n")
+    marker_index = next((i for i, ln in enumerate(lines) if ln.strip() == marker), -1)
+    if marker_index <= 0:
+        return content
+
+    # Walk backwards from the marker, skipping the blank line that separates
+    # imports from the marker, then collect the contiguous app.functions.* run.
+    end = marker_index
+    while end > 0 and lines[end - 1].strip() == "":
+        end -= 1
+    start = end
+    while start > 0 and lines[start - 1].startswith("from app.functions."):
+        start -= 1
+    if end - start < 2:
+        return content
+
+    block = lines[start:end]
+    sorted_block = sorted(block)
+    if block == sorted_block:
+        return content
+    lines[start:end] = sorted_block
+    return "\n".join(lines)
+
+
+def _legacy_marker_for(marker: str) -> str | None:
+    if marker == FUNCTION_IMPORT_MARKER:
+        return LEGACY_FUNCTION_IMPORT_MARKER
+    if marker == FUNCTION_REGISTRATION_MARKER:
+        return LEGACY_FUNCTION_REGISTRATION_MARKER
+    return None

--- a/src/azure_functions_scaffold/generator/json_mutators.py
+++ b/src/azure_functions_scaffold/generator/json_mutators.py
@@ -1,0 +1,71 @@
+"""Idempotent ``host.json`` / ``local.settings.json.example`` mutations."""
+
+from __future__ import annotations
+
+import json
+
+from azure_functions_scaffold.errors import ScaffoldError
+
+HOST_JSON_TRIGGERS = frozenset({"queue", "blob", "servicebus", "eventhub", "cosmosdb"})
+
+
+def _compute_updated_host_json(content: str, trigger: str) -> str | None:
+    if trigger not in HOST_JSON_TRIGGERS:
+        return None
+
+    try:
+        host_config = json.loads(content)
+    except json.JSONDecodeError as exc:
+        raise ScaffoldError(f"Invalid JSON in host.json: {exc}") from exc
+    if not isinstance(host_config, dict):
+        raise ScaffoldError("Expected host.json to contain a JSON object.")
+    if "extensionBundle" in host_config:
+        return None
+
+    host_config["extensionBundle"] = {
+        "id": "Microsoft.Azure.Functions.ExtensionBundle",
+        "version": "[4.*, 5.0.0)",
+    }
+    return f"{json.dumps(host_config, indent=2)}\n"
+
+
+def _compute_updated_local_settings(content: str, trigger: str) -> str | None:
+    connection_keys: dict[str, tuple[str, str]] = {
+        "servicebus": (
+            "ServiceBusConnection",
+            "Endpoint=sb://localhost/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=replace-me",
+        ),
+        "eventhub": (
+            "EventHubConnection",
+            "Endpoint=sb://localhost/;SharedAccessKeyName=RootManageSharedAccessKey;SharedAccessKey=replace-me",
+        ),
+        "cosmosdb": (
+            "CosmosDBConnection",
+            "AccountEndpoint=https://localhost:8081/;AccountKey=replace-me",
+        ),
+    }
+    if trigger not in connection_keys:
+        return None
+
+    try:
+        local_settings = json.loads(content)
+    except json.JSONDecodeError as exc:
+        raise ScaffoldError(f"Invalid JSON in local.settings.json.example: {exc}") from exc
+    if not isinstance(local_settings, dict):
+        raise ScaffoldError("Expected local.settings.json.example to contain a JSON object.")
+
+    existing_values = local_settings.get("Values")
+    if existing_values is None:
+        values: dict[str, object] = {}
+        local_settings["Values"] = values
+    elif isinstance(existing_values, dict):
+        values = existing_values
+    else:
+        raise ScaffoldError("Expected local.settings.json.example Values to be a JSON object.")
+
+    key, default = connection_keys[trigger]
+    if key in values:
+        return None
+
+    values[key] = default
+    return f"{json.dumps(local_settings, indent=2)}\n"

--- a/src/azure_functions_scaffold/generator/writer.py
+++ b/src/azure_functions_scaffold/generator/writer.py
@@ -1,0 +1,47 @@
+"""Atomic multi-file write path with rollback for scaffold generators."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+from pathlib import Path
+
+from azure_functions_scaffold.errors import ScaffoldError
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class _PendingWrite:
+    path: Path
+    new_content: str
+    original_content: str | None
+    created_parent: Path | None = None
+
+
+def _commit_pending_writes(writes: list[_PendingWrite]) -> None:
+    written: list[_PendingWrite] = []
+    try:
+        for write in writes:
+            write.path.parent.mkdir(parents=True, exist_ok=True)
+            write.path.write_text(write.new_content, encoding="utf-8")
+            written.append(write)
+    except Exception as exc:
+        for write in reversed(written):
+            try:
+                if write.original_content is None:
+                    if write.path.exists():
+                        write.path.unlink()
+                    if (
+                        write.created_parent is not None
+                        and write.created_parent.exists()
+                        and not any(write.created_parent.iterdir())
+                    ):
+                        write.created_parent.rmdir()
+                else:
+                    write.path.write_text(write.original_content, encoding="utf-8")
+            except OSError:
+                logger.exception("Rollback failed for %s", write.path)
+        raise ScaffoldError(
+            f"Atomic write failed; rolled back {len(written)} file(s): {exc}"
+        ) from exc


### PR DESCRIPTION
## Context
`generator.py` had grown to 858 lines mixing several concerns. This splits it into a `generator/` package of focused submodules — a structural refactor only, with the full public symbol surface preserved and no behavior or CLI changes.

## Changes
- `generator/writer.py` — atomic multi-file write path with rollback (`_PendingWrite`, `_commit_pending_writes`)
- `generator/function_app.py` — marker-based `function_app.py` registration updates
- `generator/json_mutators.py` — `host.json` / `local.settings.json.example` mutations
- `generator/__init__.py` — public `add_*`/`describe_*` orchestration, name normalization, Jinja rendering; re-exports helpers

## Verification
- `hatch run lint` — clean
- `hatch run typecheck` (mypy strict) — clean
- `hatch run pytest --cov` — 97.72% (gate 95%)

Part of #163