### PR TITLE
ci: add min-vs-latest dependency test matrix

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -13,15 +13,23 @@ jobs:
   test:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         # Python 3.14 is stable and required in this matrix (not allow-fail).
         python-version: ["3.10", "3.11", "3.12", "3.13", "3.14"]
+        # Default axis resolves the latest compatible dependencies.
+        resolution: ["latest"]
+        include:
+          # Extra job: resolve to the minimum declared dependency floors on the
+          # lowest supported Python, catching breaks at the declared lower bounds.
+          - python-version: "3.10"
+            resolution: "minimum"
 
     steps:
       - name: Checkout code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
 
-      - name: Set up Python ${{ matrix.python-version }}
+      - name: Set up Python ${{ matrix.python-version }} (${{ matrix.resolution }} deps)
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: ${{ matrix.python-version }}
@@ -31,6 +39,10 @@ jobs:
           pip install hatch
           make install
 
+      - name: Downgrade to minimum dependency floors
+        if: matrix.resolution == 'minimum'
+        run: hatch run pip install -c constraints-min.txt -e ".[dev]"
+
       - name: Run full quality checks
         run: make check-all
 
@@ -38,7 +50,7 @@ jobs:
         run: ls -lh coverage.xml
 
       - name: Upload coverage to Codecov
-        if: matrix.python-version == '3.10' && github.actor != 'dependabot[bot]'
+        if: matrix.python-version == '3.10' && matrix.resolution == 'latest' && github.actor != 'dependabot[bot]'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Downgrade to minimum dependency floors
         if: matrix.resolution == 'minimum'
-        run: hatch run pip install -c constraints-min.txt -e ".[dev]"
+        run: .venv/bin/hatch run pip install -c constraints-min.txt -e ".[dev]"
 
       - name: Run full quality checks
         run: make check-all

--- a/constraints-min.txt
+++ b/constraints-min.txt
@@ -1,0 +1,12 @@
+# Minimum dependency floors for the "minimum" CI resolution axis.
+# Pins each DIRECT declared dependency (runtime + smoke-test extras) to the
+# lowest version allowed by pyproject.toml so compatibility breaks at the
+# declared floor are caught in CI. Keep in sync with pyproject.toml.
+jinja2==3.1.0
+typer==0.16.0
+azure-functions==1.23.0
+azure-functions-logging==0.5.0
+azure-functions-openapi==0.17.0
+azure-functions-validation==0.7.0
+azure-functions-doctor==0.16.0
+pydantic==2.0.0


### PR DESCRIPTION
## Summary
Adds a `resolution` axis to `ci-test.yml`:
- **latest** (default) — resolves newest compatible dependencies across Python 3.10–3.14 (unchanged behavior).
- **minimum** — an extra Python 3.10 job that installs the declared dependency floors via a new committed `constraints-min.txt`, catching compatibility breaks at the lower bounds.

`fail-fast: false` so failures on either axis surface independently. Codecov upload is restricted to the `latest` 3.10 job to avoid duplicate uploads. All external `uses:` refs remain pinned to full 40-char SHAs.

## Testing
- `make check-all` passes.
- Workflow YAML validated.

Closes #197