### PR TITLE
chore: bump ruff to 0.16.2 and repair pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,9 @@
+default_language_version:
+  python: python3.12
+
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.6
+    rev: v0.16.2
     hooks:
       - id: ruff-format
       - id: ruff
@@ -24,6 +27,7 @@ repos:
     rev: 1.9.4
     hooks:
       - id: bandit
+        language_version: python3.12
         args: ["-c", "pyproject.toml"]
         additional_dependencies: ["bandit[toml]"]
         files: "^src/"
@@ -32,7 +36,7 @@ repos:
     hooks:
       - id: forbid-korean
         name: Forbid Korean Characters
-        entry: bash -c 'if grep -RIl --exclude-dir=.venv --exclude-dir=.git -n "[가-힣]" docs src README.md CONTRIBUTING.md AGENTS.md DESIGN.md PRD.md CHANGELOG.md 2>/dev/null; then echo "Korean characters detected. Please use English only."; exit 1; fi'
+        entry: bash -c 'if grep -RIn --exclude-dir=.venv --exclude-dir=.git "[가-힣]" docs src README.md CONTRIBUTING.md AGENTS.md DESIGN.md PRD.md CHANGELOG.md 2>/dev/null | grep -vE "README\.(ko|ja|zh-CN)\.md"; then echo "Korean characters detected. Please use English only."; exit 1; fi'
         language: system
         pass_filenames: false
         stages: [pre-commit]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dev = [
     "pre-commit",
     "pytest",
     "pytest-cov",
-    "ruff==0.16.1",
+    "ruff==0.16.2",
     "requests",
     "types-requests",
     # Smoke-test deps: generated project runtime packages needed by

--- a/src/azure_functions_scaffold/cli_advanced.py
+++ b/src/azure_functions_scaffold/cli_advanced.py
@@ -8,16 +8,16 @@ from typing import Annotated
 import typer
 
 from azure_functions_scaffold.cli_common import (
-PYTHON_VERSION_HELP,
-AzdOption,
-DestinationOption,
-DryRunOption,
-OverwriteOption,
+    PYTHON_VERSION_HELP,
+    AzdOption,
+    DestinationOption,
+    DryRunOption,
+    OverwriteOption,
     YesOption,
     run_add_function,
     run_add_resource,
     run_add_route,
-run_scaffold,
+    run_scaffold,
 )
 from azure_functions_scaffold.errors import ScaffoldError
 from azure_functions_scaffold.generator import ADDABLE_TRIGGERS
@@ -32,6 +32,7 @@ advanced_app = typer.Typer(
     help="Power-user project scaffolding with full option control.",
 )
 
+
 def _allowed_features_for_template(template: str) -> frozenset[str] | None:
     # Normalize the same way template_registry.get_template() resolves names
     # (case/whitespace-insensitive) so validation cannot be bypassed by passing
@@ -41,7 +42,6 @@ def _allowed_features_for_template(template: str) -> frozenset[str] | None:
     if spec is None:
         return None
     return spec.allowed_features
-
 
 
 def _validate_feature_flags_for_template(

--- a/tests/test_docs_cli_examples.py
+++ b/tests/test_docs_cli_examples.py
@@ -97,33 +97,34 @@ class TestTopLevelAfsNewRegex:
 
     def test_matches_short_alias_with_drifted_flag(self) -> None:
         """``afs new`` + a drifted flag still triggers the regex."""
-        assert TOP_LEVEL_AFS_NEW_RE.search(
-            "afs new my-api --template http"
-        ) is not None
+        assert TOP_LEVEL_AFS_NEW_RE.search("afs new my-api --template http") is not None
 
     def test_matches_long_alias_with_drifted_flag(self) -> None:
         """``azure-functions-scaffold new`` + a drifted flag also triggers."""
-        assert TOP_LEVEL_AFS_NEW_RE.search(
-            "azure-functions-scaffold new my-api --template http"
-        ) is not None
+        assert (
+            TOP_LEVEL_AFS_NEW_RE.search("azure-functions-scaffold new my-api --template http")
+            is not None
+        )
 
     def test_matches_long_alias_with_interactive_flag(self) -> None:
         """``--interactive`` on the long alias also triggers."""
-        assert TOP_LEVEL_AFS_NEW_RE.search(
-            "azure-functions-scaffold new my-api --interactive"
-        ) is not None
+        assert (
+            TOP_LEVEL_AFS_NEW_RE.search("azure-functions-scaffold new my-api --interactive")
+            is not None
+        )
 
     def test_ignores_short_alias_advanced_new(self) -> None:
         """``afs advanced new`` with drifted flag is a valid, current CLI shape."""
-        assert TOP_LEVEL_AFS_NEW_RE.search(
-            "afs advanced new my-api --template http"
-        ) is None
+        assert TOP_LEVEL_AFS_NEW_RE.search("afs advanced new my-api --template http") is None
 
     def test_ignores_long_alias_advanced_new(self) -> None:
         """``azure-functions-scaffold advanced new`` is a valid, current CLI shape."""
-        assert TOP_LEVEL_AFS_NEW_RE.search(
-            "azure-functions-scaffold advanced new my-api --template http"
-        ) is None
+        assert (
+            TOP_LEVEL_AFS_NEW_RE.search(
+                "azure-functions-scaffold advanced new my-api --template http"
+            )
+            is None
+        )
 
     def test_ignores_legacy_scaffold_python_distribution(self) -> None:
         """``azure-functions-scaffold-python new`` must be caught by LEGACY_NEW_RE,
@@ -136,9 +137,7 @@ class TestTopLevelAfsNewRegex:
     def test_ignores_bare_afs_new_without_drifted_flags(self) -> None:
         """Current, correct ``afs new`` invocations must not trip the regex."""
         assert TOP_LEVEL_AFS_NEW_RE.search("afs new my-api") is None
-        assert TOP_LEVEL_AFS_NEW_RE.search(
-            "azure-functions-scaffold new my-api"
-        ) is None
+        assert TOP_LEVEL_AFS_NEW_RE.search("azure-functions-scaffold new my-api") is None
 
 
 CLI_REFERENCE = DOCS_ROOT / "reference" / "cli.md"
@@ -229,6 +228,7 @@ def _iter_command_flags() -> list[str]:
 # Every long option flag implemented across the command groups, derived from the
 # live Click command tree so newly-added flags are caught automatically.
 IMPLEMENTED_FLAGS: list[str] = _iter_command_flags()
+
 
 class TestCliReferenceCoverage:
     """Guard: ``docs/reference/cli.md`` must cover the implemented command surface."""


### PR DESCRIPTION
## Summary
- Bump pinned `ruff` dev dependency **0.16.1 → 0.16.2** and apply the resulting formatter changes.
- Bump `ruff-pre-commit` rev **v0.15.6 → v0.16.2** so the hook formats identically to the pinned tool.
- Repair pre-commit env: pin the `bandit` hook (and default python-language version) to **python3.12** — the default env was resolving to system Python 3.9.6, which modern bandit rejects (`requires >=3.10`), crashing every commit.
- Narrow the `forbid-korean` hook so the README language-selector nav links no longer trip the Hangul check (it previously failed on `main`).

## Verification
- `pre-commit run --all-files` → ruff-format, ruff, mypy, bandit, forbid-korean all **Passed**.

## Scope
- Dev tooling + pre-commit config only. No runtime dependency or logic changes.
- `mypy`/`bandit` version pins left untouched (already at/above the highest versions on the active package index).