### PR TITLE
fix(e2e): probe existing /api/health route instead of nonexistent /api/hello

### DIFF
--- a/.github/workflows/e2e-azure.yml
+++ b/.github/workflows/e2e-azure.yml
@@ -138,8 +138,8 @@ jobs:
           sleep 60
           echo "Probing app status:"
           for i in 1 2 3 4 5; do
-            STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${APP_URL}/api/hello?name=probe" || echo "curl-failed")
-            echo "  attempt $i: ${APP_URL}/api/hello -> ${STATUS}"
+            STATUS=$(curl -s -o /dev/null -w "%{http_code}" "${APP_URL}/api/health" || echo "curl-failed")
+            echo "  attempt $i: ${APP_URL}/api/health -> ${STATUS}"
             [ "$STATUS" = "200" ] && break
             sleep 10
           done

--- a/tests/e2e/test_scaffold_e2e.py
+++ b/tests/e2e/test_scaffold_e2e.py
@@ -33,13 +33,13 @@ def warmup() -> None:
     deadline = time.time() + 300
     while time.time() < deadline:
         try:
-            r = requests.get(f"{BASE_URL}/api/hello", timeout=10)
+            r = requests.get(f"{BASE_URL}/api/health", timeout=10)
             if r.status_code == 200:
                 return
         except requests.RequestException:
             pass
         time.sleep(3)
-    pytest.fail("Warmup failed: /api/hello did not respond within 300 s")
+    pytest.fail("Warmup failed: /api/health did not respond within 300 s")
 
 
 # ── Scaffold generation tests (no Azure needed) ────────────────────────────
@@ -75,7 +75,7 @@ def test_scaffolded_function_app_imports_cleanly() -> None:
 
 
 @pytest.mark.skipif(not BASE_URL, reason=SKIP_REASON)
-def test_hello_endpoint_returns_200() -> None:
-    r = requests.get(f"{BASE_URL}/api/hello", params={"name": "e2e"}, timeout=30)
+def test_health_endpoint_returns_200() -> None:
+    r = requests.get(f"{BASE_URL}/api/health", timeout=30)
     assert r.status_code == 200
-    assert "e2e" in r.text or "hello" in r.text.lower()
+    assert "ok" in r.text.lower()


### PR DESCRIPTION
## Context
With the OIDC fix (#226) merged, the scaffold `e2e-azure` workflow finally authenticated to Azure and ran end-to-end for the first time. It then failed at `Run e2e HTTP tests` because the deployed app returned a **persistent 404** on `/api/hello`.

Root cause is drift, not a deploy failure: the default `http` scaffold template exposes `/api/health` (anonymous) and `/api/webhooks/inbound` — there is **no `/api/hello` route**. Both the e2e test (`warmup` fixture + deployed-app test) and the workflow diagnose step probed `/api/hello`, so warmup timed out after 300s. Azure login, RG creation, Bicep deploy, Core Tools install, publish, and cleanup all succeeded.

## Change
- `tests/e2e/test_scaffold_e2e.py`: repoint `warmup` and rename `test_hello_endpoint_returns_200` → `test_health_endpoint_returns_200`, probing `/api/health` and asserting on its `{"status": "ok"}` body.
- `.github/workflows/e2e-azure.yml`: diagnose step probes `/api/health`.

## Validation
- YAML + Python parse clean; no remaining `/api/hello` references.
- Real validation: re-dispatch `e2e-azure` on `main` after merge and confirm green (login → deploy → **health probe** → e2e tests → cleanup).

## Acceptance Checklist
- [ ] `e2e-azure` run passes end-to-end on `main` (all 4 toolkit repos green).