### PR TITLE
feat(packages): raise a descriptive error for unknown requirement() names

### DIFF
--- a/src/azure_functions_scaffold/packages.py
+++ b/src/azure_functions_scaffold/packages.py
@@ -27,6 +27,19 @@ SUPPORTED_PACKAGES: dict[str, str] = {
 def requirement(name: str) -> str:
     """Return the full PEP 508 requirement string for a supported package.
 
-    Example: ``requirement("azure-functions")`` -> ``"azure-functions>=1.23.0"``.
+    The returned value is a bare specifier with no surrounding quotes, e.g.
+    ``requirement("azure-functions")`` returns
+    ``azure-functions>=1.23.0,<2.0.0`` (not a quoted string).
+
+    Raises:
+        KeyError: If ``name`` is not a supported toolkit package. The message
+            names the unknown package and lists the valid keys.
     """
-    return f"{name}{SUPPORTED_PACKAGES[name]}"
+    try:
+        spec = SUPPORTED_PACKAGES[name]
+    except KeyError:
+        valid = ", ".join(sorted(SUPPORTED_PACKAGES))
+        raise KeyError(
+            f"Unknown package {name!r}; supported packages are: {valid}"
+        ) from None
+    return f"{name}{spec}"

--- a/tests/test_supported_packages.py
+++ b/tests/test_supported_packages.py
@@ -90,3 +90,12 @@ def test_rendered_pyproject_uses_catalog_specs(
         assert requirement(name) in pyproject, (
             f"{template_name} pyproject missing catalog pin {requirement(name)}"
         )
+
+
+def test_requirement_unknown_name_raises_descriptive_error() -> None:
+    with pytest.raises(KeyError) as excinfo:
+        requirement("not-a-real-package")
+    message = str(excinfo.value)
+    assert "not-a-real-package" in message
+    # The error lists the valid keys so callers can self-correct.
+    assert "azure-functions" in message


### PR DESCRIPTION
## Summary
- `requirement()` now raises a `KeyError` that names the unknown package and lists the valid keys, instead of surfacing a bare lookup `KeyError` that is hard to diagnose when the helper is called outside tests.
- Docstring example clarified so it does not imply the returned specifier is a quoted string, and now documents the raised error.
- Added a regression test covering the unknown-name error path.

## Acceptance
- [x] `requirement()` raises a descriptive `KeyError` naming the unknown package and listing valid keys.
- [x] Docstring example no longer implies surrounding quotes.
- [x] Test covers the unknown-name error path.
- [x] Catalog contents / supported-package set unchanged.

Closes #201