### PR TITLE
ci: stop auto-deploying docs to GitHub Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,4 +1,4 @@
-name: Deploy MkDocs to GitHub Pages
+name: Docs (strict build check)
 
 on:
   push:
@@ -7,10 +7,10 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
-  deploy:
+  docs-check:
     runs-on: ubuntu-latest
 
     steps:
@@ -27,8 +27,5 @@ jobs:
           pip install hatch
           make install
 
-      - name: Build docs (verify build before deploy)
+      - name: Build docs (strict)
         run: hatch run mkdocs build --strict
-
-      - name: Deploy to GitHub Pages
-        run: hatch run mkdocs gh-deploy --force


### PR DESCRIPTION
## Summary
Stop auto-deploying docs to GitHub Pages so the redirect stub on `gh-pages` (pointing to https://yeongseon.dev/azure-functions-python/) is not overwritten by `mkdocs gh-deploy --force` on push to main. The strict `mkdocs build --strict` build is retained as a CI check.

## Verification
- Deploy step removed; strict build job retained (renamed `docs-check`)
- `permissions` downgraded to `contents: read`
- YAML validated with PyYAML

## Notes
- `gh-pages` branch is left untouched by CI going forward; redirect stub preserved.

Closes #239