### PR TITLE
docs: correct azure-functions-db description in ecosystem table

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -262,16 +262,20 @@ make build
 
 このパッケージは **Azure Functions Python DX Toolkit** の一部です。
 
+**設計原則:** `azure-functions-scaffold` はプロジェクト生成とテンプレート展開を担当します。ランタイムライブラリは提供せず — ランタイムの動作は [`azure-functions-openapi`](https://github.com/yeongseon/azure-functions-openapi-python)（API ドキュメントとスペック生成）、[`azure-functions-validation`](https://github.com/yeongseon/azure-functions-validation-python)（リクエスト/レスポンスのバリデーション）、[`azure-functions-langgraph`](https://github.com/yeongseon/azure-functions-langgraph-python)（LangGraph ランタイムの公開）に属します。
+
 | パッケージ | 役割 |
 |---------|------|
-| **azure-functions-scaffold** | プロジェクトスキャフォールディング CLI |
-| [azure-functions-validation](https://github.com/yeongseon/azure-functions-validation-python) | リクエスト/レスポンスバリデーションとシリアライゼーション |
-| [azure-functions-openapi](https://github.com/yeongseon/azure-functions-openapi-python) | OpenAPI 仕様生成と Swagger UI |
-| [azure-functions-langgraph](https://github.com/yeongseon/azure-functions-langgraph-python) | Azure Functions 向け LangGraph デプロイアダプター |
-| [azure-functions-logging](https://github.com/yeongseon/azure-functions-logging-python) | 構造化ロギングとオブザーバビリティ |
-| [azure-functions-doctor](https://github.com/yeongseon/azure-functions-doctor-python) | デプロイ前診断 CLI |
-| [azure-functions-durable-graph](https://github.com/yeongseon/azure-functions-durable-graph-python) | Durable Functions ベースのグラフランタイム *(計画中)* |
-| [azure-functions-cookbook](https://github.com/yeongseon/azure-functions-cookbook-python) | レシピとサンプル |
+| [azure-functions-openapi-python](https://github.com/yeongseon/azure-functions-openapi-python) | OpenAPI スペック生成と Swagger UI |
+| [azure-functions-validation-python](https://github.com/yeongseon/azure-functions-validation-python) | リクエスト/レスポンスのバリデーションとシリアライズ |
+| [azure-functions-db-python](https://github.com/yeongseon/azure-functions-db-python) | SQLAlchemy ベースの DB 統合ヘルパー（ポーリングベースの擬似トリガー、入力/出力/クライアント注入） |
+| [azure-functions-langgraph-python](https://github.com/yeongseon/azure-functions-langgraph-python) | Azure Functions 向け LangGraph デプロイアダプター |
+| **azure-functions-scaffold-python** | プロジェクトスキャフォールディング CLI |
+| [azure-functions-logging-python](https://github.com/yeongseon/azure-functions-logging-python) | 構造化ロギングと可観測性 |
+| [azure-functions-doctor-python](https://github.com/yeongseon/azure-functions-doctor-python) | デプロイ前診断 CLI |
+| [azure-functions-durable-graph-python](https://github.com/yeongseon/azure-functions-durable-graph-python) | Durable Functions によるマニフェストファーストのグラフランタイム *(実験的)* |
+| [azure-functions-knowledge-python](https://github.com/yeongseon/azure-functions-knowledge-python) | 知識検索（RAG）デコレーター |
+| [azure-functions-cookbook-python](https://github.com/yeongseon/azure-functions-cookbook-python) | ドッグフード例 — ツールキット全体を活用する実行可能なレシピ |
 
 ## 免責事項
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -262,16 +262,20 @@ make build
 
 이 패키지는 **Azure Functions Python DX Toolkit**의 일부입니다.
 
+**설계 원칙:** `azure-functions-scaffold`는 프로젝트 생성과 템플릿 확장을 담당합니다. 런타임 라이브러리를 제공하지 않으며 — 런타임 동작은 [`azure-functions-openapi`](https://github.com/yeongseon/azure-functions-openapi-python)(API 문서화 및 스펙 생성), [`azure-functions-validation`](https://github.com/yeongseon/azure-functions-validation-python)(요청/응답 검증), [`azure-functions-langgraph`](https://github.com/yeongseon/azure-functions-langgraph-python)(LangGraph 런타임 노출)에 속합니다.
+
 | 패키지 | 역할 |
 |---------|------|
-| **azure-functions-scaffold** | 프로젝트 스캐폴딩 CLI |
-| [azure-functions-validation](https://github.com/yeongseon/azure-functions-validation-python) | 요청/응답 검증 및 직렬화 |
-| [azure-functions-openapi](https://github.com/yeongseon/azure-functions-openapi-python) | OpenAPI 사양 생성 및 Swagger UI |
-| [azure-functions-langgraph](https://github.com/yeongseon/azure-functions-langgraph-python) | Azure Functions용 LangGraph 배포 어댑터 |
-| [azure-functions-logging](https://github.com/yeongseon/azure-functions-logging-python) | 구조화된 로깅 및 관측성 |
-| [azure-functions-doctor](https://github.com/yeongseon/azure-functions-doctor-python) | 배포 전 진단 CLI |
-| [azure-functions-durable-graph](https://github.com/yeongseon/azure-functions-durable-graph-python) | Durable Functions 기반 그래프 런타임 *(계획)* |
-| [azure-functions-cookbook](https://github.com/yeongseon/azure-functions-cookbook-python) | 레시피 및 예제 |
+| [azure-functions-openapi-python](https://github.com/yeongseon/azure-functions-openapi-python) | OpenAPI 스펙 생성 및 Swagger UI |
+| [azure-functions-validation-python](https://github.com/yeongseon/azure-functions-validation-python) | 요청/응답 검증 및 직렬화 |
+| [azure-functions-db-python](https://github.com/yeongseon/azure-functions-db-python) | SQLAlchemy 기반 DB 통합 헬퍼 (폴링 기반 의사 트리거, 입력/출력/클라이언트 주입) |
+| [azure-functions-langgraph-python](https://github.com/yeongseon/azure-functions-langgraph-python) | Azure Functions용 LangGraph 배포 어댑터 |
+| **azure-functions-scaffold-python** | 프로젝트 스캐폴딩 CLI |
+| [azure-functions-logging-python](https://github.com/yeongseon/azure-functions-logging-python) | 구조화된 로깅 및 관측성 |
+| [azure-functions-doctor-python](https://github.com/yeongseon/azure-functions-doctor-python) | 배포 전 진단 CLI |
+| [azure-functions-durable-graph-python](https://github.com/yeongseon/azure-functions-durable-graph-python) | Durable Functions 기반 매니페스트 우선 그래프 런타임 *(실험적)* |
+| [azure-functions-knowledge-python](https://github.com/yeongseon/azure-functions-knowledge-python) | 지식 검색(RAG) 데코레이터 |
+| [azure-functions-cookbook-python](https://github.com/yeongseon/azure-functions-cookbook-python) | 도그푸드 예제 — 전체 툴킷을 활용하는 실행 가능한 레시피 |
 
 ## 면책 조항
 

--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ This package is part of the **Azure Functions Python DX Toolkit**.
 |---------|------|
 | [azure-functions-openapi-python](https://github.com/yeongseon/azure-functions-openapi-python) | OpenAPI spec generation and Swagger UI |
 | [azure-functions-validation-python](https://github.com/yeongseon/azure-functions-validation-python) | Request/response validation and serialization |
-| [azure-functions-db-python](https://github.com/yeongseon/azure-functions-db-python) | Database bindings for SQL, PostgreSQL, MySQL, SQLite, and Cosmos DB |
+| [azure-functions-db-python](https://github.com/yeongseon/azure-functions-db-python) | SQLAlchemy-powered DB integration helpers (poll-based pseudo trigger, input/output/client injection) |
 | [azure-functions-langgraph-python](https://github.com/yeongseon/azure-functions-langgraph-python) | LangGraph deployment adapter for Azure Functions |
 | **azure-functions-scaffold-python** | Project scaffolding CLI |
 | [azure-functions-logging-python](https://github.com/yeongseon/azure-functions-logging-python) | Structured logging and observability |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -262,16 +262,20 @@ make build
 
 本包是 **Azure Functions Python DX Toolkit** 的一部分。
 
-| 包 | 角色 |
+**设计原则：** `azure-functions-scaffold` 负责项目生成与模板展开。它不提供运行时库 —— 运行时行为归属于 [`azure-functions-openapi`](https://github.com/yeongseon/azure-functions-openapi-python)（API 文档与规范生成）、[`azure-functions-validation`](https://github.com/yeongseon/azure-functions-validation-python)（请求/响应校验）和 [`azure-functions-langgraph`](https://github.com/yeongseon/azure-functions-langgraph-python)（LangGraph 运行时暴露）。
+
+| 包 | 职责 |
 |---------|------|
-| **azure-functions-scaffold** | 项目脚手架 CLI |
-| [azure-functions-validation](https://github.com/yeongseon/azure-functions-validation-python) | 请求/响应校验与序列化 |
-| [azure-functions-openapi](https://github.com/yeongseon/azure-functions-openapi-python) | OpenAPI 规范生成与 Swagger UI |
-| [azure-functions-langgraph](https://github.com/yeongseon/azure-functions-langgraph-python) | Azure Functions 的 LangGraph 部署适配器 |
-| [azure-functions-logging](https://github.com/yeongseon/azure-functions-logging-python) | 结构化日志与可观测性 |
-| [azure-functions-doctor](https://github.com/yeongseon/azure-functions-doctor-python) | 部署前诊断 CLI |
-| [azure-functions-durable-graph](https://github.com/yeongseon/azure-functions-durable-graph-python) | 基于 Durable Functions 的图运行时 *(计划中)* |
-| [azure-functions-cookbook](https://github.com/yeongseon/azure-functions-cookbook-python) | 食谱与示例 |
+| [azure-functions-openapi-python](https://github.com/yeongseon/azure-functions-openapi-python) | OpenAPI 规范生成与 Swagger UI |
+| [azure-functions-validation-python](https://github.com/yeongseon/azure-functions-validation-python) | 请求/响应校验与序列化 |
+| [azure-functions-db-python](https://github.com/yeongseon/azure-functions-db-python) | 基于 SQLAlchemy 的数据库集成助手（基于轮询的伪触发器，输入/输出/客户端注入） |
+| [azure-functions-langgraph-python](https://github.com/yeongseon/azure-functions-langgraph-python) | 面向 Azure Functions 的 LangGraph 部署适配器 |
+| **azure-functions-scaffold-python** | 项目脚手架 CLI |
+| [azure-functions-logging-python](https://github.com/yeongseon/azure-functions-logging-python) | 结构化日志与可观测性 |
+| [azure-functions-doctor-python](https://github.com/yeongseon/azure-functions-doctor-python) | 部署前诊断 CLI |
+| [azure-functions-durable-graph-python](https://github.com/yeongseon/azure-functions-durable-graph-python) | 基于 Durable Functions 的清单优先图运行时 *(实验性)* |
+| [azure-functions-knowledge-python](https://github.com/yeongseon/azure-functions-knowledge-python) | 知识检索（RAG）装饰器 |
+| [azure-functions-cookbook-python](https://github.com/yeongseon/azure-functions-cookbook-python) | 内部实践示例 — 可运行的完整工具链演示 |
 
 ## 免责声明
 


### PR DESCRIPTION
## Summary
- Corrects the ecosystem-table description of `azure-functions-db-python` from the inaccurate "Database bindings for SQL, PostgreSQL, MySQL, SQLite, and Cosmos DB" to "SQLAlchemy-powered DB integration helpers (poll-based pseudo trigger, input/output/client injection)", matching the wording already used in the db and knowledge repos.

Closes #181

---

**Update:** Also folds in translation sync — `README.ko.md`, `README.ja.md`, `README.zh-CN.md` Ecosystem tables now match English (`-python` slugs, added db-python + knowledge-python rows, incl. the corrected db-python description).