### PR TITLE
docs: align http-template docs with health+webhooks structure

### DIFF
--- a/PRD.md
+++ b/PRD.md
@@ -81,10 +81,10 @@ pip install -e .
 func start
 ```
 
-Open `http://localhost:7071/api/hello` and get:
+Open `http://localhost:7071/api/health` and get:
 
-```text
-Hello, World!
+```json
+{"status": "ok"}
 ```
 
 Every template (HTTP, timer, queue, blob, Service Bus) produces a project that runs

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -13,7 +13,7 @@ Now you want to deploy it to Azure so it runs in the cloud. This guide assumes y
 `azure-functions-scaffold` generates ready-to-deploy Azure Functions projects from templates.
 This guide deploys two templates:
 
-- **`http` template** — An HTTP API with a `/api/hello` endpoint
+- **`http` template** — An HTTP API with a `/api/health` endpoint
 - **`timer` template** — A scheduled background job that runs every 5 minutes
 
 After following this guide, your scaffolded project will be running on Azure and reachable from the internet.
@@ -84,16 +84,20 @@ Files:
   - app/core/__init__.py
   - app/core/logging.py
   - app/functions/__init__.py
-  - app/functions/http.py
+  - app/functions/health.py
+  - app/functions/webhooks.py
   - app/schemas/__init__.py
-  - app/schemas/request_models.py
+  - app/schemas/health.py
+  - app/schemas/webhooks.py
   - app/services/__init__.py
-  - app/services/hello_service.py
+  - app/services/health_service.py
+  - app/services/webhook_service.py
   - function_app.py
   - host.json
   - local.settings.json.example
   - pyproject.toml
-  - tests/test_http.py
+  - tests/test_health.py
+  - tests/test_webhooks.py
 ```
 
 Now create the actual project:
@@ -124,13 +128,13 @@ func start
 In another terminal:
 
 ```bash
-curl http://localhost:7071/api/hello?name=Local
+curl http://localhost:7071/api/health
 ```
 
 Expected output:
 
-```text
-Hello, Local!
+```json
+{"status": "ok"}
 ```
 
 Stop the local server with `Ctrl+C` before deploying.
@@ -221,8 +225,8 @@ Performing remote build for functions project.
 ...
 Deployment completed successfully.
 Functions in func-scaffold-http:
-    hello - [httpTrigger]
-        Invoke url: https://func-scaffold-http.azurewebsites.net/api/hello
+    health - [httpTrigger]
+        Invoke url: https://func-scaffold-http.azurewebsites.net/api/health
 ```
 
 > ⚠️ **First deploy may take 1–3 minutes** because Azure installs your Python dependencies via remote build.
@@ -230,25 +234,13 @@ Functions in func-scaffold-http:
 ### Step 10 — Verify on Azure
 
 ```bash
-curl "https://$FUNCTIONAPP_NAME.azurewebsites.net/api/hello"
+curl "https://$FUNCTIONAPP_NAME.azurewebsites.net/api/health"
 ```
 
 Expected output:
 
-```text
-Hello, world!
-```
-
-Try with a name parameter:
-
-```bash
-curl "https://$FUNCTIONAPP_NAME.azurewebsites.net/api/hello?name=Azure"
-```
-
-Expected output:
-
-```text
-Hello, Azure!
+```json
+{"status": "ok"}
 ```
 
 ✅ **Your scaffolded HTTP API is now running on Azure!**
@@ -452,7 +444,7 @@ az functionapp create \
 
 | Symptom | Usually means | How to fix |
 |---|---|---|
-| HTTP 404 on `/api/hello` | Function not registered | Check `func azure functionapp publish` output — it should list `hello - [httpTrigger]` |
+| HTTP 404 on `/api/health` | Function not registered | Check `func azure functionapp publish` output — it should list `health - [httpTrigger]` |
 | Timer never fires | Schedule syntax or timezone issue | Timer uses NCRONTAB format in UTC. Check `function.json` or decorator schedule. |
 | `Internal Server Error` (500) | Python exception in your code | Check logs: `func azure functionapp logstream "$FUNCTIONAPP_NAME"` |
 

--- a/docs/examples/full_stack.md
+++ b/docs/examples/full_stack.md
@@ -77,9 +77,12 @@ curl "http://localhost:7071/api/health"
 
 Test the webhook inbound endpoint. It requires `WEBHOOK_SECRET` to be set
 locally and a matching HMAC-SHA256 `X-Signature` header; without a valid
-signature it returns `401` (or `503` when the secret is unset):
+signature it returns `401` (or `503` when the secret is unset). Set the same
+secret in `local.settings.json` (under `Values`) so the running Function can
+read it, then export it in your shell to sign the request:
 
 ```bash
+export WEBHOOK_SECRET="replace-with-your-local-secret"
 BODY='{"event_type":"order.placed","source":"shop"}'
 SIG="sha256=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" | awk '{print $2}')"
 

--- a/docs/examples/full_stack.md
+++ b/docs/examples/full_stack.md
@@ -75,12 +75,18 @@ Test the health endpoint:
 curl "http://localhost:7071/api/health"
 ```
 
-Test the webhook inbound endpoint (requires a valid `X-Signature` header in production; omit for local smoke-testing with a permissive secret):
+Test the webhook inbound endpoint. It requires `WEBHOOK_SECRET` to be set
+locally and a matching HMAC-SHA256 `X-Signature` header; without a valid
+signature it returns `401` (or `503` when the secret is unset):
 
 ```bash
+BODY='{"event_type":"order.placed","source":"shop"}'
+SIG="sha256=$(printf '%s' "$BODY" | openssl dgst -sha256 -hmac "$WEBHOOK_SECRET" | awk '{print $2}')"
+
 curl -X POST "http://localhost:7071/api/webhooks/inbound" \
   -H "Content-Type: application/json" \
-  -d '{"event_type":"order.placed","source":"shop"}'
+  -H "X-Signature: $SIG" \
+  -d "$BODY"
 ```
 
 Open docs:
@@ -130,7 +136,7 @@ def list_products() -> list[dict[str, object]]:
     ]
 ```
 
-Example schema additions (`app/schemas/request_models.py`):
+Example schema additions (`app/schemas/order_status.py`):
 
 ```python
 from pydantic import BaseModel

--- a/docs/examples/full_stack.md
+++ b/docs/examples/full_stack.md
@@ -69,12 +69,18 @@ Start runtime:
 func start
 ```
 
-Test validated hello endpoint:
+Test the health endpoint:
 
 ```bash
-curl -X POST "http://localhost:7071/api/hello" \
+curl "http://localhost:7071/api/health"
+```
+
+Test the webhook inbound endpoint (requires a valid `X-Signature` header in production; omit for local smoke-testing with a permissive secret):
+
+```bash
+curl -X POST "http://localhost:7071/api/webhooks/inbound" \
   -H "Content-Type: application/json" \
-  -d '{"name":"Commerce"}'
+  -d '{"event_type":"order.placed","source":"shop"}'
 ```
 
 Open docs:
@@ -188,8 +194,8 @@ func azure functionapp publish <APP_NAME>
 
 ## Troubleshooting Notes
 
-!!! warning "Validation route method mismatch"
-    With validation enabled, generated hello endpoint is `POST`, not `GET`.
+!!! warning "Webhook signature validation"
+    The `POST /api/webhooks/inbound` endpoint verifies an HMAC-SHA256 signature from the `X-Signature` header. Set `WEBHOOK_SECRET` in `local.settings.json` before testing locally; the endpoint returns 503 when the secret is missing.
 
 !!! warning "Doctor command missing"
     Confirm project was created with `--with-doctor` and re-run dependency

--- a/docs/examples/http_api.md
+++ b/docs/examples/http_api.md
@@ -9,7 +9,7 @@ By the end, you will have:
 
 - a scaffolded HTTP project
 - optional OpenAPI and validation support
-- two HTTP function modules (`hello` and `users`)
+- two HTTP function modules (`health` and `webhooks`)
 - local run and curl verification flow
 
 ## 1) Generate the Project
@@ -42,13 +42,13 @@ make check-all
 
 ## 2) Understand Generated HTTP Behavior
 
-With `--with-validation` enabled, the default `hello` route is generated as a
-`POST` endpoint that validates body models.
+The `http` template generates two endpoints:
 
-!!! note "Default route mode changes"
-    Without validation, the default route is `GET /api/hello` and reads query
-    params. With validation enabled, it becomes `POST /api/hello` and expects a
-    JSON body.
+- `GET /api/health` — anonymous auth, returns `{"status": "ok"}`.
+- `POST /api/webhooks/inbound` — FUNCTION auth, verifies an HMAC-SHA256 signature from the `X-Signature` header against the `WEBHOOK_SECRET` environment variable. Returns 503 when the secret is not configured, 401 on signature mismatch, and 202 on success.
+
+!!! note "Default route mode"
+    The health endpoint uses anonymous auth so it can be polled by infrastructure without credentials. The webhook endpoint uses FUNCTION auth and signature verification to authenticate external callers.
 
 The `function_app.py` entrypoint also includes OpenAPI routes when
 `--with-openapi` is enabled:
@@ -63,18 +63,16 @@ The `function_app.py` entrypoint also includes OpenAPI routes when
 func start
 ```
 
-In a second terminal, test the validated hello route:
+In a second terminal, test the health endpoint:
 
 ```bash
-curl -X POST "http://localhost:7071/api/hello" \
-  -H "Content-Type: application/json" \
-  -d '{"name":"Azure"}'
+curl "http://localhost:7071/api/health"
 ```
 
-Expected response shape:
+Expected response:
 
 ```json
-{"message":"Hello, Azure!"}
+{"status": "ok"}
 ```
 
 Open Swagger UI:
@@ -179,9 +177,8 @@ Example response:
     Regenerate with `--with-openapi`, or verify your project was created with
     that flag. OpenAPI routes are generated at creation time.
 
-!!! warning "Validation errors on hello"
-    With validation enabled, `hello` expects JSON body fields that match
-    `app/schemas/request_models.py`.
+!!! warning "Webhook secret not set"
+    With `WEBHOOK_SECRET` unset, `POST /api/webhooks/inbound` returns 503. Set it in `local.settings.json` before testing the webhook endpoint locally.
 
 ## Next Steps
 

--- a/docs/guide/features.md
+++ b/docs/guide/features.md
@@ -47,7 +47,7 @@ To use structured logging anywhere in your app:
 ```python
 from app.core.logging import logger
 
-logger.info("request received", route="/api/hello")
+logger.info("request received", route="/api/health")
 ```
 
 See [azure-functions-logging](https://github.com/yeongseon/azure-functions-logging-python) for the full API.

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -59,13 +59,13 @@ func start
 Once the local runtime is ready, use `curl` to test the default HTTP trigger.
 
 ```bash
-curl "http://localhost:7071/api/hello?name=Azure"
+curl "http://localhost:7071/api/health"
 ```
 
 **Expected Output:**
 
-```text
-Hello, Azure!
+```json
+{"status": "ok"}
 ```
 
 ### What's Next?

--- a/docs/guide/project-structure.md
+++ b/docs/guide/project-structure.md
@@ -16,13 +16,17 @@ my-api/
 │   ├── core/
 │   │   └── logging.py       # Structured JSON logging configuration
 │   ├── functions/
-│   │   └── http.py          # HTTP trigger handler (Blueprint)
+│   │   ├── health.py        # Health check HTTP trigger (Blueprint)
+│   │   └── webhooks.py      # Webhook HTTP trigger (Blueprint)
 │   ├── schemas/
-│   │   └── request_models.py  # Request/response models
+│   │   ├── health.py        # Health response model
+│   │   └── webhooks.py      # Webhook request/response models
 │   └── services/
-│       └── hello_service.py # Pure Python business logic
+│       ├── health_service.py   # Health check business logic
+│       └── webhook_service.py  # Webhook business logic
 └── tests/
-    └── test_http.py         # Pytest test suite
+    ├── test_health.py       # Pytest suite for health endpoint
+    └── test_webhooks.py     # Pytest suite for webhooks endpoint
 ```
 
 ### Layer Responsibilities
@@ -45,20 +49,26 @@ Traditional Azure Functions often mix trigger logic with business rules. By usin
 The trigger receives the request, calls a service, and returns the response. This pattern keeps the function logic minimal.
 
 ```python
-# app/functions/http.py (simplified)
+# app/functions/health.py (simplified)
 from __future__ import annotations
+
+import json
+import logging
 
 import azure.functions as func
 
-from app.services.hello_service import build_greeting
+from app.services.health_service import check_health
 
-http_blueprint = func.Blueprint()
+health_blueprint = func.Blueprint()
 
-@http_blueprint.route(route="hello", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
-def hello(req: func.HttpRequest) -> func.HttpResponse:
-    name = req.params.get("name", "world")
-    message = build_greeting(name)
-    return func.HttpResponse(message, status_code=200)
+@health_blueprint.route(route="health", methods=["GET"], auth_level=func.AuthLevel.ANONYMOUS)
+def health(req: func.HttpRequest) -> func.HttpResponse:
+    result = check_health()
+    return func.HttpResponse(
+        body=json.dumps(result),
+        mimetype="application/json",
+        status_code=200,
+    )
 ```
 
 ### Blueprint Registration
@@ -70,12 +80,14 @@ The main `function_app.py` acts as a coordinator. It imports and registers Bluep
 import azure.functions as func
 
 from app.core.logging import configure_logging
-from app.functions.http import http_blueprint
+from app.functions.health import health_blueprint
+from app.functions.webhooks import webhooks_blueprint
 
 configure_logging()
 
 app = func.FunctionApp()
-app.register_functions(http_blueprint)
+app.register_functions(health_blueprint)
+app.register_functions(webhooks_blueprint)
 ```
 
 ### What's Next?

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -25,8 +25,8 @@ The default template for building RESTful APIs.
 afs new my-api
 ```
 
-*   **Generates**: `app/functions/http.py`, `app/services/hello_service.py`, `tests/test_http.py`.
-*   **Key points**: Configured with a default `hello` route and JSON response handling.
+*   **Generates**: `app/functions/health.py`, `app/functions/webhooks.py`, `app/services/health_service.py`, `app/services/webhook_service.py`, `tests/test_health.py`, `tests/test_webhooks.py`.
+*   **Key points**: Includes a `GET /api/health` endpoint (anonymous auth) and a `POST /api/webhooks/inbound` endpoint (FUNCTION auth, HMAC-SHA256 signature verification).
 
 ### Timer Template
 

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -109,17 +109,17 @@ Supported presets are `minimal`, `standard`, `strict`.
 
 **Symptoms**
 
-- `GET /api/hello` no longer works
-- body validation errors on hello route
+- `GET /api/health` returns unexpected results
+- body validation errors on webhooks route
 
 **Explanation**
 
-With `--with-validation`, generated hello endpoint uses POST body validation.
+With `--with-validation`, the generated webhooks endpoint requires a valid request body matching the schema.
 
 **Fix**
 
-- send JSON body matching request model, or
-- adjust generated endpoint method/signature to fit your API contract
+- send a JSON body matching the request model, or
+- adjust the generated endpoint method/signature to fit your API contract
 
 ### Doctor command unavailable
 

--- a/docs/guide/tutorial.md
+++ b/docs/guide/tutorial.md
@@ -4,7 +4,7 @@ This guide provides end-to-end walkthroughs for each function template available
 
 ## HTTP API
 
-The default template generates a RESTful API endpoint with a clean separation between trigger logic and business services.
+The default template generates a RESTful API with two endpoints: a health check and a webhook receiver. Trigger logic and business services are cleanly separated.
 
 ### Generate the Project
 
@@ -18,43 +18,50 @@ make install
 
 ### Explore the Generated Code
 
-The generator creates a modular structure where the function entry point is separated from the business logic.
+The generator creates a modular structure where each function entry point is separated from its business logic.
 
 ```python
-# app/functions/http.py
+# app/functions/health.py
 from __future__ import annotations
+
+import json
+import logging
 
 import azure.functions as func
 
-from app.services.hello_service import build_greeting
+from app.services.health_service import check_health
 
-http_blueprint = func.Blueprint()  # type: ignore[no-untyped-call]
+health_blueprint = func.Blueprint()  # type: ignore[no-untyped-call]
 
 
-@http_blueprint.route(
-    route="hello",
+@health_blueprint.route(
+    route="health",
     methods=["GET"],
     auth_level=func.AuthLevel.ANONYMOUS,
 )
-def hello(req: func.HttpRequest) -> func.HttpResponse:
-    name = req.params.get("name", "world")
-    message = build_greeting(name)
-    return func.HttpResponse(message, status_code=200)
+def health(req: func.HttpRequest) -> func.HttpResponse:
+    logging.info("Health check requested")
+    result = check_health()
+    return func.HttpResponse(
+        body=json.dumps(result),
+        mimetype="application/json",
+        status_code=200,
+    )
 ```
 
-The business logic resides in a dedicated service file:
+The health business logic lives in a dedicated service file:
 
 ```python
-# app/services/hello_service.py
+# app/services/health_service.py
 from __future__ import annotations
 
 
-def build_greeting(name: str) -> str:
-    clean_name = name.strip() or "world"
-    return f"Hello, {clean_name}!"
+def check_health() -> dict[str, str]:
+    """Return a simple health status dictionary."""
+    return {"status": "ok"}
 ```
 
-The `function_app.py` file registers the blueprint:
+The `function_app.py` file registers both blueprints:
 
 ```python
 # function_app.py
@@ -63,7 +70,8 @@ from __future__ import annotations
 import azure.functions as func
 
 from app.core.logging import configure_logging
-from app.functions.http import http_blueprint
+from app.functions.health import health_blueprint
+from app.functions.webhooks import webhooks_blueprint
 
 # azure-functions-scaffold: function imports
 
@@ -71,56 +79,29 @@ configure_logging()
 
 app = func.FunctionApp()
 # azure-functions-scaffold: function registrations
-app.register_functions(http_blueprint)
+app.register_functions(health_blueprint)
+app.register_functions(webhooks_blueprint)
 ```
 
 ### Customize the Logic
 
-To return a JSON response with a timestamp, update the service first:
+To enrich the health response with version or dependency info, update the service:
 
 ```python
-# app/services/hello_service.py
+# app/services/health_service.py
 from __future__ import annotations
-from datetime import datetime
+from datetime import datetime, timezone
 
 
-def build_greeting(name: str) -> dict[str, str]:
-    clean_name = name.strip() or "world"
+def check_health() -> dict[str, str]:
+    """Return a health status dictionary with a timestamp."""
     return {
-        "message": f"Hello, {clean_name}!",
-        "timestamp": datetime.utcnow().isoformat()
+        "status": "ok",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
     }
 ```
 
-Then update the function to return a JSON response:
-
-```python
-# app/functions/http.py
-from __future__ import annotations
-
-import json
-
-import azure.functions as func
-
-from app.services.hello_service import build_greeting
-
-http_blueprint = func.Blueprint()  # type: ignore[no-untyped-call]
-
-
-@http_blueprint.route(
-    route="hello",
-    methods=["GET"],
-    auth_level=func.AuthLevel.ANONYMOUS,
-)
-def hello(req: func.HttpRequest) -> func.HttpResponse:
-    name = req.params.get("name", "world")
-    data = build_greeting(name)
-    return func.HttpResponse(
-        body=json.dumps(data),
-        mimetype="application/json",
-        status_code=200,
-    )
-```
+The function module requires no changes — it already serialises whatever the service returns.
 
 ### Run the Tests
 
@@ -130,29 +111,32 @@ Verify your changes using the included test suite.
 make test
 ```
 
-The standard preset includes a unit test for the HTTP trigger:
+The standard preset includes a unit test for the health endpoint:
 
 ```python
-# tests/test_http.py
+# tests/test_health.py
 from __future__ import annotations
+
+import json
 
 import azure.functions as func
 
-from app.functions.http import hello
+from app.functions.health import health
 
 
-def test_hello_returns_named_greeting() -> None:
+def test_health_returns_ok_status() -> None:
     request = func.HttpRequest(
         method="GET",
-        url="http://localhost/api/hello",
-        params={"name": "Azure"},
+        url="http://localhost/api/health",
+        params={},
         body=b"",
     )
 
-    response = hello(request)
+    response = health(request)
 
     assert response.status_code == 200
-    assert response.get_body() == b"Hello, Azure!"
+    body = json.loads(response.get_body())
+    assert body == {"status": "ok"}
 ```
 
 ### Run Locally
@@ -166,13 +150,13 @@ func start
 In a separate terminal, send a request:
 
 ```bash
-curl "http://localhost:7071/api/hello?name=Azure"
+curl "http://localhost:7071/api/health"
 ```
 
 Expected output:
 
-```text
-Hello, Azure!
+```json
+{"status": "ok"}
 ```
 
 ### Expand with `add`

--- a/docs/index.md
+++ b/docs/index.md
@@ -99,7 +99,7 @@ func start
 Then hit the default route:
 
 ```text
-http://localhost:7071/api/hello
+http://localhost:7071/api/health
 ```
 
 ## Common Command Patterns


### PR DESCRIPTION
## Context

The `http` template was restructured in #55 — the old `hello` endpoint was replaced with a `health` endpoint plus a `webhooks` receiver. The template source was updated, but a large amount of user-facing documentation still described the removed structure, causing drift discovered while certifying the e2e-azure pipeline (#227).

Docs referenced non-existent artifacts: `/api/hello` route, `app/functions/http.py`, `app/services/hello_service.py`, `tests/test_http.py`, and `build_greeting()`.

## What changed

Rewrote all drifted docs + `PRD.md` to match the **actual** generated `http` template:

- `GET /api/health` — anonymous auth, returns `{"status": "ok"}` (via `app/services/health_service.py::check_health`)
- `POST /api/webhooks/inbound` — FUNCTION auth, HMAC-SHA256 signature (`X-Signature`) verified against `WEBHOOK_SECRET`; 503 unset / 401 mismatch / 202 accepted
- `function_app.py` registers `health_blueprint` + `webhooks_blueprint`

Files: `PRD.md`, `docs/index.md`, `docs/deployment.md`, `docs/guide/{getting-started,templates,features,troubleshooting,project-structure,tutorial}.md`, `docs/examples/{full_stack,http_api}.md`.

## Verification

- `grep -rniE "api/hello|hello_service|functions/http\.py|test_http\.py|build_greeting" docs/ PRD.md` → zero in-scope hits (only 3 intentional `build_greeting` refs remain in `docs/examples/durable_workflow.md`, which belong to the **durable** template).
- All code samples cross-checked against template source under `src/azure_functions_scaffold/templates/http/`.

## Out of scope

- `docs/examples/durable_workflow.md` — its `build_greeting`/`hello_orchestrator` belong to the durable template, not http.
- Non-HTTP tutorial sections (timer/queue/blob/servicebus) and the `afs api add users` section — verified unchanged.
- READMEs (any language) — no drift present, so the translation rule is not triggered.

## References

- #55 (http template restructure)
- #227 (e2e probe fix that surfaced this drift)