### PR TITLE
docs(i18n): adopt best-effort translation policy with staleness banners

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,9 +26,9 @@
 - Pin every external GitHub Action `uses:` ref to a full commit SHA with a `# vX.Y.Z` comment. See [`CONTRIBUTING.md` § "GitHub Actions Pinning"](CONTRIBUTING.md#github-actions-pinning) for the policy and approved exceptions.
 
 ### Documentation & Translations
-- When a change touches `README.md` or any English documentation, update the translated READMEs (`README.ko.md`, `README.ja.md`, `README.zh-CN.md`) **in the same PR** so translations never drift from the English source.
-- This applies to any code change that alters documented behavior, CLI output, or the ecosystem/package table — not just direct edits to prose.
-- If a full translation cannot land in the same PR, add a short "translation pending" note to the affected translated file and open a tracking issue before merging.
+- English (`README.md`) is the **canonical** source of truth for all documentation. Translated READMEs (`README.ko.md`, `README.ja.md`, `README.zh-CN.md`) are **best-effort**, community-maintained, and may lag the English source.
+- Translation sync is **not** required in the same PR as an English change, and a PR is **never** blocked by translation drift. Update translations opportunistically; when you do, keep them faithful to the current English source.
+- Each translated README carries a staleness banner linking back to the canonical English README. Keep that banner in place so readers always know the translation may be out of date.
 
 ## Issue Conventions
 

--- a/README.ja.md
+++ b/README.ja.md
@@ -13,6 +13,8 @@
 
 他の言語: [English](README.md) | [한국어](README.ko.md) | [简体中文](README.zh-CN.md)
 
+> ℹ️ この翻訳はコミュニティによる参考用であり、最新の [English README](README.md) より古い場合があります。正確な最新情報は英語版を参照してください。
+
 プロダクションレベルの Azure Functions Python v2 プロジェクトのためのスキャフォールディング CLI.
 
 Python バージョンサポート: Azure Functions では 3.10-3.13 は GA、3.14 は **Preview** です。詳しくは [Python バージョンサポート](docs/guide/configuration.md#python-version-support) を参照してください。

--- a/README.ko.md
+++ b/README.ko.md
@@ -13,6 +13,8 @@
 
 다른 언어: [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
 
+> ℹ️ 이 번역은 커뮤니티가 관리하는 참고용 문서로, 최신 [English README](README.md)보다 뒤처질 수 있습니다. 정확한 최신 정보는 영어 원문을 기준으로 하세요.
+
 프로덕션 수준의 Azure Functions Python v2 프로젝트를 위한 스캐폴딩 CLI.
 
 Python 버전 지원: Azure Functions에서 3.10-3.13은 GA이며, 3.14는 **Preview**입니다. 자세한 내용은 [Python 버전 지원](docs/guide/configuration.md#python-version-support)을 참고하세요.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -13,6 +13,8 @@
 
 其他语言: [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)
 
+> ℹ️ 本翻译由社区维护，仅供参考，可能落后于最新的 [English README](README.md)。请以英文版为准。
+
 用于生产级 Azure Functions Python v2 项目的脚手架 CLI.
 
 Python 版本支持: Azure Functions 上 3.10-3.13 为 GA，3.14 为 **Preview**。详情请参阅 [Python 版本支持](docs/guide/configuration.md#python-version-support)。


### PR DESCRIPTION
## Context
Closes #229. Fleet rollout of the best-effort translation policy from azure-functions-validation#314 (Option B): English README is canonical, translations are best-effort and may lag, and a PR is never blocked by translation drift. No translations are deleted.

## Changes
- AGENTS.md: rewrite Documentation & Translations to the best-effort policy.
- README.ko.md / README.ja.md / README.zh-CN.md: add a localized staleness banner linking to the canonical README.md.