### PR TITLE
docs: consolidate official documentation URL onto yeongseon.dev (STEP 3)

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -8,7 +8,7 @@
 [![Security Scans](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-scaffold-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-scaffold-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-scaffold-python/)
+[![Docs](https://img.shields.io/badge/docs-yeongseon.dev-blue)](https://yeongseon.dev/azure-functions-python/scaffold/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 他の言語: [English](README.md) | [한국어](README.ko.md) | [简体中文](README.zh-CN.md)
@@ -241,7 +241,7 @@ func azure functionapp publish <APP_NAME>
 
 ## ドキュメント
 
-- 全文書: [yeongseon.github.io/azure-functions-scaffold-python](https://yeongseon.github.io/azure-functions-scaffold-python/)
+- 全文書: [yeongseon.dev/azure-functions-python/scaffold](https://yeongseon.dev/azure-functions-python/scaffold/)
 - Python バージョンサポート: [`docs/guide/configuration.md#python-version-support`](docs/guide/configuration.md#python-version-support)
 - はじめに: [`docs/guide/getting-started.md`](docs/guide/getting-started.md)
 - CLI リファレンス: [`docs/reference/cli.md`](docs/reference/cli.md)

--- a/README.ko.md
+++ b/README.ko.md
@@ -8,7 +8,7 @@
 [![Security Scans](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-scaffold-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-scaffold-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-scaffold-python/)
+[![Docs](https://img.shields.io/badge/docs-yeongseon.dev-blue)](https://yeongseon.dev/azure-functions-python/scaffold/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 다른 언어: [English](README.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
@@ -241,7 +241,7 @@ func azure functionapp publish <APP_NAME>
 
 ## 문서
 
-- 전체 문서: [yeongseon.github.io/azure-functions-scaffold-python](https://yeongseon.github.io/azure-functions-scaffold-python/)
+- 전체 문서: [yeongseon.dev/azure-functions-python/scaffold](https://yeongseon.dev/azure-functions-python/scaffold/)
 - Python 버전 지원: [`docs/guide/configuration.md#python-version-support`](docs/guide/configuration.md#python-version-support)
 - 시작하기: [`docs/guide/getting-started.md`](docs/guide/getting-started.md)
 - CLI 참조: [`docs/reference/cli.md`](docs/reference/cli.md)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 [![Security Scans](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-scaffold-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-scaffold-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-scaffold-python/)
+[![Docs](https://img.shields.io/badge/docs-yeongseon.dev-blue)](https://yeongseon.dev/azure-functions-python/scaffold/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 Read this in: [한국어](README.ko.md) | [日本語](README.ja.md) | [简体中文](README.zh-CN.md)
@@ -274,7 +274,7 @@ Before publishing:
 
 ## Documentation
 
-- Full docs: [yeongseon.github.io/azure-functions-scaffold-python](https://yeongseon.github.io/azure-functions-scaffold-python/)
+- Full docs: [yeongseon.dev/azure-functions-python/scaffold](https://yeongseon.dev/azure-functions-python/scaffold/)
 - Python version support: [`docs/guide/configuration.md#python-version-support`](docs/guide/configuration.md#python-version-support)
 - Getting Started: [`docs/guide/getting-started.md`](docs/guide/getting-started.md)
 - CLI Reference: [`docs/reference/cli.md`](docs/reference/cli.md)

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,7 +8,7 @@
 [![Security Scans](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/security.yml/badge.svg)](https://github.com/yeongseon/azure-functions-scaffold-python/actions/workflows/security.yml)
 [![codecov](https://codecov.io/gh/yeongseon/azure-functions-scaffold-python/branch/main/graph/badge.svg)](https://codecov.io/gh/yeongseon/azure-functions-scaffold-python)
 [![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit)](https://pre-commit.com/)
-[![Docs](https://img.shields.io/badge/docs-gh--pages-blue)](https://yeongseon.github.io/azure-functions-scaffold-python/)
+[![Docs](https://img.shields.io/badge/docs-yeongseon.dev-blue)](https://yeongseon.dev/azure-functions-python/scaffold/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 其他语言: [English](README.md) | [한국어](README.ko.md) | [日本語](README.ja.md)
@@ -241,7 +241,7 @@ func azure functionapp publish <APP_NAME>
 
 ## 文档
 
-- 完整文档: [yeongseon.github.io/azure-functions-scaffold-python](https://yeongseon.github.io/azure-functions-scaffold-python/)
+- 完整文档: [yeongseon.dev/azure-functions-python/scaffold](https://yeongseon.dev/azure-functions-python/scaffold/)
 - Python 版本支持: [`docs/guide/configuration.md#python-version-support`](docs/guide/configuration.md#python-version-support)
 - 快速开始: [`docs/guide/getting-started.md`](docs/guide/getting-started.md)
 - CLI 参考: [`docs/reference/cli.md`](docs/reference/cli.md)

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -5,22 +5,22 @@
 Part of the **Azure Functions Python DX Toolkit**. Generate production-ready Azure Functions Python v2 projects from templates and presets — wiring up structure, tooling, and recommended stacks so you start from a working baseline. Install from PyPI with `pip install azure-functions-scaffold`.
 
 ## Getting Started
-- [Introduction](https://yeongseon.github.io/azure-functions-scaffold-python/guide/): Overview.
-- [Getting Started](https://yeongseon.github.io/azure-functions-scaffold-python/guide/getting-started/): Create your first project.
-- [Configuration](https://yeongseon.github.io/azure-functions-scaffold-python/guide/configuration/): Configure generation.
+- [Introduction](https://yeongseon.dev/azure-functions-python/scaffold/guide/): Overview.
+- [Getting Started](https://yeongseon.dev/azure-functions-python/scaffold/guide/getting-started/): Create your first project.
+- [Configuration](https://yeongseon.dev/azure-functions-python/scaffold/guide/configuration/): Configure generation.
 
 ## User Guide
-- [Templates](https://yeongseon.github.io/azure-functions-scaffold-python/guide/templates/): Available templates.
-- [Features & Presets](https://yeongseon.github.io/azure-functions-scaffold-python/guide/features/): Opt-in features.
-- [Recommended Stacks](https://yeongseon.github.io/azure-functions-scaffold-python/guide/stacks/): Curated stacks.
-- [Project Structure](https://yeongseon.github.io/azure-functions-scaffold-python/guide/project-structure/): What gets generated.
+- [Templates](https://yeongseon.dev/azure-functions-python/scaffold/guide/templates/): Available templates.
+- [Features & Presets](https://yeongseon.dev/azure-functions-python/scaffold/guide/features/): Opt-in features.
+- [Recommended Stacks](https://yeongseon.dev/azure-functions-python/scaffold/guide/stacks/): Curated stacks.
+- [Project Structure](https://yeongseon.dev/azure-functions-python/scaffold/guide/project-structure/): What gets generated.
 
 ## Reference
-- [CLI Reference](https://yeongseon.github.io/azure-functions-scaffold-python/reference/cli/): Command reference.
-- [Template Specification](https://yeongseon.github.io/azure-functions-scaffold-python/reference/template-spec/): Template spec.
-- [Architecture](https://yeongseon.github.io/azure-functions-scaffold-python/reference/architecture/): How the generator works.
-- [API Reference](https://yeongseon.github.io/azure-functions-scaffold-python/reference/api/): Public API surface.
+- [CLI Reference](https://yeongseon.dev/azure-functions-python/scaffold/reference/cli/): Command reference.
+- [Template Specification](https://yeongseon.dev/azure-functions-python/scaffold/reference/template-spec/): Template spec.
+- [Architecture](https://yeongseon.dev/azure-functions-python/scaffold/reference/architecture/): How the generator works.
+- [API Reference](https://yeongseon.dev/azure-functions-python/scaffold/reference/api/): Public API surface.
 
 ## Optional
-- [Troubleshooting](https://yeongseon.github.io/azure-functions-scaffold-python/guide/troubleshooting/): Common issues and fixes.
-- [Changelog](https://yeongseon.github.io/azure-functions-scaffold-python/changelog/): Release history.
+- [Troubleshooting](https://yeongseon.dev/azure-functions-python/scaffold/guide/troubleshooting/): Common issues and fixes.
+- [Changelog](https://yeongseon.dev/azure-functions-python/scaffold/changelog/): Release history.

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -8,7 +8,7 @@
 - Version: 0.5.0
 - Python: >=3.10, <3.15
 - License: MIT
-- Docs: https://yeongseon.github.io/azure-functions-scaffold-python/
+- Docs: https://yeongseon.dev/azure-functions-python/scaffold/
 - Repository: https://github.com/yeongseon/azure-functions-scaffold-python
 - Azure Functions programming model: v2
 

--- a/llms.txt
+++ b/llms.txt
@@ -8,7 +8,7 @@
 - Version: 0.5.0
 - Python: >=3.10, <3.15
 - License: MIT
-- Docs: https://yeongseon.github.io/azure-functions-scaffold-python/
+- Docs: https://yeongseon.dev/azure-functions-python/scaffold/
 - Repository: https://github.com/yeongseon/azure-functions-scaffold-python
 
 ## What It Does
@@ -162,11 +162,11 @@ my-api/
 
 ## Documentation
 
-- [Getting Started](https://yeongseon.github.io/azure-functions-scaffold-python/getting-started/)
-- [CLI Reference](https://yeongseon.github.io/azure-functions-scaffold-python/cli/)
-- [Templates](https://yeongseon.github.io/azure-functions-scaffold-python/templates/)
-- [Architecture](https://yeongseon.github.io/azure-functions-scaffold-python/architecture/)
-- [Deployment Guide](https://yeongseon.github.io/azure-functions-scaffold-python/deployment/)
+- [Getting Started](https://yeongseon.dev/azure-functions-python/scaffold/guide/getting-started/)
+- [CLI Reference](https://yeongseon.dev/azure-functions-python/scaffold/reference/cli/)
+- [Templates](https://yeongseon.dev/azure-functions-python/scaffold/guide/templates/)
+- [Architecture](https://yeongseon.dev/azure-functions-python/scaffold/reference/architecture/)
+- [Deployment Guide](https://yeongseon.dev/azure-functions-python/scaffold/deployment/)
 
 ## Ecosystem
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -2,7 +2,7 @@ site_name: Azure Functions Scaffold
 site_description: Scaffolding CLI for Azure Functions Python v2 projects
 site_author: Yeongseon Choe
 repo_url: https://github.com/yeongseon/azure-functions-scaffold-python
-site_url: https://yeongseon.github.io/azure-functions-scaffold-python/
+site_url: https://yeongseon.dev/azure-functions-python/scaffold/
 edit_uri: edit/main/docs/
 
 theme:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,8 +58,8 @@ docs = [
 ]
 
 [project.urls]
-Homepage = "https://yeongseon.github.io/azure-functions-scaffold-python/"
-Documentation = "https://yeongseon.github.io/azure-functions-scaffold-python/"
+Homepage = "https://yeongseon.dev/azure-functions-python/scaffold/"
+Documentation = "https://yeongseon.dev/azure-functions-python/scaffold/"
 Repository = "https://github.com/yeongseon/azure-functions-scaffold-python"
 Issues = "https://github.com/yeongseon/azure-functions-scaffold-python/issues"
 


### PR DESCRIPTION
## Summary
Consolidate the official documentation URL onto **https://yeongseon.dev/azure-functions-python/scaffold/**.

- `pyproject.toml`: `Homepage`/`Documentation` → new URL. `Repository`/`Issues` unchanged.
- `mkdocs.yml`: `site_url` → new URL. `repo_url`/`edit_uri` unchanged (GitHub).
- README (en/ja/ko/zh-CN): docs link → new URL; `docs-gh--pages` badge label → `docs-yeongseon.dev`.
- `llms.txt`, `llms-full.txt`, `docs/llms.txt`: legacy `github.io` doc links → new URL (subpaths preserved).
- **Stale path fix**: root `llms.txt` used non-existent no-prefix subpaths (`/getting-started/`, `/cli/`, `/templates/`, `/architecture/`) that 404 on both old and new sites; remapped to the correct nested paths (`guide/getting-started/`, `reference/cli/`, `guide/templates/`, `reference/architecture/`).

## Verification
- All 15 resulting `yeongseon.dev/.../scaffold/...` links return HTTP 200.
- `mkdocs build --strict` passes clean (0 warnings).
- No `yeongseon.github.io` references remain in tracked files.

## Notes
- Old GitHub Pages site is a redirect stub (canonical + 0s meta refresh + visible link + hash JS); not an HTTP 301.
- No PyPI release in this pass (STEP 5).

Closes #236