### PR TITLE
chore(deps): cap azure-functions below 2.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ dev = [
     "types-requests",
     # Smoke-test deps: generated project runtime packages needed by
     # test_template_smoke.py to run the scaffolded project's own test suite.
-    "azure-functions>=1.23.0",
+    "azure-functions>=1.23.0,<2.0.0",
     "azure-functions-logging>=0.5.0",
     "azure-functions-openapi>=0.17.0",
     "azure-functions-validation>=0.7.0",

--- a/src/azure_functions_scaffold/packages.py
+++ b/src/azure_functions_scaffold/packages.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 # Keep this in sync with the smoke-test dependency floors in the root
 # ``pyproject.toml``; ``tests/test_supported_packages.py`` fails CI on drift.
 SUPPORTED_PACKAGES: dict[str, str] = {
+    # Upper bound <2.0.0: azure-functions v2 may change worker function-indexing
+    # behavior the toolkit relies on; generated projects inherit this cap. See dx#8.
     "azure-functions": ">=1.23.0,<2.0.0",
     "azure-functions-logging": ">=0.5.0",
     "azure-functions-openapi": ">=0.17.0",

--- a/src/azure_functions_scaffold/packages.py
+++ b/src/azure_functions_scaffold/packages.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 # Keep this in sync with the smoke-test dependency floors in the root
 # ``pyproject.toml``; ``tests/test_supported_packages.py`` fails CI on drift.
 SUPPORTED_PACKAGES: dict[str, str] = {
-    "azure-functions": ">=1.23.0",
+    "azure-functions": ">=1.23.0,<2.0.0",
     "azure-functions-logging": ">=0.5.0",
     "azure-functions-openapi": ">=0.17.0",
     "azure-functions-validation": ">=0.7.0",

--- a/tests/test_supported_packages.py
+++ b/tests/test_supported_packages.py
@@ -20,7 +20,7 @@ _BARE_PIN = re.compile(r'"azure-functions[a-z-]*>=')
 
 
 def test_requirement_builds_full_specifier() -> None:
-    assert requirement("azure-functions") == "azure-functions>=1.23.0"
+    assert requirement("azure-functions") == "azure-functions>=1.23.0,<2.0.0"
     assert requirement("azure-functions-doctor") == "azure-functions-doctor>=0.16.0"
 
 


### PR DESCRIPTION
## Context

Part of the DX-toolkit dependency-bounds unification. `azure-functions` was pinned with only a lower bound (`>=1.23.0`), so a future `2.x` major could be installed automatically and silently break the v2 decorator programming model — both for this CLI and for the projects it scaffolds.

## Change

- Supported-package catalog (`packages.py`): `azure-functions>=1.23.0` → `>=1.23.0,<2.0.0`, so generated project templates inherit the cap.
- Root `pyproject.toml` smoke-test floor updated to match the catalog (enforced by `test_root_pyproject_floors_match_catalog`).
- `test_requirement_builds_full_specifier` updated to the new specifier.

Matches the constraint applied across validation, db, and knowledge.

## Verification

- `make check-all` → EXIT=0 (492 passed, 5 skipped)

Refs yeongseon/azure-functions-python-dx#8