### PR TITLE
chore: ignore agent orchestration state (.omc/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ site/
 
 # Review
 .venv-review/
+.omc/


### PR DESCRIPTION
## Summary
- Add `.omc/` to `.gitignore` (`.sisyphus/` already ignored).
- Preventive hygiene; no tracked files removed.

Closes #223