### PR TITLE
docs: fix template drift in example and guide docs

### DIFF
--- a/docs/examples/ai_agents.md
+++ b/docs/examples/ai_agents.md
@@ -40,7 +40,7 @@ The generated function exposes a `POST /api/chat` endpoint:
 @ai_blueprint.route(
     route="chat",
     methods=["POST"],
-    auth_level=func.AuthLevel.ANONYMOUS,
+    auth_level=func.AuthLevel.FUNCTION,
 )
 async def chat(req: func.HttpRequest) -> func.HttpResponse:
     try:

--- a/docs/examples/cosmosdb_change_feed.md
+++ b/docs/examples/cosmosdb_change_feed.md
@@ -40,11 +40,11 @@ The generated trigger function:
 ```python
 @cosmosdb_blueprint.cosmos_db_trigger_v3(
     arg_name="documents",
-    container_name="my-container",
+    collection_name="my-container",
     database_name="my-database",
-    connection="CosmosDBConnection",
-    lease_container_name="leases",
-    create_lease_container_if_not_exists=True,
+    connection_string_setting="CosmosDBConnection",
+    lease_collection_name="leases",
+    create_lease_collection_if_not_exists=True,
 )
 def process_cosmos_changes(documents: func.DocumentList) -> None:
     count = describe_documents(documents)
@@ -54,7 +54,7 @@ def process_cosmos_changes(documents: func.DocumentList) -> None:
 !!! note "Lease container"
     The lease container tracks which changes have been processed. It enables
     multiple instances to share the change feed without duplicating work. The
-    `create_lease_container_if_not_exists=True` flag creates it automatically.
+    `create_lease_collection_if_not_exists=True` flag creates it automatically.
 
 ## 3) Generated Layout
 
@@ -149,11 +149,11 @@ def process_cosmos_changes(documents: func.DocumentList) -> None:
 
 | Parameter | Description |
 | :--- | :--- |
-| `container_name` | Source container to watch for changes. |
+| `collection_name` | Source container to watch for changes. |
 | `database_name` | Database containing the source container. |
-| `connection` | App setting name for the CosmosDB connection string. |
-| `lease_container_name` | Container used to store change feed leases. |
-| `create_lease_container_if_not_exists` | Auto-create lease container on first run. |
+| `connection_string_setting` | App setting name for the CosmosDB connection string. |
+| `lease_collection_name` | Container used to store change feed leases. |
+| `create_lease_collection_if_not_exists` | Auto-create lease container on first run. |
 | `feed_poll_delay` | Delay in milliseconds between feed polls (optional). |
 
 ## 8) Testing Strategy
@@ -185,7 +185,7 @@ service layer.
 
 !!! warning "Lease conflicts"
     Multiple local instances sharing the same lease container can cause
-    processing conflicts. Use a unique `lease_container_name` per instance
+    processing conflicts. Use a unique `lease_collection_name` per instance
     during development.
 
 !!! warning "Emulator SSL errors"

--- a/docs/examples/durable_workflow.md
+++ b/docs/examples/durable_workflow.md
@@ -44,7 +44,7 @@ instance:
 @durable_blueprint.route(
     route="orchestrators/{functionName}",
     methods=["POST"],
-    auth_level=func.AuthLevel.ANONYMOUS,
+    auth_level=func.AuthLevel.FUNCTION,
 )
 @durable_blueprint.durable_client_input(client_name="client")
 async def http_start(
@@ -59,11 +59,13 @@ async def http_start(
 
 ```python
 @durable_blueprint.orchestration_trigger(context_name="context")
-def hello_orchestrator(context: df.DurableOrchestrationContext) -> list[str]:
+def hello_orchestrator(
+    context: df.DurableOrchestrationContext,
+) -> Generator[Any, Any, list[str]]:
     results: list[str] = []
-    results.append(yield context.call_activity("say_hello", "Tokyo"))
-    results.append(yield context.call_activity("say_hello", "Seattle"))
-    results.append(yield context.call_activity("say_hello", "London"))
+    results.append((yield context.call_activity("say_hello", "Tokyo")))
+    results.append((yield context.call_activity("say_hello", "Seattle")))
+    results.append((yield context.call_activity("say_hello", "London")))
     return results
 ```
 
@@ -76,7 +78,7 @@ def say_hello(city: str) -> str:
 ```
 
 !!! note "Durable Functions imports"
-    Durable uses `azure.functions.durable_functions` (imported as `df`)
+    Durable uses `azure.durable_functions` (imported as `df`)
     alongside the standard `azure.functions` package.
 
 ## 3) Generated Layout
@@ -172,8 +174,8 @@ def format_result(greeting: str) -> str:
 Update the orchestrator to call the new activity after each greeting:
 
 ```python
-results.append(yield context.call_activity("say_hello", "Tokyo"))
-results.append(yield context.call_activity("format_result", results[-1]))
+results.append((yield context.call_activity("say_hello", "Tokyo")))
+results.append((yield context.call_activity("format_result", results[-1])))
 ```
 
 ## 7) Testing Strategy

--- a/docs/examples/http_api.md
+++ b/docs/examples/http_api.md
@@ -118,7 +118,7 @@ users_blueprint = func.Blueprint()  # type: ignore[no-untyped-call]
 @users_blueprint.route(
     route="users",
     methods=["GET"],
-    auth_level=func.AuthLevel.ANONYMOUS,
+    auth_level=func.AuthLevel.FUNCTION,
 )
 def users(req: func.HttpRequest) -> func.HttpResponse:
     payload = {

--- a/docs/guide/templates.md
+++ b/docs/guide/templates.md
@@ -109,7 +109,7 @@ afs advanced new --template durable --preset standard my-workflow
 ```
 
 *   **Generates**: `app/functions/durable.py`, `app/services/durable_service.py`, `tests/test_durable.py`.
-*   **Key points**: Uses `azure.functions.durable_functions`. Requires Azurite for state management.
+*   **Key points**: Uses `azure.durable_functions`. Requires Azurite for state management.
 
 ### AI Template
 

--- a/docs/guide/tutorial.md
+++ b/docs/guide/tutorial.md
@@ -181,7 +181,7 @@ users_blueprint = func.Blueprint()  # type: ignore[no-untyped-call]
 @users_blueprint.route(
     route="users",
     methods=["GET"],
-    auth_level=func.AuthLevel.ANONYMOUS,
+    auth_level=func.AuthLevel.FUNCTION,
 )
 def users(req: func.HttpRequest) -> func.HttpResponse:
     return func.HttpResponse(


### PR DESCRIPTION
## Summary
Aligns documented code snippets with the **actual generated template output**. Doc-only change; no CLI/template/behavior changes, no README touched (translation rule not triggered).

## Verified drift fixes (each checked against the template source of truth)
- **ai_agents.md**: `chat` route `auth_level` `ANONYMOUS` → `FUNCTION` (matches `templates/ai/app/functions/ai.py.j2`). OpenAI/`generate_completion` description confirmed correct against `ai_service.py.j2`.
- **cosmosdb_change_feed.md**: decorator params corrected to real API used by `templates/cosmosdb/app/functions/cosmosdb.py.j2` — `collection_name`, `connection_string_setting`, `lease_collection_name`, `create_lease_collection_if_not_exists`; parameter table and lease notes updated to match.
- **durable_workflow.md**: import note `azure.functions.durable_functions` → `azure.durable_functions`; starter `auth_level` → `FUNCTION`; orchestrator return type → `Generator[Any, Any, list[str]]`; parenthesized `(yield ...)` (previous form was invalid Python). Verified against `templates/durable/...`.
- **http_api.md** / **tutorial.md**: `users` route `auth_level` `ANONYMOUS` → `FUNCTION` (matches `afs api add` output `partials/functions/http_module.py.j2`).
- **templates.md**: durable key point `azure.functions.durable_functions` → `azure.durable_functions`.

## Not changed (verified already correct)
- `health` route `ANONYMOUS` (tutorial, project-structure) — matches `health.py.j2`.
- langgraph `LangGraphApp(auth_level=ANONYMOUS)` — matches `langgraph/function_app.py.j2`.
- `migration/0.6.0.md` generic public-endpoint example — intentional.