### PR TITLE
refactor(templates): centralize supported-package version catalog

### DIFF
--- a/src/azure_functions_scaffold/packages.py
+++ b/src/azure_functions_scaffold/packages.py
@@ -1,0 +1,30 @@
+"""Single source of truth for Azure Functions DX-toolkit dependency floors.
+
+The scaffolder and every generated ``pyproject.toml`` derive their toolkit
+dependency pins from :data:`SUPPORTED_PACKAGES` so a version bump happens in
+exactly one place instead of drifting across the root project and each
+template.
+"""
+
+from __future__ import annotations
+
+# Mapping of toolkit package name -> PEP 508 version specifier.
+# Keep this in sync with the smoke-test dependency floors in the root
+# ``pyproject.toml``; ``tests/test_supported_packages.py`` fails CI on drift.
+SUPPORTED_PACKAGES: dict[str, str] = {
+    "azure-functions": ">=1.23.0",
+    "azure-functions-logging": ">=0.5.0",
+    "azure-functions-openapi": ">=0.17.0",
+    "azure-functions-validation": ">=0.7.0",
+    "azure-functions-doctor": ">=0.16.0",
+    "azure-functions-durable": ">=1.2.9",
+    "azure-functions-langgraph": ">=0.5.1",
+}
+
+
+def requirement(name: str) -> str:
+    """Return the full PEP 508 requirement string for a supported package.
+
+    Example: ``requirement("azure-functions")`` -> ``"azure-functions>=1.23.0"``.
+    """
+    return f"{name}{SUPPORTED_PACKAGES[name]}"

--- a/src/azure_functions_scaffold/scaffolder.py
+++ b/src/azure_functions_scaffold/scaffolder.py
@@ -12,6 +12,7 @@ import typer
 
 from azure_functions_scaffold.errors import ScaffoldError
 from azure_functions_scaffold.models import ProjectOptions, TemplateContext, TemplateSpec
+from azure_functions_scaffold.packages import SUPPORTED_PACKAGES
 from azure_functions_scaffold.template_registry import (
     build_project_options,
     get_template,
@@ -88,6 +89,7 @@ def scaffold_project(
             include_validation=context.include_validation,
             include_doctor=context.include_doctor,
             include_azd=context.include_azd,
+            supported_packages=SUPPORTED_PACKAGES,
         )
         logger.debug("Rendering template: %s -> %s", template_rel_name, output_path)
         output_path.write_text(rendered_content, encoding="utf-8")

--- a/src/azure_functions_scaffold/templates/ai/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/ai/pyproject.toml.j2
@@ -24,12 +24,12 @@ description = "Azure Functions Python v2 app scaffolded by azure-functions-scaff
 readme = "README.md"
 requires-python = ">={{ python_version }},<{{ python_upper_bound }}"
 dependencies = [
-  "azure-functions>=1.23.0",
-  "azure-functions-logging>=0.5.0",
+  "azure-functions{{ supported_packages['azure-functions'] }}",
+  "azure-functions-logging{{ supported_packages['azure-functions-logging'] }}",
   "openai>=1.0.0",
   "orjson>=3.10.0",
 {% if include_doctor -%}
-  "azure-functions-doctor>=0.16.0",
+  "azure-functions-doctor{{ supported_packages['azure-functions-doctor'] }}",
 {% endif -%}
 ]
 

--- a/src/azure_functions_scaffold/templates/blob/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/blob/pyproject.toml.j2
@@ -24,11 +24,11 @@ description = "Azure Functions Python v2 app scaffolded by azure-functions-scaff
 readme = "README.md"
 requires-python = ">={{ python_version }},<{{ python_upper_bound }}"
 dependencies = [
-  "azure-functions>=1.23.0",
-  "azure-functions-logging>=0.5.0",
+  "azure-functions{{ supported_packages['azure-functions'] }}",
+  "azure-functions-logging{{ supported_packages['azure-functions-logging'] }}",
   "orjson>=3.10.0",
 {% if include_doctor -%}
-  "azure-functions-doctor>=0.16.0",
+  "azure-functions-doctor{{ supported_packages['azure-functions-doctor'] }}",
 {% endif -%}
 ]
 

--- a/src/azure_functions_scaffold/templates/cosmosdb/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/cosmosdb/pyproject.toml.j2
@@ -24,11 +24,11 @@ description = "Azure Functions Python v2 app scaffolded by azure-functions-scaff
 readme = "README.md"
 requires-python = ">={{ python_version }},<{{ python_upper_bound }}"
 dependencies = [
-  "azure-functions>=1.23.0",
-  "azure-functions-logging>=0.5.0",
+  "azure-functions{{ supported_packages['azure-functions'] }}",
+  "azure-functions-logging{{ supported_packages['azure-functions-logging'] }}",
   "orjson>=3.10.0",
 {% if include_doctor -%}
-  "azure-functions-doctor>=0.16.0",
+  "azure-functions-doctor{{ supported_packages['azure-functions-doctor'] }}",
 {% endif -%}
 ]
 

--- a/src/azure_functions_scaffold/templates/durable/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/durable/pyproject.toml.j2
@@ -24,12 +24,12 @@ description = "Azure Functions Python v2 app scaffolded by azure-functions-scaff
 readme = "README.md"
 requires-python = ">={{ python_version }},<{{ python_upper_bound }}"
 dependencies = [
-  "azure-functions>=1.23.0",
-  "azure-functions-logging>=0.5.0",
-  "azure-functions-durable>=1.2.9",
+  "azure-functions{{ supported_packages['azure-functions'] }}",
+  "azure-functions-logging{{ supported_packages['azure-functions-logging'] }}",
+  "azure-functions-durable{{ supported_packages['azure-functions-durable'] }}",
   "orjson>=3.10.0",
 {% if include_doctor -%}
-  "azure-functions-doctor>=0.16.0",
+  "azure-functions-doctor{{ supported_packages['azure-functions-doctor'] }}",
 {% endif -%}
 ]
 

--- a/src/azure_functions_scaffold/templates/eventhub/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/eventhub/pyproject.toml.j2
@@ -24,11 +24,11 @@ description = "Azure Functions Python v2 app scaffolded by azure-functions-scaff
 readme = "README.md"
 requires-python = ">={{ python_version }},<{{ python_upper_bound }}"
 dependencies = [
-  "azure-functions>=1.23.0",
-  "azure-functions-logging>=0.5.0",
+  "azure-functions{{ supported_packages['azure-functions'] }}",
+  "azure-functions-logging{{ supported_packages['azure-functions-logging'] }}",
   "orjson>=3.10.0",
 {% if include_doctor -%}
-  "azure-functions-doctor>=0.16.0",
+  "azure-functions-doctor{{ supported_packages['azure-functions-doctor'] }}",
 {% endif -%}
 ]
 

--- a/src/azure_functions_scaffold/templates/http/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/http/pyproject.toml.j2
@@ -24,20 +24,20 @@ description = "Azure Functions Python v2 app scaffolded by azure-functions-scaff
 readme = "README.md"
 requires-python = ">={{ python_version }},<{{ python_upper_bound }}"
 dependencies = [
-  "azure-functions>=1.23.0",
-  "azure-functions-logging>=0.5.0",
+  "azure-functions{{ supported_packages['azure-functions'] }}",
+  "azure-functions-logging{{ supported_packages['azure-functions-logging'] }}",
   "orjson>=3.10.0",
 {% if include_openapi -%}
-  "azure-functions-openapi>=0.17.0",
+  "azure-functions-openapi{{ supported_packages['azure-functions-openapi'] }}",
 {% endif -%}
 {% if include_validation -%}
-  "azure-functions-validation>=0.7.0",
+  "azure-functions-validation{{ supported_packages['azure-functions-validation'] }}",
 {% endif -%}
 {% if include_validation -%}
   "pydantic>=2.0.0",
 {% endif -%}
 {% if include_doctor -%}
-  "azure-functions-doctor>=0.16.0",
+  "azure-functions-doctor{{ supported_packages['azure-functions-doctor'] }}",
 {% endif -%}
 ]
 

--- a/src/azure_functions_scaffold/templates/langgraph/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/langgraph/pyproject.toml.j2
@@ -24,8 +24,8 @@ description = "LangGraph agent on Azure Functions Python v2, scaffolded by azure
 readme = "README.md"
 requires-python = ">={{ python_version }},<{{ python_upper_bound }}"
 dependencies = [
-  "azure-functions>=1.23.0",
-  # "azure-functions-langgraph>=0.5.1",
+  "azure-functions{{ supported_packages['azure-functions'] }}",
+  # "azure-functions-langgraph{{ supported_packages['azure-functions-langgraph'] }}",
   # Uncomment after azure-functions-langgraph is published on PyPI.
   "langgraph>=0.2.0",
   "orjson>=3.10.0",

--- a/src/azure_functions_scaffold/templates/queue/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/queue/pyproject.toml.j2
@@ -24,11 +24,11 @@ description = "Azure Functions Python v2 app scaffolded by azure-functions-scaff
 readme = "README.md"
 requires-python = ">={{ python_version }},<{{ python_upper_bound }}"
 dependencies = [
-  "azure-functions>=1.23.0",
-  "azure-functions-logging>=0.5.0",
+  "azure-functions{{ supported_packages['azure-functions'] }}",
+  "azure-functions-logging{{ supported_packages['azure-functions-logging'] }}",
   "orjson>=3.10.0",
 {% if include_doctor -%}
-  "azure-functions-doctor>=0.16.0",
+  "azure-functions-doctor{{ supported_packages['azure-functions-doctor'] }}",
 {% endif -%}
 ]
 

--- a/src/azure_functions_scaffold/templates/servicebus/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/servicebus/pyproject.toml.j2
@@ -24,11 +24,11 @@ description = "Azure Functions Python v2 app scaffolded by azure-functions-scaff
 readme = "README.md"
 requires-python = ">={{ python_version }},<{{ python_upper_bound }}"
 dependencies = [
-  "azure-functions>=1.23.0",
-  "azure-functions-logging>=0.5.0",
+  "azure-functions{{ supported_packages['azure-functions'] }}",
+  "azure-functions-logging{{ supported_packages['azure-functions-logging'] }}",
   "orjson>=3.10.0",
 {% if include_doctor -%}
-  "azure-functions-doctor>=0.16.0",
+  "azure-functions-doctor{{ supported_packages['azure-functions-doctor'] }}",
 {% endif -%}
 ]
 

--- a/src/azure_functions_scaffold/templates/timer/pyproject.toml.j2
+++ b/src/azure_functions_scaffold/templates/timer/pyproject.toml.j2
@@ -24,11 +24,11 @@ description = "Azure Functions Python v2 app scaffolded by azure-functions-scaff
 readme = "README.md"
 requires-python = ">={{ python_version }},<{{ python_upper_bound }}"
 dependencies = [
-  "azure-functions>=1.23.0",
-  "azure-functions-logging>=0.5.0",
+  "azure-functions{{ supported_packages['azure-functions'] }}",
+  "azure-functions-logging{{ supported_packages['azure-functions-logging'] }}",
   "orjson>=3.10.0",
 {% if include_doctor -%}
-  "azure-functions-doctor>=0.16.0",
+  "azure-functions-doctor{{ supported_packages['azure-functions-doctor'] }}",
 {% endif -%}
 ]
 

--- a/tests/test_supported_packages.py
+++ b/tests/test_supported_packages.py
@@ -26,12 +26,13 @@ def test_requirement_builds_full_specifier() -> None:
 
 def test_templates_have_no_hardcoded_toolkit_pins() -> None:
     offenders: list[str] = []
-    for template_pyproject in _TEMPLATES_ROOT.glob("*/pyproject.toml.j2"):
+    for template_pyproject in sorted(_TEMPLATES_ROOT.glob("*/pyproject.toml.j2")):
         for lineno, line in enumerate(
             template_pyproject.read_text(encoding="utf-8").splitlines(), start=1
         ):
             if _BARE_PIN.search(line):
-                offenders.append(f"{template_pyproject.name}:{lineno}: {line.strip()}")
+                offender = template_pyproject.relative_to(_REPO_ROOT).as_posix()
+                offenders.append(f"{offender}:{lineno}: {line.strip()}")
     assert offenders == [], (
         "Template pyproject files must reference SUPPORTED_PACKAGES, not hardcoded "
         f"toolkit pins:\n{chr(10).join(offenders)}"
@@ -41,11 +42,11 @@ def test_templates_have_no_hardcoded_toolkit_pins() -> None:
 def test_templates_reference_catalog() -> None:
     # Every template pyproject that pins a toolkit package must do so via the
     # `supported_packages` render variable.
-    for template_pyproject in _TEMPLATES_ROOT.glob("*/pyproject.toml.j2"):
+    for template_pyproject in sorted(_TEMPLATES_ROOT.glob("*/pyproject.toml.j2")):
         text = template_pyproject.read_text(encoding="utf-8")
         if "azure-functions" in text:
             assert "supported_packages[" in text, (
-                f"{template_pyproject} pins toolkit packages but does not use the catalog"
+                f"{template_pyproject.relative_to(_REPO_ROOT).as_posix()} pins toolkit packages but does not use the catalog"
             )
 
 

--- a/tests/test_supported_packages.py
+++ b/tests/test_supported_packages.py
@@ -45,8 +45,9 @@ def test_templates_reference_catalog() -> None:
     for template_pyproject in sorted(_TEMPLATES_ROOT.glob("*/pyproject.toml.j2")):
         text = template_pyproject.read_text(encoding="utf-8")
         if "azure-functions" in text:
+            rel = template_pyproject.relative_to(_REPO_ROOT).as_posix()
             assert "supported_packages[" in text, (
-                f"{template_pyproject.relative_to(_REPO_ROOT).as_posix()} pins toolkit packages but does not use the catalog"
+                f"{rel} pins toolkit packages but does not use the catalog"
             )
 
 

--- a/tests/test_supported_packages.py
+++ b/tests/test_supported_packages.py
@@ -1,0 +1,90 @@
+"""Tests for the centralized supported-package version catalog (issue #195)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+
+import pytest
+
+from azure_functions_scaffold.packages import SUPPORTED_PACKAGES, requirement
+from azure_functions_scaffold.scaffolder import scaffold_project
+from azure_functions_scaffold.template_registry import build_project_options
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_TEMPLATES_ROOT = _REPO_ROOT / "src" / "azure_functions_scaffold" / "templates"
+
+# Bare toolkit pins like `"azure-functions-openapi>=0.17.0"` must not survive in
+# the templates — they have to flow through the catalog instead.
+_BARE_PIN = re.compile(r'"azure-functions[a-z-]*>=')
+
+
+def test_requirement_builds_full_specifier() -> None:
+    assert requirement("azure-functions") == "azure-functions>=1.23.0"
+    assert requirement("azure-functions-doctor") == "azure-functions-doctor>=0.16.0"
+
+
+def test_templates_have_no_hardcoded_toolkit_pins() -> None:
+    offenders: list[str] = []
+    for template_pyproject in _TEMPLATES_ROOT.glob("*/pyproject.toml.j2"):
+        for lineno, line in enumerate(
+            template_pyproject.read_text(encoding="utf-8").splitlines(), start=1
+        ):
+            if _BARE_PIN.search(line):
+                offenders.append(f"{template_pyproject.name}:{lineno}: {line.strip()}")
+    assert offenders == [], (
+        "Template pyproject files must reference SUPPORTED_PACKAGES, not hardcoded "
+        f"toolkit pins:\n{chr(10).join(offenders)}"
+    )
+
+
+def test_templates_reference_catalog() -> None:
+    # Every template pyproject that pins a toolkit package must do so via the
+    # `supported_packages` render variable.
+    for template_pyproject in _TEMPLATES_ROOT.glob("*/pyproject.toml.j2"):
+        text = template_pyproject.read_text(encoding="utf-8")
+        if "azure-functions" in text:
+            assert "supported_packages[" in text, (
+                f"{template_pyproject} pins toolkit packages but does not use the catalog"
+            )
+
+
+def test_root_pyproject_floors_match_catalog() -> None:
+    root_pyproject = (_REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    for name, spec in SUPPORTED_PACKAGES.items():
+        # Not every catalog entry is a smoke-test floor of the root project
+        # (durable/langgraph are template-only), but any that appears must agree.
+        pin = re.search(rf'"{re.escape(name)}(>=[^"]*)"', root_pyproject)
+        if pin is not None:
+            assert pin.group(1) == spec, (
+                f"Root pyproject pins {name}{pin.group(1)} but catalog says {name}{spec}"
+            )
+
+
+@pytest.mark.parametrize(
+    ("template_name", "expected"),
+    [
+        ("http", ("azure-functions", "azure-functions-logging", "azure-functions-openapi")),
+        ("durable", ("azure-functions", "azure-functions-durable")),
+    ],
+)
+def test_rendered_pyproject_uses_catalog_specs(
+    tmp_path: Path, template_name: str, expected: tuple[str, ...]
+) -> None:
+    options = build_project_options(
+        preset_name="standard",
+        python_version="3.11",
+        include_github_actions=False,
+        initialize_git=False,
+        include_openapi=True,
+        include_validation=True,
+        include_doctor=True,
+    )
+    project_path = scaffold_project(
+        "sample", tmp_path, template_name=template_name, options=options
+    )
+    pyproject = (project_path / "pyproject.toml").read_text(encoding="utf-8")
+    for name in expected:
+        assert requirement(name) in pyproject, (
+            f"{template_name} pyproject missing catalog pin {requirement(name)}"
+        )


### PR DESCRIPTION
## Summary
- Add `SUPPORTED_PACKAGES` (in `packages.py`) as the single source of truth for Azure Functions DX-toolkit dependency floors.
- Inject the catalog into the Jinja render context; all 10 template `pyproject.toml.j2` files now derive their toolkit pins from it instead of duplicating version strings.
- Add a drift test that locks the root `pyproject.toml` smoke-test floors to the catalog, so a future bump only needs to happen in one place.

## Notes
- Rendered output is byte-for-byte identical (same version specifiers) — no behavior change for generated projects.
- Version numbers are unchanged. Min-vs-latest CI matrix (#197) and running Doctor in CI (#196) are tracked separately.

## Verification
- `make check-all` passes: 492 passed, 5 skipped, coverage 97.73%.

Closes #195