### PR TITLE
ci: gate PyPI publish behind lib-tests + real-Azure certification

### DIFF
--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -5,6 +5,15 @@ on:
     tags:
       - 'v*'
   workflow_dispatch:
+    inputs:
+      ref:
+        description: Git ref (commit SHA) to certify. Defaults to the triggering ref.
+        required: false
+        type: string
+      version:
+        description: Expected package version (must match src __version__).
+        required: false
+        type: string
 
 permissions:
   id-token: write
@@ -34,6 +43,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ inputs.ref || github.ref }}
 
       - name: Compute resource names
         id: names
@@ -141,6 +152,44 @@ jobs:
         run: pytest tests/e2e -v -k "not scaffolded" --no-cov --html=e2e-report/report.html --self-contained-html
         env:
           E2E_BASE_URL: https://${{ steps.names.outputs.app }}.azurewebsites.net
+
+      # Emit the release certification record consumed by publish-pypi.yml's
+      # verify-azure-certification gate. Written only after the live e2e HTTP
+      # tests above pass, so a green azure-cert proves this exact commit +
+      # version booted and served on real Azure.
+      - name: Record certification
+        run: |
+          SHA=$(git rev-parse HEAD)
+          FILE_VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' src/azure_functions_scaffold/__init__.py)
+          REQ_VERSION="${{ inputs.version }}"
+          if [ -n "$REQ_VERSION" ] && [ "$REQ_VERSION" != "$FILE_VERSION" ]; then
+            echo "::error ::Requested certification version ($REQ_VERSION) != source version ($FILE_VERSION)"
+            exit 1
+          fi
+          VERSION="${REQ_VERSION:-$FILE_VERSION}"
+          mkdir -p cert
+          cat > cert/certification.json <<EOF
+          {
+            "package": "azure-functions-scaffold",
+            "version": "$VERSION",
+            "commit": "$SHA",
+            "ref": "${{ inputs.ref || github.ref }}",
+            "workflow": "e2e-azure.yml",
+            "run_id": "${{ github.run_id }}",
+            "host_name": "${{ steps.names.outputs.app }}.azurewebsites.net",
+            "result": "success",
+            "certified_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          }
+          EOF
+          cat cert/certification.json
+
+      - name: Upload certification record
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: azure-cert
+          path: cert/
+          if-no-files-found: error
+          retention-days: 30
 
       - name: Upload e2e report
         if: always()

--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -1,9 +1,6 @@
 name: e2e-azure
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
     inputs:
       ref:
@@ -184,7 +181,7 @@ jobs:
           cat cert/certification.json
 
       - name: Upload certification record
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: azure-cert
           path: cert/

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -69,6 +69,22 @@ jobs:
       - name: Build distribution packages
         run: python -m build
 
+      - name: Verify built wheel is non-empty and importable
+        run: |
+          set -euo pipefail
+          WHEEL=$(ls dist/*.whl)
+          echo "Inspecting $WHEEL"
+          MODCOUNT=$(python -c "import zipfile,sys; z=zipfile.ZipFile(sys.argv[1]); print(len([n for n in z.namelist() if n.endswith('.py')]))" "$WHEEL")
+          echo "Wheel contains $MODCOUNT .py modules"
+          if [ "$MODCOUNT" -eq 0 ]; then
+            echo "::error ::Built wheel is EMPTY (0 .py modules) — refusing to publish"
+            exit 1
+          fi
+          python -m venv /tmp/verify-wheel
+          /tmp/verify-wheel/bin/pip install --upgrade pip
+          /tmp/verify-wheel/bin/pip install "$WHEEL"
+          /tmp/verify-wheel/bin/python -c "import azure_functions_scaffold; print('import OK', azure_functions_scaffold.__version__)"
+
       - name: Upload distribution artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -70,7 +70,7 @@ jobs:
         run: python -m build
 
       - name: Upload distribution artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: dist
           path: dist/

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -14,13 +14,27 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
+# Verify-before-publish gate (see AGENTS.md):
+#   build -> lib-tests -> verify-azure-certification -> publish
+# Tiered runtime verification before any PyPI upload:
+#   * lib-tests                  : the library's own unit suite (against the built wheel).
+#   * verify-azure-certification : requires the EXACT release commit to have passed a real-Azure
+#                                  deploy+live-e2e certification (e2e-azure.yml) that is fresh and
+#                                  version/SHA-matched. Real Azure is certified per release, not per publish.
+# Like azure-functions-knowledge, this package has NO cookbook host-smoke tier: e2e-azure.yml
+# generates a project with the scaffold CLI, deploys it to a live Azure Functions host, and drives
+# its HTTP routes. That IS the package-native runtime proof, and the candidate is certified from the
+# release ref, so a runtime regression in the release commit cannot slip through to PyPI.
+# The publish job uploads the EXACT artifact that was tested; it never rebuilds.
+# A tag whose gate fails is a failed release candidate: the version stays unpublished. Recover by
+# fixing forward and cutting the next patch tag (never move a tag that may already have been consumed).
 jobs:
-  build-and-publish:
+  build:
+    name: Build & verify version
     runs-on: ubuntu-latest
-    environment: pypi
-
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
@@ -38,6 +52,7 @@ jobs:
           pip install build
 
       - name: Check if tag matches __version__
+        id: version
         run: |
           TAG_NAME="${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}"
           VERSION_FROM_FILE=$(grep -Po '(?<=__version__ = ")[^"]*' src/azure_functions_scaffold/__init__.py)
@@ -49,10 +64,140 @@ jobs:
             echo "::error ::Version in __init__.py ($VERSION_FROM_FILE) does not match git tag ($TAG_VERSION)"
             exit 1
           fi
+          echo "version=$TAG_VERSION" >> "$GITHUB_OUTPUT"
 
       - name: Build distribution packages
         run: python -m build
 
+      - name: Upload distribution artifact
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+          retention-days: 5
+
+  lib-tests:
+    name: Library tests
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Set up Python
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Hatch
+        run: pip install hatch
+
+      - name: Run test suite
+        run: hatch run test
+
+  verify-azure-certification:
+    name: Verify Azure release certification
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v6
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
+
+      - name: Resolve release commit
+        id: commit
+        run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Locate successful Azure certification for this commit
+        id: cert
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          COMMIT: ${{ steps.commit.outputs.sha }}
+        run: |
+          # A release may only publish if the EXACT commit was certified against
+          # real Azure by the trusted certification workflow (see e2e-azure.yml).
+          RUN_ID=$(gh run list \
+            --workflow e2e-azure.yml \
+            --json databaseId,headSha,conclusion \
+            --limit 50 \
+            --jq "[.[] | select(.headSha==\"$COMMIT\" and .conclusion==\"success\")] | first | .databaseId")
+          if [ -z "$RUN_ID" ] || [ "$RUN_ID" = "null" ]; then
+            echo "::error ::No successful Azure certification run found for commit $COMMIT. Dispatch the 'e2e-azure' workflow on this release commit before publishing."
+            exit 1
+          fi
+          echo "Found certification run: $RUN_ID"
+          echo "run_id=$RUN_ID" >> "$GITHUB_OUTPUT"
+
+      - name: Download certification record
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: azure-cert
+          path: cert
+          run-id: ${{ steps.cert.outputs.run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Assert certification matches this release
+        env:
+          COMMIT: ${{ steps.commit.outputs.sha }}
+          VERSION: ${{ needs.build.outputs.version }}
+          FRESHNESS_DAYS: "14"
+        run: |
+          python3 - "$COMMIT" "$VERSION" "$FRESHNESS_DAYS" <<'PY'
+          import json, sys, datetime, pathlib
+          commit, version, fresh_days = sys.argv[1], sys.argv[2], int(sys.argv[3])
+          cert = json.loads(pathlib.Path("cert/certification.json").read_text())
+          def fail(m):
+              print(f"::error ::{m}")
+              sys.exit(1)
+          if cert.get("result") != "success":
+              fail("certification result is not success")
+          if cert.get("package") != "azure-functions-scaffold":
+              fail(f"cert package {cert.get('package')} != azure-functions-scaffold")
+          if cert.get("commit") != commit:
+              fail(f"cert commit {cert.get('commit')} != release commit {commit}")
+          if cert.get("version") != version:
+              fail(f"cert version {cert.get('version')} != release version {version}")
+          ts = cert.get("certified_at")
+          if not ts:
+              fail("cert missing certified_at")
+          certified = datetime.datetime.fromisoformat(ts.replace("Z", "+00:00"))
+          age = datetime.datetime.now(datetime.timezone.utc) - certified
+          if age > datetime.timedelta(days=fresh_days):
+              fail(f"certification is stale: {age.days}d > {fresh_days}d")
+          print(f"Azure certification verified: {version}@{commit[:12]} certified {age.days}d ago")
+          PY
+
+  publish:
+    name: Publish to PyPI
+    needs: [build, lib-tests, verify-azure-certification]
+    runs-on: ubuntu-latest
+    # PyPI trusted publisher (OIDC) configuration must stay in sync with:
+    #   Owner: yeongseon
+    #   Repository: azure-functions-scaffold-python
+    #   Workflow filename: publish-pypi.yml
+    #   Environment: pypi
+    environment: pypi
+    permissions:
+      id-token: write
+    steps:
+      - name: Download tested distribution artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: dist
+          path: dist
+
+      # Tokenless trusted publishing (OIDC). An `invalid-publisher` failure
+      # here almost always means the PyPI trusted publisher config drifted
+      # (repo rename, environment, or workflow filename mismatch), not a
+      # workflow secret issue.
       - name: Publish to PyPI
         # Documented exception to the SHA-pinning policy: PyPA officially
         # recommends pinning to the rolling `release/v1` branch. See

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,9 +71,6 @@ afs = "azure_functions_scaffold.cli:app"
 requires = ["hatchling"]
 build-backend = "hatchling.build"
 
-[tool.hatch.build]
-sources = ["src"]
-
 [tool.hatch.build.targets.wheel]
 packages = ["src/azure_functions_scaffold"]
 


### PR DESCRIPTION
## Summary

`azure-functions-scaffold` was the **only DX Toolkit repo publishing to PyPI without a verification gate**, AND it shipped `0.6.4` as an **empty wheel** (only `*.dist-info`, zero `.py` modules → `pip install` produced an unimportable package). This PR fixes both the fragile build config and the missing gate.

## Changes

### Empty-wheel fix (Closes #225)
- **`pyproject.toml`** — remove the global `[tool.hatch.build] sources = ["src"]` block that, combined with the prefixed wheel `packages` target, made `python -m build` emit an empty wheel (`hatch build` stayed correct; `python -m build`, used by the workflow, did not). `python -m build` now emits the full 16-module wheel.
- **`publish-pypi.yml` build job** — add a smoke step that fails if the built wheel has zero `.py` modules and verifies it installs+imports in a clean venv. An empty wheel can no longer reach PyPI.

### Verify-before-publish gate (Closes #221)
- **`publish-pypi.yml`** — split the single job into `build -> lib-tests -> verify-azure-certification -> publish`:
  - `build` builds the wheel, verifies the tag matches `src/azure_functions_scaffold/__init__.py`, **verifies the wheel is non-empty + importable**, and uploads the `dist` artifact.
  - `lib-tests` runs `hatch run test`.
  - `verify-azure-certification` requires a successful, SHA+version-matched, <14-day-fresh `e2e-azure.yml` run for the release commit.
  - `publish` (`needs: [build, lib-tests, verify-azure-certification]`) downloads the **exact tested artifact** — never rebuilds.
- **`e2e-azure.yml`** — emits an `azure-cert` (`certification.json`) artifact after the live HTTP tests pass. Added optional `ref`/`version` `workflow_dispatch` inputs and pinned checkout to the resolved ref.

## Verification

- `python -m build` → `16 py modules` (was 0)
- clean venv `pip install dist/*.whl` + `import azure_functions_scaffold` → OK
- Both workflow files parse as valid YAML.

## Out of scope
- Version bump + patch release (0.6.5) — done via `make release-patch` after merge.
- Yanking the broken 0.6.4 on PyPI — tracked in #225, requires PyPI auth.

Closes #221
Closes #225
